### PR TITLE
vmpi-provider: improve registration/unregistration logging

### DIFF
--- a/linux/net/rina/vmpi/vmpi-provider.c
+++ b/linux/net/rina/vmpi/vmpi-provider.c
@@ -109,7 +109,8 @@ int vmpi_provider_register(unsigned int provider, unsigned int id,
 
         wake_up_interruptible(&wqh);
 
-        printk("%s: Provider %u:%u registered\n", __func__, provider, id);
+        printk("%s: Provider %s:%u registered\n", __func__,
+               (provider == VMPI_PROVIDER_HOST ? "HOST" : "GUEST"), id);
 
         return 0;
 }
@@ -133,7 +134,8 @@ int vmpi_provider_unregister(unsigned int provider, unsigned int id)
         list_del(&elem->node);
         kfree(elem);
 
-        printk("%s: Provider %u:%u unregistered\n", __func__, provider, id);
+        printk("%s: Provider %s:%u unregistered\n", __func__,
+               (provider == VMPI_PROVIDER_HOST ? "HOST" : "GUEST"), id);
 
         return 0;
 }


### PR DESCRIPTION
Less obscure printk() to log registration/unregistration of a VMPI device.