### PR TITLE
librina, rinad: add -std=c++98 compiler option

### DIFF
--- a/librina/src/Makefile.am
+++ b/librina/src/Makefile.am
@@ -53,6 +53,7 @@ librina_la_CPPFLAGS =				\
 	$(LIBPROTOBUF_CFLAGS)			\
 	$(CPPFLAGS_EXTRA)
 librina_la_CXXFLAGS =				\
+	-std=c++98				\
 	$(CXXFLAGS_EXTRA)
 
 librina_stubbed_la_SOURCES  = $(allsources)
@@ -70,6 +71,7 @@ librina_stubbed_la_CPPFLAGS =			\
 	$(LIBPROTOBUF_CFLAGS)			\
 	$(CPPFLAGS_EXTRA)
 librina_stubbed_la_CXXFLAGS =			\
+	-std=c++98				\
 	$(CXXFLAGS_EXTRA)
 
 lib_LTLIBRARIES    = librina.la

--- a/rinad/src/common/Makefile.am
+++ b/rinad/src/common/Makefile.am
@@ -15,6 +15,9 @@ librinad_la_CPPFLAGS =				\
 	$(LIBPROTOBUF_CFLAGS)			\
 	-I$(srcdir)/tclap			\
 	-I$(srcdir)/..
+librinad_la_CXXFLAGS =				\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 librinad_la_LIBADD   =				\
 	$(LIBRINA_LIBS)				\
 	$(LIBPROTOBUF_LIBS)			\

--- a/rinad/src/ipcm/Makefile.am
+++ b/rinad/src/ipcm/Makefile.am
@@ -53,6 +53,9 @@ ipcm_CPPFLAGS =					\
 	-I$(srcdir)/../common			\
 	-I$(srcdir)/jsoncpp			\
 	-DPLUGINSDIR=\"$(pkglibdir)/ipcm\"
+ipcm_CXXFLAGS =					\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 ipcm_LDADD    =					\
 	$(builddir)/../common/librinad.la	\
 	$(builddir)/libjsoncpp.la		\
@@ -78,6 +81,9 @@ test_empty_CPPFLAGS =				\
 	$(LIBRINA_CFLAGS)			\
 	-I$(srcdir)/..				\
 	-I$(srcdir)/../common
+test_empty_CXXFLAGS =				\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 test_empty_LDADD    = $(builddir)/../common/librinad.la $(LIBRINA_LIBS)
 
 check_PROGRAMS =				\

--- a/rinad/src/ipcp/Makefile.am
+++ b/rinad/src/ipcp/Makefile.am
@@ -25,6 +25,9 @@ ipcp_CFLAGS   =
 ipcp_CPPFLAGS =					\
 	$(COMMONCPPFLAGS)			\
 	-DPLUGINSDIR=\"$(pkglibdir)/ipcp\"
+ipcp_CXXFLAGS =					\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 ipcp_LDADD    = $(COMMONLIBS) -ldl
 ipcp_SOURCES  =						\
 	main.cc						\
@@ -48,6 +51,9 @@ plugins_LTLIBRARIES =
 default_la_CFLAGS =
 default_la_CPPFLAGS =				\
 	$(COMMONCPPFLAGS)
+default_la_CXXFLAGS =				\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 default_la_LIBADD = $(COMMONLIBS) -ldl
 default_la_LDFLAGS = -module
 default_la_SOURCES =				\
@@ -71,6 +77,9 @@ test_encoders_SOURCES  =			\
 	enrollment-task.cc   enrollment-task.h	\
     link-state-routing-ps.cc   link-state-routing-ps.h
 test_encoders_CPPFLAGS = $(testsCPPFLAGS)
+test_encoders_CXXFLAGS =			\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 test_encoders_LDADD    = $(testsLIBS)
 
 test_pduftg_SOURCES  =				\
@@ -79,6 +88,9 @@ test_pduftg_SOURCES  =				\
 	events.cc          events.h		\
 	link-state-routing-ps.cc link-state-routing-ps.h
 test_pduftg_CPPFLAGS = $(testsCPPFLAGS)
+test_pduftg_CXXFLAGS =				\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 test_pduftg_LDADD    = $(testsLIBS)
 
 check_PROGRAMS =				\

--- a/rinad/src/ipcp/plugins/Makefile.am
+++ b/rinad/src/ipcp/plugins/Makefile.am
@@ -19,6 +19,9 @@ plugins_LTLIBRARIES =
 sm_passwd_la_CFLAGS   =
 sm_passwd_la_CPPFLAGS =				\
 	$(COMMONCPPFLAGS)
+sm_passwd_la_CXXFLAGS =				\
+	-std=c++98				\
+	$(CXXFLAGS_EXTRA)
 sm_passwd_la_LIBADD   =
 sm_passwd_la_LDFLAGS  = -module
 sm_passwd_la_SOURCES  =				\


### PR DESCRIPTION
Add compiler flags to force user-space stack to follow the c++98 standard.