### PR TITLE
Fix #517: cleanup of IPCP kernel state when detecting a crashed IPCP Daemon OS Process

### DIFF
--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -47,61 +47,65 @@ void IPCManager_::os_process_finalized_handler(
 			<< "terminated" << endl;
 	FLUSH_LOG(INFO, ss);
 
-	//Prevent any insertion/deletion to happen
-	rina::ReadScopedLock readlock(ipcp_factory_.rwlock);
+	{
+		//Prevent any insertion/deletion to happen
+		rina::ReadScopedLock readlock(ipcp_factory_.rwlock);
 
-	// Look if the terminating application has allocated flows
-	// with some IPC processes
-	collect_flows_by_application(app_name, involved_flows);
-	unsigned short ipcp_id = 0;
-	for (list<rina::FlowInformation>::iterator fit = involved_flows.begin();
-			fit != involved_flows.end(); fit++) {
+		// Look if the terminating application has allocated flows
+		// with some IPC processes
+		collect_flows_by_application(app_name, involved_flows);
+		unsigned short ipcp_id = 0;
+		for (list<rina::FlowInformation>::iterator fit = involved_flows.begin();
+				fit != involved_flows.end(); fit++) {
 
-		IPCMIPCProcess *ipcp = select_ipcp_by_dif(fit->difName);
-		if (!ipcp) {
-			ss  << ": Cannot find the IPC process "
-					"that provides the flow with port-id " <<
-					fit->portId << endl;
-			FLUSH_LOG(ERR, ss);
-			continue;
+			IPCMIPCProcess *ipcp = select_ipcp_by_dif(fit->difName);
+			if (!ipcp) {
+				ss  << ": Cannot find the IPC process "
+						"that provides the flow with port-id " <<
+						fit->portId << endl;
+				FLUSH_LOG(ERR, ss);
+				continue;
+			}
+
+			{
+				//Auto release the read lock
+				rina::ReadScopedLock readlock(ipcp->rwlock, false);
+				ipcp_id = ipcp->get_id();
+			}
+
+			rina::FlowDeallocateRequestEvent req_event(fit->portId, 0);
+			IPCManager->deallocate_flow(NULL, ipcp_id, req_event);
 		}
 
-		{
-			//Auto release the read lock
-			rina::ReadScopedLock readlock(ipcp->rwlock, false);
-			ipcp_id = ipcp->get_id();
-		}
-
-		rina::FlowDeallocateRequestEvent req_event(fit->portId, 0);
-		IPCManager->deallocate_flow(NULL, ipcp_id, req_event);
-	}
-
-	// Look if the terminating application has pending registrations
-	// with some IPC processes
-	vector<IPCMIPCProcess *> ipcps;
-	ipcp_factory_.listIPCProcesses(ipcps);
-	for (unsigned int i = 0; i < ipcps.size(); i++) {
-		if (application_is_registered_to_ipcp(app_name,
-							    ipcps[i])) {
-			// Build a structure that will be used during
-			// the unregistration process. The last argument
-			// is the request sequence number: 0 means that
-			// the unregistration response does not match
-			// an application request - this is indeed an
-			// unregistration forced by the IPCM.
-			rina::ApplicationUnregistrationRequestEvent
+		// Look if the terminating application has pending registrations
+		// with some IPC processes
+		vector<IPCMIPCProcess *> ipcps;
+		ipcp_factory_.listIPCProcesses(ipcps);
+		for (unsigned int i = 0; i < ipcps.size(); i++) {
+			if (application_is_registered_to_ipcp(app_name,
+					ipcps[i])) {
+				// Build a structure that will be used during
+				// the unregistration process. The last argument
+				// is the request sequence number: 0 means that
+				// the unregistration response does not match
+				// an application request - this is indeed an
+				// unregistration forced by the IPCM.
+				rina::ApplicationUnregistrationRequestEvent
 				req_event(app_name, ipcps[i]->dif_name_, 0);
 
-			IPCManager->unregister_app_from_ipcp(NULL,
+				IPCManager->unregister_app_from_ipcp(NULL,
 						req_event,
 						ipcps[i]->get_id());
+			}
 		}
 	}
 
 	if (event->ipcProcessId != 0) {
-		// TODO The process that crashed was an IPC Process daemon
-		// Should we destroy the state in the kernel? Or try to
-		// create another IPC Process in user space to bring it back?
+		// Cleanup IPC Process state in the kernel
+		if(IPCManager->destroy_ipcp(event->ipcProcessId) < 0 ){
+			LOG_WARN("Problems cleaning up state of IPCP with id: %d\n",
+					event->ipcProcessId);
+		}
 	}
 }
 

--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -101,6 +101,9 @@ void IPCManager_::os_process_finalized_handler(
 	}
 
 	if (event->ipcProcessId != 0) {
+		//TODO if the IPCP was supporting flows or had
+		//registered applications, notify them
+
 		// Cleanup IPC Process state in the kernel
 		if(IPCManager->destroy_ipcp(event->ipcProcessId) < 0 ){
 			LOG_WARN("Problems cleaning up state of IPCP with id: %d\n",

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1188,7 +1188,6 @@ IPCManager_::unregister_app_from_ipcp(Promise* promise,
 	return IPCM_PENDING;
 }
 
-
 //
 // Promises
 //


### PR DESCRIPTION
Sorry, forgot to create a separate branch to address the issue. The fix is tested.