### PR TITLE
tests/conf: add configuration files for vm-to-vm tests

### DIFF
--- a/tests/conf/vm-to-vm/ipcmanager.conf-pm
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-pm
@@ -1,0 +1,154 @@
+{
+    "localConfiguration": {
+        "installationPath": "/usr/local/irati/bin",
+        "libraryPath": "/usr/local/irati/lib",
+        "logPath": "/usr/local/irati/var/log",
+        "consolePort": 32766
+    },
+    "applicationToDIFMappings": [
+        {
+            "encodedAppName": "rina.apps.echotime.server-1--",
+            "difName": "n.DIF"
+        },
+        {
+            "encodedAppName": "rina.apps.echotime.client-1--",
+            "difName": "n.DIF"
+        }
+    ],
+    "ipcProcessesToCreate": [
+        {
+            "apName": "h.hv.1.IPCP",
+            "apInstance": "1",
+            "difName": "hv.1.DIF"
+        },
+        {
+            "apName": "h.n.1.IPCP",
+            "apInstance": "1",
+            "difName": "n.DIF",
+            "difsToRegisterAt": [
+                "hv.1.DIF",
+                "hv.2.DIF"
+            ]
+        }
+    ],
+    "difConfigurations": [
+        {
+            "difName": "hv.1.DIF",
+            "difType": "shim-hv",
+            "configParameters": {
+                "vmpi-id": "0"
+            }
+        },
+        {
+            "difName": "hv.2.DIF",
+            "difType": "shim-hv",
+            "configParameters": {
+                "vmpi-id": "1"
+            }
+        },
+        {
+            "difName": "n.DIF",
+            "difType": "normal-ipc",
+            "dataTransferConstants": {
+                "addressLength": 2,
+                "cepIdLength": 2,
+                "lengthLength": 2,
+                "portIdLength": 2,
+                "qosIdLength": 2,
+                "sequenceNumberLength": 4,
+                "maxPduSize": 10000,
+                "maxPduLifetime": 30
+            },
+            "configParameters": {
+                "bar": "foo"
+            },
+            "qosCubes": [
+                {
+                    "name": "unreliablewithflowcontrol",
+                    "id": 1,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": false,
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "reliablewithflowcontrol",
+                    "id": 2,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": true,
+                            "rtxcontrolconfig": {
+                                "datarxmsnmax": 5,
+                                "initialRtxTime": 20
+                            },
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "knownIPCProcessAddresses": [
+                {
+                    "apName": "h.n.1.IPCP",
+                    "apInstance": "1",
+                    "address": 16
+                },
+                {
+                    "apName": "g.n.1.IPCP",
+                    "apInstance": "1",
+                    "address": 17
+                },
+                {
+                    "apName": "g.n.2.IPCP",
+                    "apInstance": "1",
+                    "address": 19
+                }
+            ],
+            "pdufTableGeneratorConfiguration": {
+                "pduFtGeneratorPolicy": {
+                    "name": "LinkState",
+                    "version": "0"
+                },
+                "linkStateRoutingConfiguration": {
+                    "objectMaximumAge": 10000,
+                    "waitUntilReadCDAP": 5001,
+                    "waitUntilError": 5001,
+                    "waitUntilPDUFTComputation": 103,
+                    "waitUntilFSODBPropagation": 101,
+                    "waitUntilAgeIncrement": 997,
+                    "routingAlgorithm": "Dijkstra"
+                }
+            },
+            "enrollmentTaskConfiguration" : {
+                "enrollTimeoutInMs" : 10000,
+                    "watchdogPeriodInMs" : 30000,
+                    "declaredDeadIntervalInMs" : 120000,
+                    "neighborsEnrollerPeriodInMs" : 30000,
+                    "maxEnrollmentRetries" : 3
+            }
+        }
+    ]
+}

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
@@ -1,0 +1,146 @@
+{
+    "localConfiguration": {
+        "installationPath": "/usr/local/irati/bin",
+        "libraryPath": "/usr/local/irati/lib",
+        "logPath": "/usr/local/irati/var/log",
+        "consolePort": 32766
+    },
+    "applicationToDIFMappings": [
+        {
+            "encodedAppName": "rina.apps.echotime.server-1--",
+            "difName": "n.DIF"
+        },
+        {
+            "encodedAppName": "rina.apps.echotime.client-1--",
+            "difName": "n.DIF"
+        }
+    ],
+    "ipcProcessesToCreate": [
+        {
+            "apName": "g.hv.1.IPCP",
+            "apInstance": "1",
+            "difName": "hv.1.DIF"
+        },
+        {
+            "apName": "g.n.1.IPCP",
+            "apInstance": "1",
+            "difName": "n.DIF",
+            "difsToRegisterAt": [
+                "hv.1.DIF"
+            ]
+        }
+    ],
+    "difConfigurations": [
+        {
+            "difName": "hv.1.DIF",
+            "difType": "shim-hv",
+            "configParameters": {
+                "vmpi-id": "0"
+            }
+        },
+        {
+            "difName": "n.DIF",
+            "difType": "normal-ipc",
+            "dataTransferConstants": {
+                "addressLength": 2,
+                "cepIdLength": 2,
+                "lengthLength": 2,
+                "portIdLength": 2,
+                "qosIdLength": 2,
+                "sequenceNumberLength": 4,
+                "maxPduSize": 10000,
+                "maxPduLifetime": 30
+            },
+            "configParameters": {
+                "bar": "foo"
+            },
+            "qosCubes": [
+                {
+                    "name": "unreliablewithflowcontrol",
+                    "id": 1,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": false,
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "reliablewithflowcontrol",
+                    "id": 2,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": true,
+                            "rtxcontrolconfig": {
+                                "datarxmsnmax": 5,
+                                "initialRtxTime": 20
+                            },
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "knownIPCProcessAddresses": [
+                {
+                    "apName": "h.n.1.IPCP",
+                    "apInstance": "1",
+                    "address": 16
+                },
+                {
+                    "apName": "g.n.1.IPCP",
+                    "apInstance": "1",
+                    "address": 17
+                },
+                {
+                    "apName": "g.n.2.IPCP",
+                    "apInstance": "1",
+                    "address": 19
+                }
+            ],
+            "pdufTableGeneratorConfiguration": {
+                "pduFtGeneratorPolicy": {
+                    "name": "LinkState",
+                    "version": "0"
+                },
+                "linkStateRoutingConfiguration": {
+                    "objectMaximumAge": 10000,
+                    "waitUntilReadCDAP": 5001,
+                    "waitUntilError": 5001,
+                    "waitUntilPDUFTComputation": 103,
+                    "waitUntilFSODBPropagation": 101,
+                    "waitUntilAgeIncrement": 997,
+                    "routingAlgorithm": "Dijkstra"
+                }
+            },
+            "enrollmentTaskConfiguration" : {
+                "enrollTimeoutInMs" : 10000,
+                    "watchdogPeriodInMs" : 30000,
+                    "declaredDeadIntervalInMs" : 120000,
+                    "neighborsEnrollerPeriodInMs" : 30000,
+                    "maxEnrollmentRetries" : 3
+            }
+        }
+    ]
+}

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
@@ -1,0 +1,146 @@
+{
+    "localConfiguration": {
+        "installationPath": "/usr/local/irati/bin",
+        "libraryPath": "/usr/local/irati/lib",
+        "logPath": "/usr/local/irati/var/log",
+        "consolePort": 32766
+    },
+    "applicationToDIFMappings": [
+        {
+            "encodedAppName": "rina.apps.echotime.server-1--",
+            "difName": "n.DIF"
+        },
+        {
+            "encodedAppName": "rina.apps.echotime.client-1--",
+            "difName": "n.DIF"
+        }
+    ],
+    "ipcProcessesToCreate": [
+        {
+            "apName": "g.hv.2.IPCP",
+            "apInstance": "1",
+            "difName": "hv.2.DIF"
+        },
+        {
+            "apName": "g.n.2.IPCP",
+            "apInstance": "1",
+            "difName": "n.DIF",
+            "difsToRegisterAt": [
+                "hv.2.DIF"
+            ]
+        }
+    ],
+    "difConfigurations": [
+        {
+            "difName": "hv.2.DIF",
+            "difType": "shim-hv",
+            "configParameters": {
+                "vmpi-id": "0"
+            }
+        },
+        {
+            "difName": "n.DIF",
+            "difType": "normal-ipc",
+            "dataTransferConstants": {
+                "addressLength": 2,
+                "cepIdLength": 2,
+                "lengthLength": 2,
+                "portIdLength": 2,
+                "qosIdLength": 2,
+                "sequenceNumberLength": 4,
+                "maxPduSize": 10000,
+                "maxPduLifetime": 30
+            },
+            "configParameters": {
+                "bar": "foo"
+            },
+            "qosCubes": [
+                {
+                    "name": "unreliablewithflowcontrol",
+                    "id": 1,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": false,
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "reliablewithflowcontrol",
+                    "id": 2,
+                    "partialDelivery": false,
+                    "orderedDelivery": false,
+                    "efcpPolicies": {
+                        "dtcpPresent": true,
+                        "dtcpConfiguration": {
+                            "rtxcontrol": true,
+                            "rtxcontrolconfig": {
+                                "datarxmsnmax": 5,
+                                "initialRtxTime": 20
+                            },
+                            "flowcontrol": true,
+                            "flowcontrolconfig": {
+                                "ratebased": false,
+                                "windowbased": true,
+                                "windowbasedconfig": {
+                                    "maxclosedwindowqueuelength": 200,
+                                    "initialcredit": 50
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "knownIPCProcessAddresses": [
+                {
+                    "apName": "h.n.1.IPCP",
+                    "apInstance": "1",
+                    "address": 16
+                },
+                {
+                    "apName": "g.n.1.IPCP",
+                    "apInstance": "1",
+                    "address": 17
+                },
+                {
+                    "apName": "g.n.2.IPCP",
+                    "apInstance": "1",
+                    "address": 19
+                }
+            ],
+            "pdufTableGeneratorConfiguration": {
+                "pduFtGeneratorPolicy": {
+                    "name": "LinkState",
+                    "version": "0"
+                },
+                "linkStateRoutingConfiguration": {
+                    "objectMaximumAge": 10000,
+                    "waitUntilReadCDAP": 5001,
+                    "waitUntilError": 5001,
+                    "waitUntilPDUFTComputation": 103,
+                    "waitUntilFSODBPropagation": 101,
+                    "waitUntilAgeIncrement": 997,
+                    "routingAlgorithm": "Dijkstra"
+                }
+            },
+            "enrollmentTaskConfiguration" : {
+                "enrollTimeoutInMs" : 10000,
+                    "watchdogPeriodInMs" : 30000,
+                    "declaredDeadIntervalInMs" : 120000,
+                    "neighborsEnrollerPeriodInMs" : 30000,
+                    "maxEnrollmentRetries" : 3
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Three configuration files for a normal-over-shim-hv test involving a physical machine and two virtual machines.