### PR TITLE
Pristine-1.2 #531: Fixed bug in DU protection, sleeping functions called in invalid context

### DIFF
--- a/linux/net/rina/buffer.c
+++ b/linux/net/rina/buffer.c
@@ -247,7 +247,8 @@ static void buffer_assign(struct buffer * buffer,
 }
 
 /* FIXME: To be heavily hammered, it is temporary (lastin' forever, sigh) */
-int buffer_head_grow(struct buffer * buffer,
+int buffer_head_grow(gfp_t           flags,
+                     struct buffer * buffer,
                      size_t          bytes)
 {
         char * new_data;
@@ -257,7 +258,7 @@ int buffer_head_grow(struct buffer * buffer,
         if (!bytes)
                 return 0; /* This is a NO-OP */
 
-        new_data = rkmalloc(buffer->size + bytes, GFP_KERNEL);
+        new_data = rkmalloc(buffer->size + bytes, flags);
         if (!new_data)
                 return -1;
 
@@ -270,7 +271,8 @@ int buffer_head_grow(struct buffer * buffer,
 EXPORT_SYMBOL(buffer_head_grow);
 
 /* FIXME: To be heavily hammered, it is temporary (lastin' forever, sigh) */
-int buffer_head_shrink(struct buffer * buffer,
+int buffer_head_shrink(gfp_t           flags,
+                       struct buffer * buffer,
                        size_t          bytes)
 {
         char * new_data;
@@ -280,7 +282,7 @@ int buffer_head_shrink(struct buffer * buffer,
         if (!bytes)
                 return 0; /* This is a NO-OP */
 
-        new_data = rkmalloc(buffer->size - bytes, GFP_KERNEL);
+        new_data = rkmalloc(buffer->size - bytes, flags);
         if (!new_data)
                 return -1;
 

--- a/linux/net/rina/buffer.h
+++ b/linux/net/rina/buffer.h
@@ -47,8 +47,10 @@ struct buffer * buffer_dup(const struct buffer * b);
 struct buffer * buffer_dup_ni(const struct buffer * b);
 bool            buffer_is_ok(const struct buffer * b);
 
-int             buffer_head_grow(struct buffer * b, size_t bytes);
-int             buffer_head_shrink(struct buffer * b, size_t bytes);
+int             buffer_head_grow(gfp_t flags, struct buffer * b, size_t bytes);
+int             buffer_head_shrink(gfp_t           flags,
+                                   struct buffer * b,
+                                   size_t          bytes);
 int             buffer_tail_grow(struct buffer * b, size_t bytes);
 int             buffer_tail_shrink(struct buffer * b, size_t bytes);
 

--- a/linux/net/rina/pdu-ser.c
+++ b/linux/net/rina/pdu-ser.c
@@ -96,10 +96,10 @@ int pdu_ser_buffer_disown(struct pdu_ser * pdu)
 }
 EXPORT_SYMBOL(pdu_ser_buffer_disown);
 
-int pdu_ser_head_grow(struct pdu_ser * pdu, size_t bytes)
-{ return buffer_head_grow(pdu->buf, bytes); }
-EXPORT_SYMBOL(pdu_ser_head_grow);
+int pdu_ser_head_grow_gfp(gfp_t flags, struct pdu_ser * pdu, size_t bytes)
+{ return buffer_head_grow(flags, pdu->buf, bytes); }
+EXPORT_SYMBOL(pdu_ser_head_grow_gfp);
 
-int pdu_ser_head_shrink(struct pdu_ser * pdu, size_t bytes)
-{ return buffer_head_shrink(pdu->buf, bytes); }
-EXPORT_SYMBOL(pdu_ser_head_shrink);
+int pdu_ser_head_shrink_gfp(gfp_t flags, struct pdu_ser * pdu, size_t bytes)
+{ return buffer_head_shrink(flags, pdu->buf, bytes); }
+EXPORT_SYMBOL(pdu_ser_head_shrink_gfp);

--- a/linux/net/rina/pdu-ser.h
+++ b/linux/net/rina/pdu-ser.h
@@ -38,7 +38,7 @@ bool             pdu_ser_is_ok(const struct pdu_ser * s);
 struct buffer *  pdu_ser_buffer(struct pdu_ser * pdu);
 int              pdu_ser_buffer_disown(struct pdu_ser * pdu);
 
-int              pdu_ser_head_grow(struct pdu_ser * pdu, size_t bytes);
-int              pdu_ser_head_shrink(struct pdu_ser * pdu, size_t bytes);
+int              pdu_ser_head_grow_gfp(gfp_t flags, struct pdu_ser * pdu, size_t bytes);
+int              pdu_ser_head_shrink_gfp(gfp_t flags, struct pdu_ser * pdu, size_t bytes);
 
 #endif

--- a/linux/net/rina/serdes.c
+++ b/linux/net/rina/serdes.c
@@ -718,7 +718,7 @@ static struct pdu_ser * pdu_serialize_gfp(gfp_t                       flags,
         }
 
 #ifdef CONFIG_RINA_IPCPS_TTL
-        if (pdu_ser_head_grow(tmp, sizeof(u8))) {
+        if (pdu_ser_head_grow_gfp(flags, tmp, sizeof(u8))) {
                 LOG_ERR("Failed to grow ser PDU");
                 pdu_ser_destroy(tmp);
                 return NULL;
@@ -739,7 +739,7 @@ static struct pdu_ser * pdu_serialize_gfp(gfp_t                       flags,
 
 #ifdef CONFIG_RINA_IPCPS_CRC
         /* Assuming CRC32 */
-        if (pdu_ser_head_grow(tmp, sizeof(u32))) {
+        if (pdu_ser_head_grow_gfp(flags, tmp, sizeof(u32))) {
                 LOG_ERR("Failed to grow ser PDU");
                 pdu_ser_destroy(tmp);
                 return NULL;
@@ -797,7 +797,7 @@ static struct pdu * pdu_deserialize_gfp(gfp_t                 flags,
         }
 
         /* Assuming CRC32 */
-        if (pdu_ser_head_shrink(pdu, sizeof(u32))) {
+        if (pdu_ser_head_shrink_gfp(flags, pdu, sizeof(u32))) {
                 LOG_ERR("Failed to shrink ser PDU");
                 return NULL;
         }
@@ -843,7 +843,7 @@ static struct pdu * pdu_deserialize_gfp(gfp_t                 flags,
                 return NULL;
         }
 
-        if (pdu_ser_head_shrink(pdu, sizeof(u8))) {
+        if (pdu_ser_head_shrink_gfp(flags, pdu, sizeof(u8))) {
                 LOG_ERR("Failed to shrink ser PDU");
                 pci_destroy(new_pci);
                 pdu_destroy(new_pdu);


### PR DESCRIPTION
Added the necessary GFP flag handling so head grow/shrink functions can be called in the mode required by the context, i.e. non interruptible in interrupt context.