### PR TITLE
vmpi: fix some include directives

### DIFF
--- a/linux/net/rina/vmpi/vmpi-ops.h
+++ b/linux/net/rina/vmpi/vmpi-ops.h
@@ -21,6 +21,8 @@
 #ifndef __VMPI_OPS_H__
 #define __VMPI_OPS_H__
 
+#include <linux/aio.h>
+
 typedef void (*vmpi_read_cb_t)(void *opaque, unsigned int channel,
                                const char *buffer, int len);
 

--- a/linux/net/rina/vmpi/vmpi-ops.h
+++ b/linux/net/rina/vmpi/vmpi-ops.h
@@ -40,7 +40,7 @@ struct vmpi_ops {
 unsigned int vmpi_get_num_channels(void);
 unsigned int vmpi_get_max_payload_size(void);
 
-/* Use spinlocks on the TX side. */
+/* Use mutexes on the TX datapath (in place of spinlocks). */
 // #define VMPI_TX_MUTEX
 
 #endif  /* __VMPI_OPS_H__ */

--- a/linux/net/rina/vmpi/vmpi-structs.h
+++ b/linux/net/rina/vmpi/vmpi-structs.h
@@ -25,6 +25,7 @@
 #include <linux/slab.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
+#include "vmpi-ops.h"
 
 
 struct vmpi_hdr {


### PR DESCRIPTION
Fix some include directives to allow compilation if VMPI_TX_MUTEX is defined.