### PR TITLE
vmpi: fix some include directives

### DIFF
--- a/linux/net/rina/dtcp.c
+++ b/linux/net/rina/dtcp.c
@@ -537,6 +537,8 @@ void dump_we(struct dtcp * dtcp, struct pci *  pci)
         seq_num_t    my_lf_we;
         seq_num_t    ack;
 
+        (void)cwq_lf_we; /* avoid compiler barfs */
+
         ASSERT(dtcp);
         ASSERT(pci);
 

--- a/linux/net/rina/ipcps/shim-hv.c
+++ b/linux/net/rina/ipcps/shim-hv.c
@@ -528,7 +528,6 @@ shim_hv_flow_deallocate(struct ipcp_instance_data *priv, port_id_t port_id)
 static int shim_hv_unbind_user_ipcp(struct ipcp_instance_data * priv,
                                     port_id_t                   port_id)
 {
-        int ret = 0;
         unsigned int ch;
 
         if (unlikely(!priv->assigned)) {
@@ -543,6 +542,7 @@ static int shim_hv_unbind_user_ipcp(struct ipcp_instance_data * priv,
                 priv->vmpi.channels[ch].user_ipcp = NULL;
 
         mutex_unlock(&priv->vc_lock);
+
         return 0;
 }
 

--- a/linux/net/rina/vmpi/vmpi-ops.h
+++ b/linux/net/rina/vmpi/vmpi-ops.h
@@ -21,6 +21,8 @@
 #ifndef __VMPI_OPS_H__
 #define __VMPI_OPS_H__
 
+#include <linux/aio.h>
+
 typedef void (*vmpi_read_cb_t)(void *opaque, unsigned int channel,
                                const char *buffer, int len);
 

--- a/linux/net/rina/vmpi/vmpi-ops.h
+++ b/linux/net/rina/vmpi/vmpi-ops.h
@@ -40,7 +40,7 @@ struct vmpi_ops {
 unsigned int vmpi_get_num_channels(void);
 unsigned int vmpi_get_max_payload_size(void);
 
-/* Use spinlocks on the TX side. */
+/* Use mutexes on the TX datapath (in place of spinlocks). */
 // #define VMPI_TX_MUTEX
 
 #endif  /* __VMPI_OPS_H__ */

--- a/linux/net/rina/vmpi/vmpi-structs.h
+++ b/linux/net/rina/vmpi/vmpi-structs.h
@@ -25,6 +25,7 @@
 #include <linux/slab.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
+#include "vmpi-ops.h"
 
 
 struct vmpi_hdr {


### PR DESCRIPTION
Fix compilation problem that shows up when VMPI_TX_MUTEX is defined.