### PR TITLE
librina: put Exception class in namespace rina

### DIFF
--- a/librina/include/librina/exceptions.h
+++ b/librina/include/librina/exceptions.h
@@ -27,6 +27,8 @@
 
 #include <stdexcept>
 
+namespace rina {
+
 class Exception : public std::exception {
 public:
         Exception() { }
@@ -39,6 +41,8 @@ public:
 private:
         std::string description_;
 };
+
+}
 
 #endif
 

--- a/librina/src/exceptions.cc
+++ b/librina/src/exceptions.cc
@@ -21,5 +21,9 @@
 
 #include "librina/exceptions.h"
 
+namespace rina {
+
 const char * Exception::what() const throw()
 { return description_.c_str(); }
+
+}

--- a/rina-tools/src/rina-cdap-echo/main.cc
+++ b/rina-tools/src/rina-cdap-echo/main.cc
@@ -179,7 +179,7 @@ int main(int argc, char * argv[])
 
         //try {
                 retval = wrapped_main(argc, argv);
-       /* } catch (Exception& e) {
+       /* } catch (rina::Exception& e) {
                 LOG_ERR("%s", e.what());
                 return EXIT_FAILURE;
 

--- a/rina-tools/src/rina-echo-time/main.cc
+++ b/rina-tools/src/rina-echo-time/main.cc
@@ -213,7 +213,7 @@ int main(int argc, char * argv[])
 
         try {
                 retval = wrapped_main(argc, argv);
-        } catch (Exception& e) {
+        } catch (rina::Exception& e) {
                 LOG_ERR("%s", e.what());
                 return EXIT_FAILURE;
 

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -132,12 +132,12 @@ void Encoder::addEncoder(const std::string& object_class, rina::EncoderInterface
 void Encoder::encode(const void* object, rina::CDAPMessage * cdapMessage) {
 	rina::EncoderInterface* encoder = get_encoder(cdapMessage->obj_class_);
 	if (!encoder) {
-		throw Exception("Could not find encoder");
+		throw rina::Exception("Could not find encoder");
 	}
 
 	const rina::SerializedObject * encodedObject =  encoder->encode(object);
 	if (!encodedObject) {
-		throw Exception("The encoder returned a null pointer");
+		throw rina::Exception("The encoder returned a null pointer");
 	}
 
 	cdapMessage->obj_value_ =  new rina::ByteArrayObjectValue(
@@ -149,12 +149,12 @@ void Encoder::encode(const void* object, rina::CDAPMessage * cdapMessage) {
 }
 void* Encoder::decode(const rina::CDAPMessage * cdapMessage) {
 	if (!cdapMessage->obj_value_) {
-		throw Exception ("Object value is null");
+		throw rina::Exception ("Object value is null");
 	}
 
 	rina::EncoderInterface* encoder = get_encoder(cdapMessage->obj_class_);
 	if (!encoder) {
-		throw Exception("Could not find encoder");
+		throw rina::Exception("Could not find encoder");
 	}
 	return encoder->decode(cdapMessage->obj_value_);
 }
@@ -162,7 +162,7 @@ void* Encoder::decode(const rina::CDAPMessage * cdapMessage) {
 rina::EncoderInterface * Encoder::get_encoder(const std::string& object_class) {
 	std::map<std::string, rina::EncoderInterface*>::iterator it = encoders_.find(object_class);
 	if (it == encoders_.end()) {
-		throw Exception("Could not find an Encoder associated to object class");
+		throw rina::Exception("Could not find an Encoder associated to object class");
 	}
 
 	return it->second;
@@ -171,14 +171,14 @@ rina::EncoderInterface * Encoder::get_encoder(const std::string& object_class) {
 rina::SerializedObject * Encoder::get_serialized_object(
 		const rina::ObjectValueInterface * object_value) {
 	if (!object_value) {
-		throw Exception ("Object value is null");
+		throw rina::Exception ("Object value is null");
 	}
 
 	rina::ByteArrayObjectValue * value =
 			(rina::ByteArrayObjectValue*) object_value;
 
 	if (!value) {
-		throw Exception("Object value is not of type Byte Array Object Value");
+		throw rina::Exception("Object value is not of type Byte Array Object Value");
 	}
 
 	return (rina::SerializedObject *) value->get_value();

--- a/rinad/src/common/event-loop.cc
+++ b/rinad/src/common/event-loop.cc
@@ -75,7 +75,7 @@ EventLoop::run()
                 	if (post_function) {
                 		post_function(event, data_model);
                 	}
-                } catch (Exception &e) {
+                } catch (rina::Exception &e) {
                 	LOG_ERR("Problems processing event: %s", e.what());
                 }
 

--- a/rinad/src/ipcm/console.cc
+++ b/rinad/src/ipcm/console.cc
@@ -142,7 +142,7 @@ IPCMConsole::init()
                 if (sfd < 0) {
                         ss  << " Error [" << errno <<
                                 "] calling socket() " << endl;
-                        throw Exception();
+                        throw rina::Exception();
                 }
 
                 ret = setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR,
@@ -159,16 +159,16 @@ IPCMConsole::init()
                 if (ret < 0) {
                         ss  << " Error [" << errno <<
                                 "] calling bind() " << endl;
-                        throw Exception();
+                        throw rina::Exception();
                 }
 
                 ret = listen(sfd, 5);
                 if (ret < 0) {
                         ss  << " Error [" << errno <<
                                 "] calling listen() " << endl;
-                        throw Exception();
+                        throw rina::Exception();
                 }
-        } catch (Exception) {
+        } catch (rina::Exception) {
                 FLUSH_LOG(ERR, ss);
                 if (sfd >= 0) {
                         close(sfd);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -513,7 +513,7 @@ IPCManager::assign_to_dif(rina::IPCProcess * ipcp,
                 if (!found) {
                         ss << "Cannot find properties for DIF "
                                 << dif_name.toString();
-                        throw Exception();
+                        throw rina::Exception();
                 }
 
                 // Fill in the DIFConfiguration object.
@@ -565,7 +565,7 @@ IPCManager::assign_to_dif(rina::IPCProcess * ipcp,
                                         ipcp->name.toString() <<
                                         " in DIF " << dif_name.toString() <<
                                         endl;
-                                throw Exception();
+                                throw rina::Exception();
                         }
                         dif_config.set_efcp_configuration(efcp_config);
                         dif_config.nsm_configuration_ = nsm_config;
@@ -615,7 +615,7 @@ IPCManager::assign_to_dif(rina::IPCProcess * ipcp,
                 LOG_ERR("DIF %s configuration failed", dif_name.toString().c_str());
                 throw e;
         }
-        catch (Exception) {
+        catch (rina::Exception) {
                 FLUSH_LOG(ERR, ss);
         }
 
@@ -669,7 +669,7 @@ IPCManager::register_at_dif(rina::IPCProcess *ipcp,
 
                 arrived = concurrency.wait_for_event(
                         rina::IPCM_REGISTER_APP_RESPONSE_EVENT, seqnum, ret);
-        } catch (Exception) {
+        } catch (rina::Exception) {
                 ss  << ": Error while requesting registration"
                     << endl;
                 FLUSH_LOG(ERR, ss);
@@ -790,8 +790,8 @@ IPCManager::apply_configuration()
                         }
                         assign_to_dif(ipcp, cit->difName);
                         register_at_difs(ipcp, cit->difsToRegisterAt);
-                } catch (Exception &e) {
-                        LOG_ERR("Exception while applying configuration: %s",
+                } catch (rina::Exception &e) {
+                        LOG_ERR("rina::Exception while applying configuration: %s",
                                 e.what());
                 }
 

--- a/rinad/src/ipcp/components.cc
+++ b/rinad/src/ipcp/components.cc
@@ -83,7 +83,7 @@ rina::Connection * Flow::getActiveConnection() {
 		}
 	}
 
-	throw Exception("No active connection is currently defined");
+	throw rina::Exception("No active connection is currently defined");
 }
 
 std::string Flow::toString() {
@@ -171,7 +171,7 @@ SimpleSetIPCPRIBObject::SimpleSetIPCPRIBObject(IPCProcess * ipc_process, const s
 void SimpleSetIPCPRIBObject::createObject(const std::string& objectClass, const std::string& objectName,
 		const void* objectValue) {
 	if (set_member_object_class_.compare(objectClass) != 0) {
-		throw Exception("Class of set member does not match the expected value");
+		throw rina::Exception("Class of set member does not match the expected value");
 	}
 
 	SimpleSetMemberIPCPRIBObject * ribObject = new SimpleSetMemberIPCPRIBObject(ipc_process_, objectClass,

--- a/rinad/src/ipcp/default-flow-allocator-ps.cc
+++ b/rinad/src/ipcp/default-flow-allocator-ps.cc
@@ -66,7 +66,7 @@ Flow * FlowAllocatorPs::newFlowRequest(IPCProcess * ipc_process,
 	std::list<rina::Connection*> connections;
 	try {
 		qosCube = selectQoSCube(event.flowSpecification);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		dm->destroyFlow(flow);
 		throw e;
 	}
@@ -116,7 +116,7 @@ rina::QoSCube * FlowAllocatorPs::selectQoSCube(
 		}
 	}
 
-	throw Exception("Could not find a QoS Cube");
+	throw rina::Exception("Could not find a QoS Cube");
 }
 
 int FlowAllocatorPs::set_policy_set_param(const std::string& name,

--- a/rinad/src/ipcp/default-namespace-manager-ps.cc
+++ b/rinad/src/ipcp/default-namespace-manager-ps.cc
@@ -81,7 +81,7 @@ bool NamespaceManagerPs::isValidAddress(unsigned int address, const std::string&
 			if (address < prefix || address >= prefix + rina::AddressPrefixConfiguration::MAX_ADDRESSES_PER_PREFIX){
 				return false;
 			}
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			//We don't know the organization of the IPC Process
 			return false;
 		}
@@ -104,7 +104,7 @@ unsigned int NamespaceManagerPs::getValidAddress(const std::string& ipcp_name,
 
 		try {
 			prefix = getAddressPrefix(ipcp_name, configuration);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			//We don't know the organization of the IPC Process
 			return 0;
 		}
@@ -147,7 +147,7 @@ unsigned int NamespaceManagerPs::getAddressPrefix(const std::string& process_nam
 		}
 	}
 
-	throw Exception("Unknown organization");
+	throw rina::Exception("Unknown organization");
 }
 
 bool NamespaceManagerPs::isAddressInUse(unsigned int address,

--- a/rinad/src/ipcp/default-resource-allocator-ps.cc
+++ b/rinad/src/ipcp/default-resource-allocator-ps.cc
@@ -74,7 +74,7 @@ void ResourceAllocatorPs::routingTableUpdated(
 
 	try {
 		rina::kernelIPCProcess->modifyPDUForwardingTableEntries(pduft, 2);
-	} catch (Exception & e) {
+	} catch (rina::Exception & e) {
 		LOG_ERR("Error setting PDU Forwarding Table in the kernel: %s",
 				e.what());
 	}

--- a/rinad/src/ipcp/enrollment-task.cc
+++ b/rinad/src/ipcp/enrollment-task.cc
@@ -98,7 +98,7 @@ void WatchdogRIBObject::remoteReadObject(int invoke_id, rina::CDAPSessionDescrip
 
 		rib_daemon_->remoteReadObjectResponse(class_, name_, robject_value, 0,
 				"", false, invoke_id, remote_id);
-	} catch(Exception &e) {
+	} catch(rina::Exception &e) {
 		LOG_ERR("Problems creating or sending CDAP Message: %s", e.what());
 	}
 
@@ -149,7 +149,7 @@ void WatchdogRIBObject::sendMessages() {
 			rib_daemon_->remoteReadObject(class_, name_, 0, remote_id, this);
 
 			neighbor_statistics_[(*it)->name_.processName] = currentTimeInMs;
-		}catch(Exception &e){
+		}catch(rina::Exception &e){
 			LOG_ERR("Problems generating or sending CDAP message: %s", e.what());
 		}
 	}
@@ -250,7 +250,7 @@ void NeighborSetRIBObject::remoteCreateObject(void * object_value, const std::st
 			rina::Neighbor * neighbor = (rina::Neighbor *) object_value;
 			populateNeighborsToCreateList(neighbor, &neighborsToCreate);
 		}
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Error decoding CDAP object value: %s", e.what());
 	}
 
@@ -262,7 +262,7 @@ void NeighborSetRIBObject::remoteCreateObject(void * object_value, const std::st
 	try {
 		rib_daemon_->createObject(EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_NAME, &neighborsToCreate, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 }
@@ -336,7 +336,7 @@ void NeighborSetRIBObject::createNeighbor(rina::Neighbor * neighbor) {
 	add_child(ribObject);
 	try {
 		rib_daemon_->addRIBObject(ribObject);
-	} catch(Exception &e){
+	} catch(rina::Exception &e){
 		LOG_ERR("Problems adding object to the RIB: %s", e.what());
 	}
 }
@@ -382,7 +382,7 @@ void EnrollmentFailedTimerTask::run() {
 	try {
 		state_machine_->abortEnrollment(state_machine_->remote_peer_->name_, state_machine_->port_id_,
 				reason_, enrollee_, true);
-	} catch(Exception &e) {
+	} catch(rina::Exception &e) {
 		LOG_ERR("Problems aborting enrollment: %s", e.what());
 	}
 }
@@ -488,7 +488,7 @@ void BaseEnrollmentStateMachine::release(int invoke_id,
 		remote_id.port_id_ = port_id_;
 
 		rib_daemon_->closeApplicationConnectionResponse(0, "", invoke_id, remote_id);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems generating or sending CDAP Message: %s", e.what());
 	}
 }
@@ -544,7 +544,7 @@ void BaseEnrollmentStateMachine::createOrUpdateNeighborInformation(bool enrolled
 		ss<<remote_peer_->name_.processName;
 		rib_daemon_->createObject(EncoderConstants::NEIGHBOR_RIB_OBJECT_CLASS, ss.str(),
 				remote_peer_, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 }
@@ -583,7 +583,7 @@ void BaseEnrollmentStateMachine::sendDFTEntries() {
 
 		rib_daemon_->remoteCreateObject(EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_NAME, robject_value, 0, remote_id, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending DFT entries: %s", e.what());
 	}
 }
@@ -623,7 +623,7 @@ void BaseEnrollmentStateMachine::sendNeighbors() {
 
 		rib_daemon_->remoteCreateObject(EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_NAME, robject_value, 0, remote_id, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending neighbors: %s", e.what());
 	}
 
@@ -636,7 +636,7 @@ void BaseEnrollmentStateMachine::sendCreateInformation(const std::string& object
 
 	try {
 		ribObject = rib_daemon_->readObject(objectClass, objectName);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems reading object from RIB: %s", e.what());
 		return;
 	}
@@ -650,7 +650,7 @@ void BaseEnrollmentStateMachine::sendCreateInformation(const std::string& object
 			remote_id.port_id_ = port_id_;
 
 			rib_daemon_->remoteCreateObject(objectClass, objectName, robject_value, 0, remote_id, 0);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems generating or sending CDAP message: %s", e.what());
 		}
 	}
@@ -682,7 +682,7 @@ void EnrolleeStateMachine::initiateEnrollment(EnrollmentRequest * enrollmentRequ
 	remote_peer_->supporting_difs_ = enrollment_request_->neighbor_->supporting_difs_;
 
 	if (state != STATE_NULL) {
-		throw Exception("Enrollee state machine not in NULL state");
+		throw rina::Exception("Enrollee state machine not in NULL state");
 	}
 
 	try{
@@ -702,7 +702,7 @@ void EnrolleeStateMachine::initiateEnrollment(EnrollmentRequest * enrollmentRequ
 
 		//Update state
 		state = STATE_WAIT_CONNECT_RESPONSE;
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems sending M_CONNECT message: %s", e.what());
 		abortEnrollment(remote_peer_->name_, port_id_, std::string(e.what()), true, false);
 	}
@@ -765,7 +765,7 @@ void EnrolleeStateMachine::connectResponse(int result,
 
 		//Update state
 		state = STATE_WAIT_START_ENROLLMENT_RESPONSE;
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems sending M_START request message: %s", e.what());
 		//TODO what to do?
 	}
@@ -804,7 +804,7 @@ void EnrolleeStateMachine::startResponse(int result, const std::string& result_r
 		try {
 			rib_daemon_->writeObject(EncoderConstants::ADDRESS_RIB_OBJECT_CLASS,
 					EncoderConstants::ADDRESS_RIB_OBJECT_NAME, &address);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems writing RIB object: %s", e.what());
 		}
 	}
@@ -849,7 +849,7 @@ void EnrolleeStateMachine::stop(EnrollmentInformationRequest * eiRequest, int in
 	//Request more information or start
 	try{
 		requestMoreInformationOrStart();
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems requesting more information or starting: %s", e.what());
 		abortEnrollment(remote_peer_->name_, port_id_, std::string(e.what()), true, true);
 	}
@@ -880,7 +880,7 @@ void EnrolleeStateMachine::requestMoreInformationOrStart() {
 			rib_daemon_->remoteStopObjectResponse("", "", object_value, 0, "", stop_request_invoke_id_, remote_id);
 
 			enrollmentCompleted();
-		}catch(Exception &e){
+		}catch(rina::Exception &e){
 			LOG_ERR("Problems sending CDAP message: %s", e.what());
 
 			rib_daemon_->remoteStopObjectResponse("", "", object_value, -1,
@@ -894,7 +894,7 @@ void EnrolleeStateMachine::requestMoreInformationOrStart() {
 
 	try {
 		rib_daemon_->remoteStopObjectResponse("", "", object_value, 0, "", stop_request_invoke_id_, remote_id);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 	}
 
@@ -928,7 +928,7 @@ bool EnrolleeStateMachine::sendNextObjectRequired() {
 	if (result) {
 		try{
 			rib_daemon_->remoteReadObject(object_class, object_name, 0, remote_id, this);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_WARN("Problems executing remote operation: %s", e.what());
 		}
 	}
@@ -940,7 +940,7 @@ void EnrolleeStateMachine::commitEnrollment() {
 	try {
 		rib_daemon_->startObject(EncoderConstants::OPERATIONAL_STATUS_RIB_OBJECT_CLASS,
 				EncoderConstants::OPERATIONAL_STATUS_RIB_OBJECT_NAME, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems starting RIB object: %s", e.what());
 	}
 }
@@ -963,7 +963,7 @@ void EnrolleeStateMachine::enrollmentCompleted() {
 	if (!was_dif_member_before_enrollment_) {
 		try {
 			rina::kernelIPCProcess->assignToDIF(ipc_process_->get_dif_information());
-		} catch(Exception &e) {
+		} catch(rina::Exception &e) {
 			LOG_ERR("Problems communicating with the Kernel components of the IPC Processs: %s",
 					e.what());
 		}
@@ -976,7 +976,7 @@ void EnrolleeStateMachine::enrollmentCompleted() {
 			neighbors.push_back(*remote_peer_);
 			rina::extendedIPCManager->enrollToDIFResponse(enrollment_request_->event_,
 					0, neighbors, ipc_process_->get_dif_information());
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems sending message to IPC Manager: %s", e.what());
 		}
 	}
@@ -1015,7 +1015,7 @@ void EnrolleeStateMachine::readResponse(int result, const std::string& result_re
 					(rina::DataTransferConstants *) object_value;
 			rib_daemon_->createObject(EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_CLASS,
 					EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_NAME, constants, 0);
-		}catch(Exception &e){
+		}catch(rina::Exception &e){
 			LOG_ERR("Problems creating RIB object: %s", e.what());
 		}
 	}else if (object_name.compare(EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_NAME) == 0){
@@ -1024,7 +1024,7 @@ void EnrolleeStateMachine::readResponse(int result, const std::string& result_re
 					(std::list<rina::QoSCube *> *) object_value;
 			rib_daemon_->createObject(EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_CLASS,
 					EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_NAME, cubes, 0);
-		}catch(Exception &e){
+		}catch(rina::Exception &e){
 			LOG_ERR("Problems creating RIB object: %s", e.what());
 		}
 	}else if (object_name.compare(EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_NAME) == 0){
@@ -1033,7 +1033,7 @@ void EnrolleeStateMachine::readResponse(int result, const std::string& result_re
 					(std::list<rina::Neighbor *> *) object_value;
 			rib_daemon_->createObject(EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_CLASS,
 					EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_NAME, neighbors, 0);
-		}catch(Exception &e){
+		}catch(rina::Exception &e){
 			LOG_ERR("Problems creating RIB object: %s", e.what());
 		}
 	}else{
@@ -1073,7 +1073,7 @@ void EnrolleeStateMachine::start(int result, const std::string& result_reason,
 	try{
 		commitEnrollment();
 		enrollmentCompleted();
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems commiting enrollment: %s", e.what());
 		abortEnrollment(remote_peer_->name_, port_id_,
 				PROBLEMS_COMMITTING_ENROLLMENT_INFO, true, true);
@@ -1139,7 +1139,7 @@ void EnrollerStateMachine::connect(int invoke_id, rina::CDAPSessionDescriptor * 
 		LOG_DBG("M_CONNECT_R sent to portID %d. Waiting for start enrollment request message", port_id_);
 
 		state = STATE_WAIT_START_ENROLLMENT;
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 		abortEnrollment(remote_peer_->name_, port_id_,
 						std::string(e.what()), false, true);
@@ -1157,7 +1157,7 @@ void EnrollerStateMachine::sendNegativeStartResponseAndAbortEnrollment(int resul
 				resultReason, invoke_id, remote_id);
 
 		abortEnrollment(remote_peer_->name_, port_id_, resultReason, false, true);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 	}
 }
@@ -1210,7 +1210,7 @@ void EnrollerStateMachine::start(EnrollmentInformationRequest * eiRequest, int i
 					it != eiRequest->supporting_difs_.end(); ++it) {
 				remote_peer_->supporting_difs_.push_back(*it);
 			}
-		}catch (Exception &e) {
+		}catch (rina::Exception &e) {
 			LOG_ERR("%s", e.what());
 			sendNegativeStartResponseAndAbortEnrollment(-1, std::string(e.what()), invoke_id);
 			return;
@@ -1245,7 +1245,7 @@ void EnrollerStateMachine::start(EnrollmentInformationRequest * eiRequest, int i
 				invoke_id, remote_id);
 
 		remote_peer_->address_ = eiRequest->address_;
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 		delete eiRequest;
 		sendNegativeStartResponseAndAbortEnrollment(-1, std::string(e.what()), invoke_id);
@@ -1273,7 +1273,7 @@ void EnrollerStateMachine::start(EnrollmentInformationRequest * eiRequest, int i
 				EncoderConstants::ENROLLMENT_INFO_OBJECT_NAME, object_value, 0, remote_id, this);
 
 		delete eiRequest;
-	} catch(Exception &e) {
+	} catch(rina::Exception &e) {
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 		delete eiRequest;
 		sendNegativeStartResponseAndAbortEnrollment(-1, std::string(e.what()), invoke_id);
@@ -1319,7 +1319,7 @@ void EnrollerStateMachine::stopResponse(int result, const std::string& result_re
 
 		rib_daemon_->remoteStartObject(EncoderConstants::OPERATIONAL_STATUS_RIB_OBJECT_CLASS,
 				EncoderConstants::OPERATIONAL_STATUS_RIB_OBJECT_NAME, robject_value, 0, remote_id, 0);
-	} catch(Exception &e){
+	} catch(rina::Exception &e){
 		LOG_ERR("Problems sending CDAP Message: %s", e.what());
 	}
 
@@ -1340,7 +1340,7 @@ void EnrollerStateMachine::enrollmentCompleted() {
 		std::list<rina::Neighbor> neighbors;
 		neighbors.push_back(*remote_peer_);
 		rina::extendedIPCManager->notifyNeighborsModified(true, neighbors);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending message to IPC Manager: %s", e.what());
 	}
 
@@ -1377,7 +1377,7 @@ void * doNeighborsEnrollerWork(void * arg) {
 					ss<<(*it)->name_.processName;
 					ipcProcess->rib_daemon_->deleteObject(EncoderConstants::NEIGHBOR_RIB_OBJECT_CLASS,
 							ss.str(), 0, 0);
-				} catch (Exception &e){
+				} catch (rina::Exception &e){
 				}
 			}
 
@@ -1430,7 +1430,7 @@ void EnrollmentTask::populateRIB() {
 		rib_daemon_->addRIBObject(ribObject);
 		ribObject = new AddressRIBObject(ipcp);
 		rib_daemon_->addRIBObject(ribObject);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems adding object to RIB Daemon: %s", e.what());
 	}
 }
@@ -1449,7 +1449,7 @@ void EnrollmentTask::set_dif_configuration(const rina::DIFConfiguration& dif_con
 	try{
 		BaseIPCPRIBObject * ribObject = new WatchdogRIBObject(ipcp, dif_configuration);
 		rib_daemon_->addRIBObject(ribObject);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems adding object to RIB Daemon: %s", e.what());
 	}
 
@@ -1468,7 +1468,7 @@ const std::list<rina::Neighbor *> EnrollmentTask::get_neighbors() const{
 	try{
 		ribObject = rib_daemon_->readObject(EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_NAME);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems reading RIB object: %s", e.what());
 		return result;
 	}
@@ -1534,7 +1534,7 @@ void EnrollmentTask::processEnrollmentRequestEvent(rina::EnrollToDIFRequestEvent
 		try {
 			rina::extendedIPCManager->enrollToDIFResponse(*event, -1,
 					std::list<rina::Neighbor>(), ipcp->get_dif_information());
-		}catch (Exception &e) {
+		}catch (rina::Exception &e) {
 			LOG_ERR("Problems sending message to IPC Manager: %s", e.what());
 		}
 
@@ -1551,7 +1551,7 @@ void EnrollmentTask::processEnrollmentRequestEvent(rina::EnrollToDIFRequestEvent
 		try {
 			rina::extendedIPCManager->enrollToDIFResponse(*event, -1,
 					std::list<rina::Neighbor>(), ipcp->get_dif_information());
-		}catch (Exception &e) {
+		}catch (rina::Exception &e) {
 			LOG_ERR("Problems sending message to IPC Manager: %s", e.what());
 		}
 
@@ -1591,14 +1591,14 @@ void EnrollmentTask::initiateEnrollment(EnrollmentRequest * request) {
 	unsigned int handle = -1;
 	try {
 		handle = resource_allocator_->get_n_minus_one_flow_manager()->allocateNMinus1Flow(flowInformation);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems allocating N-1 flow: %s", e.what());
 
 		if (request->ipcm_initiated_) {
 			try {
 				rina::extendedIPCManager->enrollToDIFResponse(request->event_, -1,
 						std::list<rina::Neighbor>(), ipcp->get_dif_information());
-			} catch (Exception &e) {
+			} catch (rina::Exception &e) {
 				LOG_ERR("Problems sending message to IPC Manager: %s", e.what());
 			}
 		}
@@ -1612,7 +1612,7 @@ void EnrollmentTask::initiateEnrollment(EnrollmentRequest * request) {
 void EnrollmentTask::deallocateFlow(int portId) {
 	try {
 		resource_allocator_->get_n_minus_one_flow_manager()->deallocateNMinus1Flow(portId);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems deallocating N-1 flow: %s", e.what());
 	}
 }
@@ -1644,7 +1644,7 @@ BaseEnrollmentStateMachine * EnrollmentTask::createEnrollmentStateMachine(
 		return stateMachine;
 	}
 
-	throw Exception("Unknown application entity for enrollment");
+	throw rina::Exception("Unknown application entity for enrollment");
 }
 
 BaseEnrollmentStateMachine * EnrollmentTask::getEnrollmentStateMachine(
@@ -1657,7 +1657,7 @@ BaseEnrollmentStateMachine * EnrollmentTask::getEnrollmentStateMachine(
 		} else {
 			return 0;
 		}
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems retrieving state machine: &s", e.what());
 		return 0;
 	}
@@ -1689,7 +1689,7 @@ void EnrollmentTask::connect(int invoke_id,
 					session_descriptor->dest_ap_inst_, session_descriptor->dest_ap_name_, -2, message,
 					session_descriptor->src_ae_inst_, session_descriptor->src_ae_name_,
 					session_descriptor->src_ap_inst_, session_descriptor->src_ap_name_, invoke_id, remote_id);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems sending CDAP message: %s", e.what());
 		}
 
@@ -1706,7 +1706,7 @@ void EnrollmentTask::connect(int invoke_id,
 				session_descriptor->get_destination_application_process_naming_info(),
 				session_descriptor->port_id_, false, flowInformation.difName);
 		enrollmentStateMachine->connect(invoke_id, session_descriptor);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems: %s", e.what());
 
 		try {
@@ -1718,7 +1718,7 @@ void EnrollmentTask::connect(int invoke_id,
 					session_descriptor->dest_ap_inst_, session_descriptor->dest_ap_name_, -2,
 					std::string(e.what()), session_descriptor->src_ae_inst_, session_descriptor->src_ae_name_,
 					session_descriptor->src_ap_inst_, session_descriptor->src_ap_name_, invoke_id, remote_id);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems sending CDAP message: %s", e.what());
 		}
 
@@ -1734,7 +1734,7 @@ void EnrollmentTask::connectResponse(int result, const std::string& result_reaso
 		EnrolleeStateMachine * stateMachine = (EnrolleeStateMachine*)
 				getEnrollmentStateMachine(session_descriptor, false);
 		stateMachine->connectResponse(result, result_reason);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		//Error getting the enrollment state machine
 		LOG_ERR("Problems getting enrollment state machine: %s", e.what());
 
@@ -1743,7 +1743,7 @@ void EnrollmentTask::connectResponse(int result, const std::string& result_reaso
 			remote_id.port_id_ = session_descriptor->port_id_;
 
 			rib_daemon_->closeApplicationConnection(remote_id, 0);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems closing application connection: %s", e.what());
 		}
 
@@ -1759,7 +1759,7 @@ void EnrollmentTask::release(int invoke_id,
 		BaseEnrollmentStateMachine * stateMachine = (BaseEnrollmentStateMachine*)
 						getEnrollmentStateMachine(session_descriptor, false);
 		stateMachine->release(invoke_id, session_descriptor);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		//Error getting the enrollment state machine
 		LOG_ERR("Problems getting enrollment state machine: %s", e.what());
 
@@ -1768,7 +1768,7 @@ void EnrollmentTask::release(int invoke_id,
 			remote_id.port_id_ = session_descriptor->port_id_;
 
 			rib_daemon_->closeApplicationConnection(remote_id, 0);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems closing application connection: %s", e.what());
 		}
 
@@ -1784,7 +1784,7 @@ void EnrollmentTask::releaseResponse(int result, const std::string& result_reaso
 		BaseEnrollmentStateMachine * stateMachine = (BaseEnrollmentStateMachine*)
 						getEnrollmentStateMachine(session_descriptor, false);
 		stateMachine->releaseResponse(result, result_reason, session_descriptor);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		//Error getting the enrollment state machine
 		LOG_ERR("Problems getting enrollment state machine: %s", e.what());
 
@@ -1793,7 +1793,7 @@ void EnrollmentTask::releaseResponse(int result, const std::string& result_reaso
 			remote_id.port_id_ = session_descriptor->port_id_;
 
 			rib_daemon_->closeApplicationConnection(remote_id, 0);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems closing application connection: %s", e.what());
 		}
 
@@ -1821,7 +1821,7 @@ void EnrollmentTask::neighborDeclaredDead(NeighborDeclaredDeadEvent * deadEvent)
 	try{
 		resource_allocator_->get_n_minus_one_flow_manager()->getNMinus1FlowInformation(
 				deadEvent->neighbor_->underlying_port_id_);
-	} catch(Exception &e){
+	} catch(rina::Exception &e){
 		LOG_INFO("The N-1 flow with the dead neighbor has already been deallocated");
 		return;
 	}
@@ -1830,7 +1830,7 @@ void EnrollmentTask::neighborDeclaredDead(NeighborDeclaredDeadEvent * deadEvent)
 		LOG_INFO("Requesting the deallocation of the N-1 flow with the dead neibhor");
 		resource_allocator_->get_n_minus_one_flow_manager()->deallocateNMinus1Flow(
 				deadEvent->neighbor_->underlying_port_id_);
-	} catch (Exception &e){
+	} catch (rina::Exception &e){
 		LOG_ERR("Problems requesting the deallocation of a N-1 flow: %s", e.what());
 	}
 }
@@ -1852,7 +1852,7 @@ void EnrollmentTask::nMinusOneFlowDeallocated(NMinusOneFlowDeallocatedEvent  * e
 			enrollmentStateMachine->flowDeallocated(&(event->cdap_session_descriptor_));
 			delete enrollmentStateMachine;
 		}
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems: %s", e.what());
 	}
 
@@ -1882,7 +1882,7 @@ void EnrollmentTask::nMinusOneFlowDeallocated(NMinusOneFlowDeallocatedEvent  * e
 			lostNeighbors.push_back(*(*it2));
 			try {
 				rina::extendedIPCManager->notifyNeighborsModified(false, lostNeighbors);
-			} catch (Exception &e) {
+			} catch (rina::Exception &e) {
 				LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 			}
 
@@ -1906,7 +1906,7 @@ void EnrollmentTask::nMinusOneFlowAllocated(NMinusOneFlowAllocatedEvent * flowEv
 		enrollmentStateMachine = (EnrolleeStateMachine *) createEnrollmentStateMachine(
 				request->neighbor_->name_, flowEvent->flow_information_.portId, true,
 				flowEvent->flow_information_.difName);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problem retrieving enrollment state machine: %s", e.what());
 		delete request;
 		return;
@@ -1917,7 +1917,7 @@ void EnrollmentTask::nMinusOneFlowAllocated(NMinusOneFlowAllocatedEvent * flowEv
 	try{
 		enrollmentStateMachine->initiateEnrollment(
 				request, flowEvent->flow_information_.portId);
-	}catch(Exception &e){
+	}catch(rina::Exception &e){
 		LOG_ERR("Problems initiating enrollment: %s", e.what());
 	}
 }
@@ -1938,7 +1938,7 @@ void EnrollmentTask::nMinusOneFlowAllocationFailed(NMinusOneFlowAllocationFailed
 		try {
 			rina::extendedIPCManager->enrollToDIFResponse(request->event_, -1,
 					std::list<rina::Neighbor>(), ipcp->get_dif_information());
-		} catch(Exception &e) {
+		} catch(rina::Exception &e) {
 			LOG_ERR("Could not send a message to the IPC Manager: %s", e.what());
 		}
 	}
@@ -1967,7 +1967,7 @@ void EnrollmentTask::enrollmentFailed(const rina::ApplicationProcessNamingInform
 			remote_id.port_id_ = portId;
 
 			rib_daemon_->closeApplicationConnection(remote_id, 0);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems closing application connection: %s", e.what());
 		}
 
@@ -1982,7 +1982,7 @@ void EnrollmentTask::enrollmentFailed(const rina::ApplicationProcessNamingInform
 				try {
 					rina::extendedIPCManager->enrollToDIFResponse(request->event_, -1,
 							std::list<rina::Neighbor>(), ipcp->get_dif_information());
-				} catch (Exception &e) {
+				} catch (rina::Exception &e) {
 					LOG_ERR("Problems sending message to IPC Manager: %s", e.what());
 				}
 			}
@@ -2016,7 +2016,7 @@ void EnrollmentRIBObject::remoteStartObject(void * object_value, int invoke_id,
 	try {
 		stateMachine = (EnrollerStateMachine *) enrollment_task_->getEnrollmentStateMachine(
 				cdapSessionDescriptor->dest_ap_name_, cdapSessionDescriptor->port_id_, false);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems retrieving state machine: %s", e.what());
 		sendErrorMessage(cdapSessionDescriptor);
 		return;
@@ -2041,7 +2041,7 @@ void EnrollmentRIBObject::remoteStopObject(void * object_value, int invoke_id,
 	try {
 		stateMachine = (EnrolleeStateMachine *) enrollment_task_->getEnrollmentStateMachine(
 				cdapSessionDescriptor->dest_ap_name_, cdapSessionDescriptor->port_id_, false);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems retrieving state machine: %s", e.what());
 		sendErrorMessage(cdapSessionDescriptor);
 		return;
@@ -2065,7 +2065,7 @@ void EnrollmentRIBObject::sendErrorMessage(const rina::CDAPSessionDescriptor * c
 		remote_id.port_id_ = cdapSessionDescriptor->port_id_;
 
 		rib_daemon_->closeApplicationConnection(remote_id, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 	}
 }
@@ -2090,7 +2090,7 @@ void OperationalStatusRIBObject::remoteStartObject(void * object_value, int invo
 			LOG_ERR("Got a CDAP message that is not for me: %s");
 			return;
 		}
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems retrieving state machine: %s", e.what());
 		sendErrorMessage(cdapSessionDescriptor);
 		return;
@@ -2121,7 +2121,7 @@ void OperationalStatusRIBObject::sendErrorMessage(const rina::CDAPSessionDescrip
 		remote_id.port_id_ = cdapSessionDescriptor->port_id_;
 
 		rib_daemon_->closeApplicationConnection(remote_id, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending CDAP message: %s", e.what());
 	}
 }

--- a/rinad/src/ipcp/flow-allocator.cc
+++ b/rinad/src/ipcp/flow-allocator.cc
@@ -257,7 +257,7 @@ void FlowAllocator::populateRIB()
     rib_daemon_->addRIBObject(object);
     object = new DataTransferConstantsRIBObject(ipcp);
     rib_daemon_->addRIBObject(object);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems adding object to the RIB : %s", e.what());
   }
 }
@@ -286,7 +286,7 @@ void FlowAllocator::createFlowRequestMessageReceived(
     try {
       portId = rina::extendedIPCManager->allocatePortId(
           flow->destination_naming_info);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR(
           "Problems requesting an available port-id: %s. Ignoring the Flow allocation request",
           e.what());
@@ -324,7 +324,7 @@ void FlowAllocator::replyToIPCManager(
   try {
     rina::extendedIPCManager->allocateFlowRequestResult(event,
                                                         result);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems communicating with the IPC Manager Daemon: %s",
             e.what());
   }
@@ -340,7 +340,7 @@ void FlowAllocator::submitAllocateRequest(
     portId = rina::extendedIPCManager->allocatePortId(
         event.localApplicationName);
     LOG_DBG("Got assigned port-id %d", portId);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR(
         "Problems requesting an available port-id to the Kernel IPC Manager: %s",
         e.what());
@@ -354,14 +354,14 @@ void FlowAllocator::submitAllocateRequest(
 
   try {
     flowAllocatorInstance->submitAllocateRequest(event);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems allocating flow: %s", e.what());
     flow_allocator_instances_.erase(portId);
     delete flowAllocatorInstance;
 
     try {
       rina::extendedIPCManager->deallocatePortId(portId);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Problems releasing port-id %d: %s", portId, e.what());
     }
     replyToIPCManager(event, -1);
@@ -421,7 +421,7 @@ void FlowAllocator::processCreateConnectionResultEvent(
             event.getPortId());
     try {
       rina::extendedIPCManager->deallocatePortId(event.getPortId());
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR(
           "Problems requesting IPC Manager to deallocate port-id %d: %s",
           event.getPortId(), e.what());
@@ -443,7 +443,7 @@ void FlowAllocator::processUpdateConnectionResponseEvent(
             event.getPortId());
     try {
       rina::extendedIPCManager->deallocatePortId(event.getPortId());
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR(
           "Problems requesting IPC Manager to deallocate port-id %d: %s",
           event.getPortId(), e.what());
@@ -465,7 +465,7 @@ void FlowAllocator::submitDeallocate(
     LOG_ERR("Problems looking for FAI at portId %d", event.portId);
     try {
       rina::extendedIPCManager->deallocatePortId(event.portId);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR(
           "Problems requesting IPC Manager to deallocate port-id %d: %s",
           event.portId, e.what());
@@ -473,7 +473,7 @@ void FlowAllocator::submitDeallocate(
 
     try {
       rina::extendedIPCManager->notifyflowDeallocated(event, -1);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Error communicating with the IPC Manager: %s",
               e.what());
     }
@@ -481,7 +481,7 @@ void FlowAllocator::submitDeallocate(
     flowAllocatorInstance->submitDeallocate(event);
     try {
       rina::extendedIPCManager->notifyflowDeallocated(event, 0);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Error communicating with the IPC Manager: %s",
               e.what());
     }
@@ -624,7 +624,7 @@ void FlowAllocatorInstance::submitAllocateRequest(
     std::stringstream ss;
     ss << "Could not find entry in DFT for application ";
     ss << event.remoteApplicationName.toString();
-    throw Exception(ss.str().c_str());
+    throw rina::Exception(ss.str().c_str());
   }
 
   //2 Check if the destination address is this IPC process (then invoke degenerated form of IPC)
@@ -639,7 +639,7 @@ void FlowAllocatorInstance::submitAllocateRequest(
   if (destinationAddress == sourceAddress) {
     // At the moment we don't support allocation of flows between applications at the
     // same processing system
-    throw Exception(
+    throw rina::Exception(
         "Allocation of flows between local applications not supported yet");
   }
 
@@ -658,7 +658,7 @@ void FlowAllocatorInstance::replyToIPCManager(
   try {
     rina::extendedIPCManager->allocateFlowRequestResult(event,
                                                         result);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems communicating with the IPC Manager Daemon: %s",
             e.what());
   }
@@ -668,7 +668,7 @@ void FlowAllocatorInstance::releasePortId()
 {
   try {
     rina::extendedIPCManager->deallocatePortId(port_id_);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems releasing port-id %d", port_id_);
   }
 }
@@ -725,7 +725,7 @@ void FlowAllocatorInstance::processCreateConnectionResponseEvent(
 
     underlying_port_id_ = cdapSessions[0];
     state = MESSAGE_TO_PEER_FAI_SENT;
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR(
         "Problems sending M_CREATE <Flow> CDAP message to neighbor: %s",
         e.what());
@@ -794,7 +794,7 @@ void FlowAllocatorInstance::createFlowRequestMessageReceived(
           robject_value, -1,
           "EncoderConstants::FLOW_RIB_OBJECT_CLASS", invoke_id_,
           remote_id);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Problems sending CDAP message: %s", e.what());
     }
 
@@ -812,7 +812,7 @@ void FlowAllocatorInstance::createFlowRequestMessageReceived(
     LOG_DBG(
         "Requested the creation of a connection to the kernel to support flow with port-id %d",
         port_id_);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems requesting a connection to the kernel: %s ",
             e.what());
     releaseUnlockRemove();
@@ -853,7 +853,7 @@ void FlowAllocatorInstance::processCreateConnectionResultEvent(
     LOG_DBG(
         "Informed IPC Manager about incoming flow allocation request, got handle: %ud",
         allocate_response_message_handle_);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR(
         "Problems informing the IPC Manager about an incoming flow allocation request: %s",
         e.what());
@@ -892,14 +892,14 @@ void FlowAllocatorInstance::submitAllocateResponse(
       rib_daemon_->remoteCreateObjectResponse(
           EncoderConstants::FLOW_RIB_OBJECT_CLASS, object_name_,
           robject_value, 0, "", invoke_id_, remote_id);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR(
           "Problems requesting RIB Daemon to send CDAP Message: %s",
           e.what());
 
       try {
         rina::extendedIPCManager->flowDeallocated(port_id_);
-      } catch (Exception &e) {
+      } catch (rina::Exception &e) {
         LOG_ERR("Problems communicating with the IPC Manager: %s",
                 e.what());
       }
@@ -913,7 +913,7 @@ void FlowAllocatorInstance::submitAllocateResponse(
       rib_daemon_->createObject(
           EncoderConstants::FLOW_RIB_OBJECT_CLASS, object_name_, this,
           0);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_WARN("Error creating Flow Rib object: %s", e.what());
     }
 
@@ -937,7 +937,7 @@ void FlowAllocatorInstance::submitAllocateResponse(
         EncoderConstants::FLOW_RIB_OBJECT_CLASS, object_name_,
         robject_value, -1, "Application rejected the flow",
         invoke_id_, remote_id);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems requesting RIB Daemon to send CDAP Message: %s",
             e.what());
   }
@@ -967,7 +967,7 @@ void FlowAllocatorInstance::processUpdateConnectionResponseEvent(
       flow_request_event_.portId = -1;
       rina::extendedIPCManager->allocateFlowRequestResult(
           flow_request_event_, event.getResult());
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Problems communicating with the IPC Manager: %s",
               e.what());
     }
@@ -981,7 +981,7 @@ void FlowAllocatorInstance::processUpdateConnectionResponseEvent(
     flow_->state = Flow::ALLOCATED;
     rib_daemon_->createObject(EncoderConstants::FLOW_RIB_OBJECT_CLASS,
                               object_name_, this, 0);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_WARN(
         "Problems requesting the RIB Daemon to create a RIB object: %s",
         e.what());
@@ -993,7 +993,7 @@ void FlowAllocatorInstance::processUpdateConnectionResponseEvent(
     flow_request_event_.portId = port_id_;
     rina::extendedIPCManager->allocateFlowRequestResult(
         flow_request_event_, 0);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems communicating with the IPC Manager: %s",
             e.what());
   }
@@ -1035,7 +1035,7 @@ void FlowAllocatorInstance::submitDeallocate(
           EncoderConstants::FLOW_RIB_OBJECT_CLASS, object_name_, 0,
           remote_id, 0);
       ;
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Problems sending M_DELETE flow request: %s", e.what());
     }
 
@@ -1043,7 +1043,7 @@ void FlowAllocatorInstance::submitDeallocate(
     TearDownFlowTimerTask * timerTask = new TearDownFlowTimerTask(
         this, object_name_, true);
     timer_->scheduleTask(timerTask, TearDownFlowTimerTask::DELAY);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems processing flow deallocation request: %s",
             +e.what());
   }
@@ -1073,7 +1073,7 @@ void FlowAllocatorInstance::deleteFlowRequestMessageReceived()
   //4 Inform IPC Manager
   try {
     rina::extendedIPCManager->flowDeallocatedRemotely(port_id_, 0);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Error communicating with the IPC Manager: %s", e.what());
   }
 }
@@ -1097,7 +1097,7 @@ void FlowAllocatorInstance::destroyFlowAllocatorInstance(
   try {
     rib_daemon_->deleteObject(EncoderConstants::FLOW_RIB_OBJECT_CLASS,
                               object_name_, 0, 0);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems deleting object from RIB: %s", e.what());
   }
 
@@ -1132,7 +1132,7 @@ void FlowAllocatorInstance::createResponse(
       flow_request_event_.portId = -1;
       rina::extendedIPCManager->allocateFlowRequestResult(
           flow_request_event_, result);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Problems communicating with the IPC Manager: %s",
               e.what());
     }
@@ -1157,7 +1157,7 @@ void FlowAllocatorInstance::createResponse(
     rina::kernelIPCProcess->updateConnection(
         *(flow_->getActiveConnection()));
     lock_->unlock();
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems requesting kernel to update connection: %s",
             e.what());
 
@@ -1166,7 +1166,7 @@ void FlowAllocatorInstance::createResponse(
       flow_request_event_.portId = -1;
       rina::extendedIPCManager->allocateFlowRequestResult(
           flow_request_event_, result);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
       LOG_ERR("Problems communicating with the IPC Manager: %s",
               e.what());
     }
@@ -1222,7 +1222,7 @@ void DataTransferConstantsRIBObject::remoteReadObject(
         EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_CLASS,
         EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_NAME,
         robject_value, 0, "", invoke_id, false, remote_id);
-  } catch (Exception &e) {
+  } catch (rina::Exception &e) {
     LOG_ERR("Problems generating or sending CDAP Message: %s",
             e.what());
   }

--- a/rinad/src/ipcp/flow-allocator.h
+++ b/rinad/src/ipcp/flow-allocator.h
@@ -53,7 +53,7 @@ public:
 	/// M_CREATE request with the flow object and send it to the appropriate IPC process (search the
 	/// directory and the directory forwarding table if needed)
 	/// @param flowRequestEvent The flow allocation request
-	/// @throws Exception if there are not enough resources to fulfill the allocate request
+	/// @throws rina::Exception if there are not enough resources to fulfill the allocate request
 	virtual void submitAllocateRequest(const rina::FlowRequestEvent& event) = 0;
 
 	virtual void processCreateConnectionResponseEvent(

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -49,7 +49,7 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
 		rina::extendedIPCManager->ipcProcessId = id;
 		rina::kernelIPCProcess->ipcProcessId = id;
 		LOG_INFO("Librina initialized");
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
         std::cerr << "Cannot initialize librina" << std::endl;
         exit(EXIT_FAILURE);
 	}
@@ -60,7 +60,7 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
 
         // Load the default pluggable components
         if (plugin_load("default")) {
-                throw Exception("Failed to load default plugin");
+                throw rina::Exception("Failed to load default plugin");
         }
 
 	// Initialize subcomponents
@@ -87,32 +87,32 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
         // Select the default policy sets
         security_manager_->select_policy_set(std::string(), "default");
         if (!security_manager_->ps) {
-                throw Exception("Cannot create security manager policy-set");
+                throw rina::Exception("Cannot create security manager policy-set");
         }
 
         flow_allocator_->select_policy_set(std::string(), "default");
         if (!flow_allocator_->ps) {
-                throw Exception("Cannot create flow allocator policy-set");
+                throw rina::Exception("Cannot create flow allocator policy-set");
         }
 
         namespace_manager_->select_policy_set(std::string(), "default");
         if (!namespace_manager_->ps) {
-                throw Exception("Cannot create namespace manager policy-set");
+                throw rina::Exception("Cannot create namespace manager policy-set");
         }
 
         resource_allocator_->select_policy_set(std::string(), "default");
         if (!resource_allocator_->ps) {
-                throw Exception("Cannot create resource allocator policy-set");
+                throw rina::Exception("Cannot create resource allocator policy-set");
         }
 
         routing_component_->select_policy_set(std::string(), "link-state");
         if (!routing_component_->ps) {
-                throw Exception("Cannot create routing component policy-set");
+                throw rina::Exception("Cannot create routing component policy-set");
         }
 
 	try {
 		rina::extendedIPCManager->notifyIPCProcessInitialized(name_);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with IPC Manager: %s. Exiting... ", e.what());
 		exit(EXIT_FAILURE);
 	}
@@ -286,7 +286,7 @@ void IPCProcessImpl::processAssignToDIFRequestEvent(const rina::AssignToDIFReque
 		pending_events_.insert(std::pair<unsigned int,
 				rina::AssignToDIFRequestEvent>(handle, event));
 		state = ASSIGN_TO_DIF_IN_PROCESS;
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending DIF Assignment request to the kernel: %s", e.what());
 		rina::extendedIPCManager->assignToDIFResponse(event, -1);
 	}
@@ -327,7 +327,7 @@ void IPCProcessImpl::processAssignToDIFResponseEvent(const rina::AssignToDIFResp
 
 		try {
 			rina::extendedIPCManager->assignToDIFResponse(requestEvent, -1);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 
@@ -345,7 +345,7 @@ void IPCProcessImpl::processAssignToDIFResponseEvent(const rina::AssignToDIFResp
 		flow_allocator_->set_dif_configuration(dif_information_.dif_configuration_);
 		enrollment_task_->set_dif_configuration(dif_information_.dif_configuration_);
 	}
-	catch(Exception &e){
+	catch(rina::Exception &e){
 		state = INITIALIZED;
 		LOG_ERR("Bad configuration error: %s", e.what());
 		rina::extendedIPCManager->assignToDIFResponse(requestEvent, -1);
@@ -355,7 +355,7 @@ void IPCProcessImpl::processAssignToDIFResponseEvent(const rina::AssignToDIFResp
 
 	try {
 		rina::extendedIPCManager->assignToDIFResponse(requestEvent, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 	}
 }
@@ -363,7 +363,7 @@ void IPCProcessImpl::processAssignToDIFResponseEvent(const rina::AssignToDIFResp
 void IPCProcessImpl::requestPDUFTEDump() {
 	try{
 		rina::kernelIPCProcess->dumptPDUFT();
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_WARN("Error requesting IPC Process to Dump PDU Forwarding Table: %s", e.what());
 	}
 }
@@ -458,7 +458,7 @@ void IPCProcessImpl::processSetPolicySetParamRequestEvent(
 		pending_set_policy_set_param_events.insert(
                         std::pair<unsigned int,
 			rina::SetPolicySetParamRequestEvent>(handle, event));
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending set-policy-set-param request "
                         "to the kernel: %s", e.what());
 		rina::extendedIPCManager->setPolicySetParamResponse(event, -1);
@@ -487,7 +487,7 @@ void IPCProcessImpl::processSetPolicySetParamResponseEvent(
 
 		try {
 			rina::extendedIPCManager->setPolicySetParamResponse(it->second, -1);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 
@@ -499,7 +499,7 @@ void IPCProcessImpl::processSetPolicySetParamResponseEvent(
 
 	try {
 		rina::extendedIPCManager->setPolicySetParamResponse(requestEvent, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 	}
 }
@@ -553,7 +553,7 @@ void IPCProcessImpl::processSelectPolicySetRequestEvent(
 		pending_select_policy_set_events.insert(
                         std::pair<unsigned int,
 			rina::SelectPolicySetRequestEvent>(handle, event));
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending select-policy-set request "
                         "to the kernel: %s", e.what());
 		rina::extendedIPCManager->selectPolicySetResponse(event, -1);
@@ -582,7 +582,7 @@ void IPCProcessImpl::processSelectPolicySetResponseEvent(
 
 		try {
 			rina::extendedIPCManager->selectPolicySetResponse(it->second, -1);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 
@@ -594,7 +594,7 @@ void IPCProcessImpl::processSelectPolicySetResponseEvent(
 
 	try {
 		rina::extendedIPCManager->selectPolicySetResponse(requestEvent, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 	}
 }

--- a/rinad/src/ipcp/link-state-routing-ps.cc
+++ b/rinad/src/ipcp/link-state-routing-ps.cc
@@ -52,7 +52,7 @@ void LinkStateRoutingPs::set_dif_configuration(const rina::DIFConfiguration& dif
 			LINK_STATE_POLICY) != 0) {
 		LOG_WARN("Unsupported routing policy: %s.",
 				pduftgConfig.get_pduft_generator_policy().get_name().c_str());
-		throw Exception("Unknown routing Policy");
+		throw rina::Exception("Unknown routing Policy");
 	}
 
 	lsr_policy = new LinkStateRoutingPolicy(rc->ipcp);
@@ -781,7 +781,7 @@ void FlowStateDatabase::updateObjects(
 			flow_state_rib_object_group_->createObject(
 					EncoderConstants::FLOW_STATE_OBJECT_RIB_OBJECT_CLASS,
 					(*newIt)->object_name_, (*newIt));
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems creating RIB object: %s", e.what());
 		}
 	}
@@ -857,7 +857,7 @@ void KillFlowStateObjectTimerTask::run()
 							EncoderConstants::FLOW_STATE_OBJECT_RIB_OBJECT_CLASS,
 							fso_->object_name_);
 			fs_rib_o->deleteObject(fso_);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Object could not be removed from the RIB");
 		}
 		delete fso_;
@@ -950,7 +950,7 @@ void LinkStateRoutingPolicy::populateRIB()
 	try {
 		fs_rib_group_ = new FlowStateRIBObjectGroup(ipc_process_, this);
 		rib_daemon_->addRIBObject(fs_rib_group_);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems adding object to RIB: %s", e.what());
 	}
 }
@@ -1068,7 +1068,7 @@ void LinkStateRoutingPolicy::processFlowAllocatedEvent(
 				ipc_process_->namespace_manager_->getAdressByname(
 						event->flow_information_.remoteAppName), 1,
 						event->flow_information_.portId);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_DBG("flow allocation waiting for enrollment");
 		allocated_flows_.push_back(event->flow_information_);
 	}
@@ -1091,7 +1091,7 @@ void LinkStateRoutingPolicy::processNeighborAddedEvent(
 								event->neighbor_->get_name()), 1, it->portId);
 				allocated_flows_.erase(it);
 				break;
-			} catch (Exception &e) {
+			} catch (rina::Exception &e) {
 				LOG_ERR("Could not allocate the flow, no neighbor found");
 			}
 		}
@@ -1116,7 +1116,7 @@ void LinkStateRoutingPolicy::processNeighborAddedEvent(
 				EncoderConstants::FLOW_STATE_OBJECT_GROUP_RIB_OBJECT_NAME,
 				robject_value, 0, remote_id, 0);
 		db_->setAvoidPort(portId);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems encoding and sending CDAP message: %s", e.what());
 	}
 }
@@ -1148,7 +1148,7 @@ void LinkStateRoutingPolicy::propagateFSDB() const
           EncoderConstants::FLOW_STATE_OBJECT_GROUP_RIB_OBJECT_CLASS,
           EncoderConstants::FLOW_STATE_OBJECT_GROUP_RIB_OBJECT_NAME,
           robject_value, 0, remote_id, 0);
-      } catch (Exception &e) {
+      } catch (rina::Exception &e) {
         LOG_ERR("Errors sending message: %s", e.what());
       }
 	  }
@@ -1191,7 +1191,7 @@ void LinkStateRoutingPolicy::writeMessageReceived(
 	try {
 		db_->updateObjects(flow_state_objects, portId,
 				ipc_process_->get_address());
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems decoding Flow State Object Group: %s", e.what());
 	}
 }
@@ -1212,7 +1212,7 @@ void LinkStateRoutingPolicy::readMessageRecieved(int invoke_id,
 		rib_daemon_->remoteReadObjectResponse(fs_rib_group_->class_,
 				fs_rib_group_->name_, robject_value, 0, "", invoke_id, false,
 				remote_id);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems encoding and sending CDAP message: %s", e.what());
 	}
 }

--- a/rinad/src/ipcp/main.cc
+++ b/rinad/src/ipcp/main.cc
@@ -71,7 +71,7 @@ int wrapped_main(int argc, char * argv[])
 
         try {
         	loop.run();
-        } catch (Exception &e) {
+        } catch (rina::Exception &e) {
         	LOG_ERR("Problems running event loop: %s", e.what());
         } catch (std::exception &e1) {
         	LOG_ERR("Problems running event loop: %s", e1.what());

--- a/rinad/src/ipcp/namespace-manager.cc
+++ b/rinad/src/ipcp/namespace-manager.cc
@@ -69,7 +69,7 @@ void WhateverCastNameSetRIBObject::remoteCreateObject(void * object_value,
 			rina::WhatevercastName * name = (rina::WhatevercastName *) object_value;
 			namesToCreate.push_back(name);
 		}
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Error decoding CDAP object value: %s", e.what());
 	}
 
@@ -81,7 +81,7 @@ void WhateverCastNameSetRIBObject::remoteCreateObject(void * object_value,
 	try {
 		rib_daemon_->createObject(EncoderConstants::WHATEVERCAST_NAME_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::WHATEVERCAST_NAME_SET_RIB_OBJECT_NAME, &namesToCreate, 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 }
@@ -114,7 +114,7 @@ void WhateverCastNameSetRIBObject::createName(rina::WhatevercastName * name) {
 	add_child(ribObject);
 	try {
 		rib_daemon_->addRIBObject(ribObject);
-	} catch(Exception &e){
+	} catch(rina::Exception &e){
 		LOG_ERR("Problems adding object to the RIB: %s", e.what());
 	}
 }
@@ -138,7 +138,7 @@ void DirectoryForwardingTableEntryRIBObject::remoteCreateObject(void * object_va
 
 	try {
 		entry = (rina::DirectoryForwardingTableEntry *) object_value;
-	} catch (Exception & e){
+	} catch (rina::Exception & e){
 		LOG_ERR("Problems decoding message: %s", e.what());
 		return;
 	}
@@ -158,7 +158,7 @@ void DirectoryForwardingTableEntryRIBObject::remoteCreateObject(void * object_va
 		try {
 			rib_daemon_->createObject(EncoderConstants::DFT_ENTRY_RIB_OBJECT_CLASS, object_name,
 					currentEntry, &notificationPolicy);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems creating RIB object: %s", e.what());
 		}
 	}
@@ -187,7 +187,7 @@ void DirectoryForwardingTableEntryRIBObject::remoteDeleteObject(int invoke_id,
 	rina::NotificationPolicy notificationPolicy = rina::NotificationPolicy(cdapSessionIds);
 	try {
 		rib_daemon_->deleteObject(class_, name_, 0, &notificationPolicy);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems deleting RIB object: %s", e.what());
 	}
 }
@@ -270,7 +270,7 @@ void DirectoryForwardingTableEntrySetRIBObject::remoteCreateObject(void * object
 					(rina::DirectoryForwardingTableEntry *) object_value;
 			populateEntriesToCreateList(receivedEntry, &entriesToCreateOrUpdate);
 		}
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Error decoding CDAP object value: %s", e.what());
 	}
 
@@ -287,7 +287,7 @@ void DirectoryForwardingTableEntrySetRIBObject::remoteCreateObject(void * object
 		rib_daemon_->createObject(EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_NAME, &entriesToCreateOrUpdate,
 				&notificationPolicy);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 }
@@ -332,7 +332,7 @@ void DirectoryForwardingTableEntrySetRIBObject::createObject(const std::string& 
 		add_child(ribObject);
 		try {
 			rib_daemon_->addRIBObject(ribObject);
-		} catch(Exception &e){
+		} catch(rina::Exception &e){
 			LOG_ERR("Problems adding object to the RIB: %s", e.what());
 		}
 	}
@@ -364,7 +364,7 @@ void DirectoryForwardingTableEntrySetRIBObject::deleteObject(const void* objectV
 			remove_child(ribObject->name_);
 			try {
 				rib_daemon_->removeRIBObject(ribObject->name_);
-			} catch (Exception &e) {
+			} catch (rina::Exception &e) {
 				LOG_ERR("Problems removing object from the RIB: %s", e.what());
 			}
 		} else {
@@ -413,7 +413,7 @@ void NamespaceManager::populateRIB() {
 		rib_daemon_->addRIBObject(object);
 		object = new WhateverCastNameSetRIBObject(ipcp);
 		rib_daemon_->addRIBObject(object);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems adding object to the RIB : %s", e.what());
 	}
 }
@@ -465,7 +465,7 @@ int NamespaceManager::replyToIPCManagerRegister(const rina::ApplicationRegistrat
 		int result) {
 	try {
 		rina::extendedIPCManager->registerApplicationResponse(event, result);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		return -1;
 	}
@@ -516,7 +516,7 @@ void NamespaceManager::processApplicationRegistrationRequestEvent(
 		rib_daemon_->createObject(EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_CLASS,
 				EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_NAME, &entriesToCreate,
 				&notificationPolicy);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 }
@@ -525,7 +525,7 @@ int NamespaceManager::replyToIPCManagerUnregister(const rina::ApplicationUnregis
 		int result) {
 	try {
 		rina::extendedIPCManager->unregisterApplicationResponse(event, result);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		return -1;
 	}
@@ -565,7 +565,7 @@ void NamespaceManager::processApplicationUnregistrationRequestEvent(
 		ss<<EncoderConstants::SEPARATOR<< unregisteredApp->appName.getEncodedString();
 		rib_daemon_->deleteObject(EncoderConstants::DFT_ENTRY_RIB_OBJECT_CLASS,
 				ss.str(), 0, &notificationPolicy);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 
@@ -581,7 +581,7 @@ unsigned int NamespaceManager::getAdressByname(const rina::ApplicationProcessNam
 		}
 	}
 
-	throw Exception("Unknown neighbor");
+	throw rina::Exception("Unknown neighbor");
 }
 
 int NamespaceManager::select_policy_set(const std::string& path,

--- a/rinad/src/ipcp/resource-allocator.cc
+++ b/rinad/src/ipcp/resource-allocator.cc
@@ -54,7 +54,7 @@ void NMinusOneFlowManager::populateRIB(){
 		rib_daemon_->addRIBObject(object);
 		object = new NMinusOneFlowSetRIBObject(ipc_process_);
 		rib_daemon_->addRIBObject(object);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems adding object to the RIB : %s", e.what());
 	}
 }
@@ -63,7 +63,7 @@ const rina::FlowInformation& NMinusOneFlowManager::getNMinus1FlowInformation(int
 const {
 	rina::Flow * flow = rina::extendedIPCManager->getAllocatedFlow(portId);
 	if (flow == 0) {
-		throw Exception("Unknown N-1 flow");
+		throw rina::Exception("Unknown N-1 flow");
 	}
 
 	return flow->getFlowInformation();
@@ -77,7 +77,7 @@ unsigned int NMinusOneFlowManager::allocateNMinus1Flow(const rina::FlowInformati
 				flowInformation.remoteAppName, flowInformation.difName,
 				flowInformation.flowSpecification);
 	} catch(rina::FlowAllocationException &e) {
-		throw Exception(e.what());
+		throw rina::Exception(e.what());
 	}
 
 	LOG_INFO("Requested the allocation of N-1 flow to application %s-%s through DIF %s",
@@ -106,7 +106,7 @@ void NMinusOneFlowManager::allocateRequestResult(const rina::AllocateFlowRequest
 		ss<<EncoderConstants::SEPARATOR<<event.portId;
 		rib_daemon_->createObject(EncoderConstants::N_MINUS_ONE_FLOW_RIB_OBJECT_CLASS,
 				ss.str(), &(flow->getFlowInformation()), 0);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 
@@ -125,7 +125,7 @@ void NMinusOneFlowManager::flowAllocationRequested(const rina::FlowRequestEvent&
 				event.remoteApplicationName.processInstance.c_str());
 		try {
 			rina::extendedIPCManager->allocateFlowResponse(event, -1, true);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 		return;
@@ -136,7 +136,7 @@ void NMinusOneFlowManager::flowAllocationRequested(const rina::FlowRequestEvent&
 		LOG_ERR("Rejecting flow request since the IPC Process is not ASSIGNED to a DIF");
 		try {
 			rina::extendedIPCManager->allocateFlowResponse(event, -1, true);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 		return;
@@ -151,7 +151,7 @@ void NMinusOneFlowManager::flowAllocationRequested(const rina::FlowRequestEvent&
 				event.remoteApplicationName.processInstance.c_str());
 		try {
 			rina::extendedIPCManager->allocateFlowResponse(event, -1, true);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 		return;
@@ -160,7 +160,7 @@ void NMinusOneFlowManager::flowAllocationRequested(const rina::FlowRequestEvent&
 	rina::Flow * flow = 0;
 	try {
 		flow = rina::extendedIPCManager->allocateFlowResponse(event, 0, true);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		if (!flow) {
 			return;
@@ -176,7 +176,7 @@ void NMinusOneFlowManager::flowAllocationRequested(const rina::FlowRequestEvent&
 		ss<<EncoderConstants::SEPARATOR<<event.portId;
 		rib_daemon_->createObject(EncoderConstants::N_MINUS_ONE_FLOW_RIB_OBJECT_CLASS,
 				ss.str(), &(flow->getFlowInformation()), 0);
-	} catch (Exception &e){
+	} catch (rina::Exception &e){
 		LOG_ERR("Error creating RIB object: %s", e.what());
 	}
 
@@ -200,7 +200,7 @@ void NMinusOneFlowManager::deallocateFlowResponse(
 
 	try {
 		rina::extendedIPCManager->flowDeallocationResult(event.portId, success);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 	}
 
@@ -210,7 +210,7 @@ void NMinusOneFlowManager::deallocateFlowResponse(
 void NMinusOneFlowManager::flowDeallocatedRemotely(const rina::FlowDeallocatedEvent& event) {
 	try {
 		rina::extendedIPCManager->flowDeallocated(event.portId);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 	}
 
@@ -223,7 +223,7 @@ void NMinusOneFlowManager::cleanFlowAndNotify(int portId) {
 		ss<<EncoderConstants::N_MINUS_ONE_FLOW_SET_RIB_OBJECT_NAME;
 		ss<<EncoderConstants::SEPARATOR<<portId;
 		rib_daemon_->deleteObject(EncoderConstants::N_MINUS_ONE_FLOW_RIB_OBJECT_CLASS, ss.str(), 0, 0);
-	}catch(Exception &e) {
+	}catch(rina::Exception &e) {
 		LOG_ERR("Problems deleting object from the RIB: %s", e.what());
 	}
 
@@ -243,7 +243,7 @@ void NMinusOneFlowManager::processRegistrationNotification(const rina::IPCProces
 	if (event.isRegistered()) {
 		try {
 			rina::extendedIPCManager->appRegistered(event.getIPCProcessName(), event.getDIFName());
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 		}
 
@@ -256,7 +256,7 @@ void NMinusOneFlowManager::processRegistrationNotification(const rina::IPCProces
 			std::string * dif_name = new std::string(event.getDIFName().processName);
 			rib_daemon_->createObject(EncoderConstants::DIF_REGISTRATION_RIB_OBJECT_CLASS, ss.str(),
 					dif_name, 0);
-		}catch(Exception &e){
+		}catch(rina::Exception &e){
 			LOG_ERR("Problems creating RIB object: %s", e.what());;
 		}
 
@@ -265,7 +265,7 @@ void NMinusOneFlowManager::processRegistrationNotification(const rina::IPCProces
 
 	try {
 		rina::extendedIPCManager->appUnregistered(event.getIPCProcessName(), event.getDIFName());
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems communicating with the IPC Manager: %s", e.what());
 	}
 
@@ -277,7 +277,7 @@ void NMinusOneFlowManager::processRegistrationNotification(const rina::IPCProces
 		ss<<EncoderConstants::DIF_REGISTRATION_SET_RIB_OBJECT_NAME;
 		ss<<EncoderConstants::SEPARATOR<<event.getDIFName().processName;
 		rib_daemon_->deleteObject(EncoderConstants::DIF_REGISTRATION_RIB_OBJECT_CLASS, ss.str(), 0, 0);
-	}catch (Exception &e) {
+	}catch (rina::Exception &e) {
 		LOG_ERR("Problems deleting object from RIB: %s", e.what());
 	}
 }

--- a/rinad/src/ipcp/rib-daemon.cc
+++ b/rinad/src/ipcp/rib-daemon.cc
@@ -46,7 +46,7 @@ void * doManagementSDUReaderWork(void* arg)
 	while (true) {
 		try {
 		result = rina::kernelIPCProcess->readManagementSDU(buffer, data->max_sdu_size_);
-		} catch (Exception &e) {
+		} catch (rina::Exception &e) {
 			LOG_ERR("Problems reading management SDU: %s", e.what());
 			continue;
 		}
@@ -220,7 +220,7 @@ void IPCPRIBDaemonImpl::processQueryRIBRequestEvent(const rina::QueryRIBRequestE
 
 	try {
 		rina::extendedIPCManager->queryRIBResponse(event, 0, result);
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		LOG_ERR("Problems sending query RIB response to IPC Manager: %s",
 				e.what());
 	}
@@ -245,7 +245,7 @@ void IPCPRIBDaemonImpl::sendMessageSpecific(bool useAddress, const rina::CDAPMes
 			&& cdapMessage.get_op_code() != rina::CDAPMessage::M_DELETE_R
 			&& cdapMessage.get_op_code() != rina::CDAPMessage::M_START_R
 			&& cdapMessage.get_op_code() != rina::CDAPMessage::M_STOP_R) {
-		throw Exception("Requested a response message but message handler is null");
+		throw rina::Exception("Requested a response message but message handler is null");
 	}
 
 	atomic_send_lock_.lock();
@@ -274,7 +274,7 @@ void IPCPRIBDaemonImpl::sendMessageSpecific(bool useAddress, const rina::CDAPMes
 			cdsm->messageSent(cdapMessage, sessionId);
 		    delete sdu;
 		}
-	} catch (Exception &e) {
+	} catch (rina::Exception &e) {
 		if (sdu) {
 			delete sdu;
 		}
@@ -319,7 +319,7 @@ void IPCPRIBDaemonImpl::cdapMessageDelivered(char* message, int length, int port
     try {
             rina::SerializedObject serializedMessage = rina::SerializedObject(message, length);
             cdapMessage = cdap_session_manager_->messageReceived(serializedMessage, portId);
-    } catch (Exception &e) {
+    } catch (rina::Exception &e) {
             atomic_send_lock_.unlock();
             LOG_ERR("Error decoding CDAP message: %s", e.what());
             return;
@@ -348,7 +348,7 @@ void IPCPRIBDaemonImpl::cdapMessageDelivered(char* message, int length, int port
     		delete cdapSessionDescriptor;
     		delete cdapMessage;
     		return;
-    	} catch (Exception &e) {
+    	} catch (rina::Exception &e) {
     		atomic_send_lock_.unlock();
     		LOG_ERR("Error processing A-data message: %s", e.what());
     		return;

--- a/rinad/src/ipcp/test-link-state-routing.cc
+++ b/rinad/src/ipcp/test-link-state-routing.cc
@@ -396,7 +396,7 @@ public:
 	}
 	unsigned int getAdressByname(const rina::ApplicationProcessNamingInformation& name) {
 		if (name.processName.compare("") == 0) {
-			throw Exception();
+			throw rina::Exception();
 		}
 		return 0;
 	}
@@ -442,7 +442,7 @@ public:
 		state_ = operational_state;
 	}
 	rina::DIFInformation& get_dif_information() const {
-		throw Exception();
+		throw rina::Exception();
 	}
 	void set_dif_information(const rina::DIFInformation& dif_information) {
 		dif_information_ = dif_information;


### PR DESCRIPTION
Closes #383

librina, rinad and rina-tools have been modified so that the Exception class (defined in librina/include/librina/exceptions.h) is referenced in the rina namespace, using the scope resolution operator "::".