### PR TITLE
Pristine 1.2 #530: fix incorrect transaction handling in IPCP initialized response handler

### DIFF
--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -100,7 +100,8 @@ void IPCManager_::os_process_finalized_handler(
 		}
 	}
 
-	if (event->ipcProcessId != 0) {
+	if (IPCManager->ipcp_exists(event->ipcProcessId)) {
+		//An IPCP OS process has crashed, we need to clean up state
 		//TODO if the IPCP was supporting flows or had
 		//registered applications, notify them
 

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1305,6 +1305,7 @@ int IPCManager_::add_syscall_transaction_state(SyscallTransState* t){
 		assert(0);
 		return -1;
 	}
+
 	return 0;
 }
 

--- a/rinad/src/ipcm/ipcp-handlers.cc
+++ b/rinad/src/ipcm/ipcp-handlers.cc
@@ -92,7 +92,7 @@ void IPCManager_::ipc_process_daemon_initialized_event_handler(
 
 	//Set return value, mark as completed and signal
 	trans->completed(IPCM_SUCCESS);
-	remove_transaction_state(trans->tid);
+	remove_syscall_transaction_state(trans->tid);
 
 	return;
 }


### PR DESCRIPTION
remove_transaction_state was called instead of remove_syscall_transaction_state
Also fixed condition in os_process_finalized event handler, in case an IPCP crashed.