### PR TITLE
tests/conf/vm-to-vm: add missing shim IPCP creation

### DIFF
--- a/tests/conf/vm-to-vm/ipcmanager.conf-pm
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-pm
@@ -22,6 +22,11 @@
             "difName": "hv.1.DIF"
         },
         {
+            "apName": "h.hv.2.IPCP",
+            "apInstance": "1",
+            "difName": "hv.2.DIF"
+        },
+        {
             "apName": "h.n.1.IPCP",
             "apInstance": "1",
             "difName": "n.DIF",


### PR DESCRIPTION
Add missing stanza for shim IPCP for HV creation on physical machine.