### PR TITLE
Pristine 1.2 #539 Initial refactor of IPCP 

### DIFF
--- a/librina/include/librina/Makefile.am
+++ b/librina/include/librina/Makefile.am
@@ -8,6 +8,7 @@ nobase_pkginclude_HEADERS =			\
 	librina.h				\
 	logs.h					\
 	common.h				\
+	ipc-api.h                               \
 	application.h				\
 	configuration.h				\
 	ipc-daemons.h				\

--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -27,6 +27,7 @@
 
 #include <map>
 #include <string>
+#include <list>
 
 #include "librina/patterns.h"
 #include "librina/concurrency.h"
@@ -86,6 +87,7 @@ public:
 		void add_instance(ApplicationEntityInstance * instance);
 		ApplicationEntityInstance * remove_instance(const std::string& instance_id);
 		ApplicationEntityInstance * get_instance(const std::string& instance_id);
+		std::list<ApplicationEntityInstance*> get_all_instances();
 
         virtual int select_policy_set(const std::string& path,
                                       const std::string& name) {
@@ -169,6 +171,7 @@ public:
 		void add_entity(ApplicationEntity * entity);
 		ApplicationEntity * remove_entity(const std::string& name);
 		ApplicationEntity * get_entity(const std::string& name);
+		std::list<ApplicationEntity*> get_all_entities();
 
 		//Policy management
         virtual std::vector<PsFactory>::iterator

--- a/librina/include/librina/concurrency.h
+++ b/librina/include/librina/concurrency.h
@@ -439,7 +439,9 @@ public:
                 rina::ScopedLock g(*lock_);
                 for(iterator = map.begin();
                                 iterator != map.end(); ++iterator){
-                        delete iterator->second;
+                		if (iterator->second) {
+                				delete iterator->second;
+                		}
                 }
         }
 

--- a/librina/include/librina/ipc-api.h
+++ b/librina/include/librina/ipc-api.h
@@ -1,0 +1,607 @@
+/*
+ * RINA IPC API
+ *
+ *    Eduard Grasa          <eduard.grasa@i2cat.net>
+ *    Francesco Salvestrini <f.salvestrini@nextworks.it>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+
+#ifndef LIBRINA_IPC_API_H
+#define LIBRINA_IPC_API_H
+
+#ifdef __cplusplus
+
+#include <map>
+#include <list>
+#include <vector>
+#include <string>
+
+#include "librina/common.h"
+#include "librina/patterns.h"
+#include "librina/concurrency.h"
+
+/**
+ * The librina-ipc-api library provides the native IPC API, which
+ * allows applications to i) express their availability to be accessed
+ * through one or more DIFS (application registration); ii) allocate
+ * and deallocate flows to destination applications (flow allocation
+ * and deallocation); iii) read and write data from/to allocated flows
+ * (in the form of Service Data Units or SDUs) and iv) query the DIFs
+ * available in the system and their properties.
+ *
+ * For the "slow-path" operations, librina-ipc-api interacts
+ * with the RINA daemons in by exchanging messages over Netlink
+ * sockets. In the case of the "fast-path" operations - i.e. those
+ * that need to be invoked for every single SDU: read and write -
+ * librina-ipc-api communicates directly with the services
+ * provided by the kernel through the use of system calls.
+ *
+ * The librina-ipc-api is event-based; that is: the API
+ * provides a different method for each action that can be invoked
+ * (allocate_flow, register_application and so on), but only two
+ * methods - one blocking, the other non-blocking - to get the
+ * results of the operations and SDUs available to be read
+ * (event_wait and event_poll).
+ */
+namespace rina {
+
+enum FlowState {
+	FLOW_ALLOCATED, FLOW_DEALLOCATION_REQUESTED, FLOW_DEALLOCATED
+};
+
+/**
+ * Thrown when some operation is invoked in a flow that is not allocated
+ */
+class FlowNotAllocatedException: public IPCException {
+public:
+	FlowNotAllocatedException():
+		IPCException(
+				"Invalid operation invoked when the flow is not allocated "){
+	}
+	FlowNotAllocatedException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems reading SDUs
+ */
+class ReadSDUException: public IPCException {
+public:
+	ReadSDUException():
+		IPCException("Problems reading SDU from flow"){
+	}
+	ReadSDUException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems writing SDUs
+ */
+class WriteSDUException: public IPCException {
+public:
+	WriteSDUException():
+		IPCException("Problems writing SDU to flow"){
+	}
+	WriteSDUException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems registering an application to a DIF
+ */
+class ApplicationRegistrationException: public IPCException {
+public:
+	ApplicationRegistrationException():
+		IPCException("Problems registering application to DIF"){
+	}
+	ApplicationRegistrationException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems unregistering an application from a DIF
+ */
+class ApplicationUnregistrationException: public IPCException {
+public:
+	ApplicationUnregistrationException():
+		IPCException("Problems unregistering application from DIF"){
+	}
+	ApplicationUnregistrationException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems allocating a flow
+ */
+class FlowAllocationException: public IPCException {
+public:
+	FlowAllocationException():
+		IPCException("Problems allocating flow"){
+	}
+	FlowAllocationException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems deallocating a flow
+ */
+class FlowDeallocationException: public IPCException {
+public:
+	FlowDeallocationException():
+		IPCException("Problems deallocating flow"){
+	}
+	FlowDeallocationException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Thrown when there are problems querying DIF properties
+ */
+class GetDIFPropertiesException: public IPCException {
+public:
+	GetDIFPropertiesException():
+		IPCException("Problems getting DIF properties"){
+	}
+	GetDIFPropertiesException(const std::string& description):
+		IPCException(description){
+	}
+};
+
+/**
+ * Represents a flow between two application processes, and encapsulates
+ * the services that the flow provides.
+ */
+class Flow {
+	/** The state of the flow */
+	FlowState flowState;
+
+	/** A summary of the flow information */
+	FlowInformation flowInformation;
+
+	Flow(const ApplicationProcessNamingInformation& localApplicationName,
+	     const ApplicationProcessNamingInformation& remoteApplicationName,
+	     const FlowSpecification& flowSpecification, FlowState flowState);
+
+	Flow(const ApplicationProcessNamingInformation& localApplicationName,
+	     const ApplicationProcessNamingInformation& remoteApplicationName,
+	     const FlowSpecification& flowSpecification, FlowState flowState,
+	     const ApplicationProcessNamingInformation& DIFName, int portId);
+
+	void setPortId(int portId);
+	void setDIFName(const ApplicationProcessNamingInformation& DIFName);
+	void setState(FlowState flowState);
+
+public:
+	Flow();
+	const FlowState& getState() const;
+	int getPortId() const;
+	const ApplicationProcessNamingInformation& getDIFName() const;
+	const ApplicationProcessNamingInformation& getLocalApplicationName() const;
+	const ApplicationProcessNamingInformation& getRemoteApplcationName() const;
+	const FlowSpecification& getFlowSpecification() const;
+	bool isAllocated() const;
+	const FlowInformation& getFlowInformation() const;
+
+	/**
+	 * Reads an SDU from the flow. This function will block until there is an
+	 * SDU available.
+	 *
+	 * @param sdu A buffer to store the SDU data
+	 * @param maxBytes The maximum number of bytes to read
+	 * @return int The number of bytes read
+	 * @throws IPCException if the flow is not in the ALLOCATED state
+	 */
+	int readSDU(void * sdu, int maxBytes) throw(Exception);
+
+	/**
+	 * Writes an SDU to the flow
+	 *
+	 * @param sdu A buffer that contains the SDU data
+	 * @param size The size of the SDU data, in bytes
+	 * @throws IPCException if the flow is not in the ALLOCATED state or
+	 * there are problems writing to the flow
+	 */
+	void writeSDU(void * sdu, int size) throw(Exception);
+
+	friend class IPCManager;
+};
+
+/**
+ * Contains the information about a registered application: its
+ * name and the DIFs where it is registered
+ */
+class ApplicationRegistration {
+public:
+	/** The registered application name */
+	ApplicationProcessNamingInformation applicationName;
+
+	/** The list of one or more DIFs in which the application is registered */
+	std::list<ApplicationProcessNamingInformation> DIFNames;
+
+	ApplicationRegistration(
+			const ApplicationProcessNamingInformation& applicationName);
+	void addDIFName(const ApplicationProcessNamingInformation& DIFName);
+	void removeDIFName(const ApplicationProcessNamingInformation& DIFName);
+};
+
+/**
+ * Point of entry to the IPC functionality available in the system. This class
+ * is a singleton.
+ */
+class IPCManager : public Lockable{
+	/** The flows that are currently allocated */
+	std::map<int, Flow*> allocatedFlows;
+
+	/** The flows that are pending to be allocated or deallocated*/
+	std::map<unsigned int, Flow*> pendingFlows;
+
+	/** The applications that are pending to be registered or unregistered */
+	std::map<unsigned int, ApplicationRegistrationInformation>
+	        registrationInformation;
+
+	/** The applications that are currently registered in one or more DIFs */
+	std::map<ApplicationProcessNamingInformation,
+	        ApplicationRegistration*> applicationRegistrations;
+
+protected:
+	/** Return the pending flow at sequenceNumber */
+	Flow * getPendingFlow(unsigned int seqNumber);
+
+	/** Return the information of a registration request */
+	ApplicationRegistrationInformation getRegistrationInfo(
+	                unsigned int seqNumber);
+
+	ApplicationRegistration * getApplicationRegistration(
+	                const ApplicationProcessNamingInformation& appName);
+
+	void putApplicationRegistration(
+	                const ApplicationProcessNamingInformation& key,
+	                ApplicationRegistration * value);
+
+	void removeApplicationRegistration(
+	                const ApplicationProcessNamingInformation& key);
+
+	unsigned int internalRequestFlowAllocation(
+	        const ApplicationProcessNamingInformation& localAppName,
+	        const ApplicationProcessNamingInformation& remoteAppName,
+	        const FlowSpecification& flow,
+	        unsigned short sourceIPCProcessId);
+
+	unsigned int internalRequestFlowAllocationInDIF(
+	        const ApplicationProcessNamingInformation& localAppName,
+	        const ApplicationProcessNamingInformation& remoteAppName,
+	        const ApplicationProcessNamingInformation& difName,
+	        unsigned short sourceIPCProcessId,
+	        const FlowSpecification& flow);
+
+	Flow * internalAllocateFlowResponse(
+	        const FlowRequestEvent& flowRequestEvent,
+	        int result, bool notifySource, unsigned short ipcProcessId);
+
+public:
+	IPCManager();
+	~IPCManager() throw();
+	static const std::string application_registered_error;
+	static const std::string application_not_registered_error;
+	static const std::string unknown_flow_error;
+	static const std::string error_registering_application;
+	static const std::string error_unregistering_application;
+	static const std::string error_requesting_flow_allocation;
+	static const std::string error_requesting_flow_deallocation;
+	static const std::string error_getting_dif_properties;
+	static const std::string wrong_flow_state;
+
+	/** Return the allocated flow at portId */
+	Flow * getAllocatedFlow(int portId);
+
+	/** Return a flow allocated to the remote application name */
+	Flow * getFlowToRemoteApp(
+			ApplicationProcessNamingInformation remoteAppName);
+
+	/**
+	 * Retrieves the names and characteristics of a single DIF or of all the
+	 * DIFs available to the application.
+	 *
+	 * @param applicationName The name of the application that wants to query
+	 * the properties of one or more DIFs
+	 * @param DIFName If provided, the function will return the information of
+	 * the requested DIF, otherwise it will return the properties of all the
+	 * DIFs available to the application.
+	 * @return A handler to be able to identify the proper response event
+	 * @throws GetDIFPropertiesException
+	 */
+	unsigned int getDIFProperties(
+			const ApplicationProcessNamingInformation& applicationName,
+			const ApplicationProcessNamingInformation& DIFName);
+
+	/**
+	 * Requests an application to be registered in a DIF
+	 *
+	 * @param appRegistrationInfo Information about the registration request
+	 * (what application, how many DIFs, what specific DIFs)
+	 * @throws ApplicationRegistrationException
+	 * @return A handler to be able to identify the proper response event
+	 */
+	unsigned int requestApplicationRegistration(
+			const ApplicationRegistrationInformation& appRegistrationInfo);
+
+	/**
+	 * The application registration has been successful,
+	 * update data structures
+	 * @param seqNumber the id of the registration request
+	 * @param DIFName the DIF where the application has been registered
+	 * @throws ApplicationRegistrationException if there are issues
+	 * registering the application
+	 * @return the information on the application registration
+	 */
+	ApplicationRegistration * commitPendingRegistration(
+	                unsigned int seqNumber,
+	                const ApplicationProcessNamingInformation& DIFName);
+
+	/**
+	 * The application registration has been unsuccessful,
+	 * update data structures
+	 * @param seqNumber the if of the registration request
+	 * @throws ApplicationRegistrationException if the pending registration
+	 * is not found
+	 */
+	void withdrawPendingRegistration(unsigned int seqNumber);
+
+	/**
+	 * Requests an application to be unregistered from a DIF
+	 *
+	 * @param applicationName The name of the application to be unregistered
+	 * @param DIFName Then name of the DIF where the application has to be
+	 * unregistered from
+	 * @return A handler to be able to identify the proper response event
+	 * @throws ApplicationUnregistrationException
+	 */
+	unsigned int requestApplicationUnregistration(
+			const ApplicationProcessNamingInformation& applicationName,
+			const ApplicationProcessNamingInformation& DIFName);
+
+	/**
+	 * Inform about the result of a pending application unregistration request
+	 * @param seqNumber the id of the request
+	 * @param success true if request was successful, false otherwise
+	 */
+	 void appUnregistrationResult(unsigned int seqNumber, bool success);
+
+	/**
+	 * Requests the allocation of a Flow
+	 *
+	 * @param localAppName The naming information of the local application
+	 * @param remoteAppName The naming information of the remote application
+	 * @param flowSpecifiction The characteristics required for the flow
+	 * @return A handler to be able to identify the proper response event
+	 * @throws FlowAllocationException if there are problems during the flow allocation
+	 */
+	virtual unsigned int requestFlowAllocation(
+			const ApplicationProcessNamingInformation& localAppName,
+			const ApplicationProcessNamingInformation& remoteAppName,
+			const FlowSpecification& flow);
+
+	/**
+	 * Requests the allocation of a flow using a speficif dIF
+         * @param localAppName The naming information of the local application
+         * @param remoteAppName The naming information of the remote application
+         * @param flowSpecifiction The characteristics required for the flow
+         * @param difName The DIF through which we want the flow allocated
+         * @return A handler to be able to identify the proper response event
+         * @throws FlowAllocationException if there are problems during the flow allocation
+	 */
+	virtual unsigned int requestFlowAllocationInDIF(
+	                const ApplicationProcessNamingInformation& localAppName,
+	                const ApplicationProcessNamingInformation& remoteAppName,
+	                const ApplicationProcessNamingInformation& difName,
+	                const FlowSpecification& flow);
+
+	/**
+	 * Tell the IPC Manager that a pending flow has been allocated, and
+	 * get the flow structure
+	 * @param sequenceNumber the handler of the pending flow
+	 * @param portId the portId that has been allocated to the pending flow
+	 * @param DIFName the name of the DIF where the flow has been allocated
+	 * @return the flow, ready to be used
+	 * @throws FlowAllocationException if the pending flow is not found
+	 */
+	Flow * commitPendingFlow(unsigned int sequenceNumber, int portId,
+	                const ApplicationProcessNamingInformation& DIFName);
+
+	/**
+	 * Tell the IPC Manager that a pending flow allocation has been denied
+	 * @param sequenceNumber the handler of the pending flow
+	 * @returns the information of the flow that has been withdrawn
+	 * @throws FlowAllocationException if the pending flow is not found
+	 */
+	FlowInformation withdrawPendingFlow(unsigned int sequenceNumber);
+
+	/**
+	 * Confirms or denies the request for a flow to this application.
+	 *
+	 * @param flowRequestEvent information of the flow request
+	 * @param result 0 means the flow is accepted, a different number
+	 * indicates the deny code
+	 * @param notifySource if true the source IPC Process will get
+	 * the allocate flow response message back, otherwise it will be ignored
+	 * @return Flow If the flow is accepted, returns the flow object
+	 * @throws FlowAllocationException If there are problems
+	 * confirming/denying the flow
+	 */
+	virtual Flow * allocateFlowResponse(const FlowRequestEvent& flowRequestEvent,
+			int result, bool notifySource);
+
+	/**
+	 * Requests the deallocation of a flow
+	 *
+	 * @param portId, the portId of the flow to be deallocated
+	 * @throws FlowDeallocationException if the flow is not in
+	 * the ALLOCATED state or there are problems deallocating the flow
+	 */
+	unsigned int requestFlowDeallocation(int portId);
+
+	/**
+	 * Inform about the success/failure of a flow deallocation request
+	 * @param success true if request has been successful, false otherwise
+	 * @param portId the portId of the flow to be deallocated
+	 * @throws flowDeallocationException if there are problems
+	 */
+	void flowDeallocationResult(int portId, bool success);
+
+	/**
+	 * Inform the IPC Manager that a flow has been deallocated remotely,
+	 * so that the local data structures can be updated
+	 * @param portId the portId of the flow deallocated
+	 * @throws FlowDeallocationException if no flow with the provided
+	 * portId was allocated
+	 */
+	void flowDeallocated(int portId);
+
+	/**
+	 * Returns the flows that are currently allocated
+	 *
+	 * @return the flows allocated
+	 */
+	std::vector<Flow *> getAllocatedFlows();
+
+	/**
+	 * Returns the applications that are currently registered in one or more
+	 * DIFs.
+	 *
+	 * @return the registered applications
+	 */
+	std::vector<ApplicationRegistration *> getRegisteredApplications();
+};
+
+/**
+ * Make IPCManager singleton
+ */
+extern Singleton<IPCManager> ipcManager;
+
+/**
+ * Event informing that an application has been unregistered from a DIF,
+ * without the application having requested it
+ */
+class ApplicationUnregisteredEvent: public IPCEvent {
+public:
+	/** The application that has been unregistered */
+	ApplicationProcessNamingInformation applicationName;
+
+	/** The DIF from which the application has been unregistered */
+	ApplicationProcessNamingInformation DIFName;
+
+	ApplicationUnregisteredEvent(
+			const ApplicationProcessNamingInformation& appName,
+			const ApplicationProcessNamingInformation& DIFName,
+			unsigned int sequenceNumber);
+};
+
+/**
+ * Event informing that an application registration has been canceled
+ * without the application having requested it
+ */
+class AppRegistrationCanceledEvent: public IPCEvent {
+public:
+	/** The application whose registration has been canceled */
+	ApplicationProcessNamingInformation applicationName;
+
+	/** The name of the DIF */
+	ApplicationProcessNamingInformation difName;
+
+	/** An error code indicating why the flow was deallocated */
+	int code;
+
+	/** Optional explanation giving more details about why the application registration has been canceled */
+	std::string reason;
+
+	AppRegistrationCanceledEvent(int code, const std::string& reason,
+			const ApplicationProcessNamingInformation& difName,
+			unsigned int sequenceNumber);
+};
+
+/**
+ * Event informing about the result of a flow allocation request
+ */
+class AllocateFlowRequestResultEvent: public IPCEvent {
+public:
+        /** The application that requested the flow allocation */
+        ApplicationProcessNamingInformation sourceAppName;
+
+        /**
+         * The port-id assigned to the flow, or error code if the value is
+         * negative
+         */
+        int portId;
+
+        /**
+         * The DIF where the flow has been allocated
+         */
+        ApplicationProcessNamingInformation difName;
+
+        AllocateFlowRequestResultEvent(
+                        const ApplicationProcessNamingInformation& appName,
+                        const ApplicationProcessNamingInformation& difName,
+                        int portId, unsigned int sequenceNumber);
+};
+
+/**
+ * Event informing about the result of a flow deallocation request
+ */
+class DeallocateFlowResponseEvent: public BaseResponseEvent {
+public:
+        /** The application that requested the flow deallocation */
+        ApplicationProcessNamingInformation appName;
+
+        /** The portId of the flow */
+        int portId;
+
+        DeallocateFlowResponseEvent(
+                        const ApplicationProcessNamingInformation& appName,
+                        int portId, int result, unsigned int sequenceNumber);
+};
+
+/**
+ * Event informing about the result of a get DIF properties operation
+ */
+class GetDIFPropertiesResponseEvent: public BaseResponseEvent {
+public:
+        /**
+         * The name of the application that is querying the DIF properties
+         */
+        ApplicationProcessNamingInformation applicationName;
+
+        /** The properties of zero or more DIFs */
+        std::list<DIFProperties> difProperties;
+
+        GetDIFPropertiesResponseEvent(
+                        const ApplicationProcessNamingInformation& appName,
+                        const std::list<DIFProperties>& difProperties,
+                        int result, unsigned int sequenceNumber);
+};
+
+}
+
+#endif
+
+#endif

--- a/librina/include/librina/rib.h
+++ b/librina/include/librina/rib.h
@@ -756,7 +756,7 @@ public:
 // /A RIB Daemon partial implementation, that internally uses the RIB
 /// implementation provided by the RIB class. Complete implementations have
 /// to extend this class to adapt it to the environment they are operating
-class RIBDaemon : public IRIBDaemon {
+class RIBDaemon : public IRIBDaemon{
 public:
         RIBDaemon();
         void initialize(const std::string& separator, IEncoder * encoder,

--- a/librina/src/Makefile.am
+++ b/librina/src/Makefile.am
@@ -22,6 +22,7 @@ allsources =							\
         exceptions.cc						\
         librina.cc						\
         common.cc						\
+        ipc-api.cc                                              \
         application.cc						\
         configuration.cc					\
         ipc-daemons.cc						\

--- a/librina/src/application.cc
+++ b/librina/src/application.cc
@@ -74,6 +74,11 @@ ApplicationEntityInstance * ApplicationEntity::get_instance(const std::string& i
 		return instances.find(instance_id);
 }
 
+std::list<ApplicationEntityInstance*> ApplicationEntity::get_all_instances()
+{
+		return instances.getEntries();
+}
+
 int ApplicationEntity::select_policy_set_common(const std::string& component,
                                            	   const std::string& path,
                                            	   const std::string& ps_name)
@@ -182,6 +187,11 @@ ApplicationEntity * ApplicationProcess::remove_entity(const std::string& name)
 ApplicationEntity * ApplicationProcess::get_entity(const std::string& name)
 {
 		return entities.find(name);
+}
+
+std::list<ApplicationEntity*> ApplicationProcess::get_all_entities()
+{
+		return entities.getEntries();
 }
 
 }

--- a/librina/src/application.cc
+++ b/librina/src/application.cc
@@ -810,4 +810,86 @@ GetDIFPropertiesResponseEvent::GetDIFPropertiesResponseEvent(
         this->difProperties = difProperties;
 }
 
+// DAF Related classes, with support for policies
+
+// Class ApplicationEntityInstance
+ApplicationEntityInstance::ApplicationEntityInstance(const std::string& instance_id)
+{
+	instance_id_ = instance_id;
+}
+
+const std::string& ApplicationEntityInstance::get_instance_id() const
+{
+	return instance_id_;
+}
+
+// Class ApplicationEntity
+ApplicationEntity::ApplicationEntity(const std::string& name)
+{
+		name_ = name;
+}
+
+ApplicationEntity::~ApplicationEntity()
+{
+		instances.deleteValues();
+}
+
+const std::string& ApplicationEntity::get_name() const
+{
+		return name_;
+}
+
+void ApplicationEntity::add_instance(const std::string& instance_id,
+									 ApplicationEntityInstance * instance)
+{
+		instances.put(instance_id, instance);
+}
+
+ApplicationEntityInstance * ApplicationEntity::remove_instance(const std::string& instance_id)
+{
+		return instances.erase(instance_id);
+}
+
+ApplicationEntityInstance * ApplicationEntity::get_instance(const std::string& instance_id)
+{
+		return instances.find(instance_id);
+}
+
+//Class Application Process
+ApplicationProcess::ApplicationProcess(const std::string& name, const std::string& instance)
+{
+		name_ = name;
+		instance_ = instance;
+}
+
+ApplicationProcess::~ApplicationProcess()
+{
+	entities.deleteValues();
+}
+
+const std::string& ApplicationProcess::get_name() const
+{
+		return name_;
+}
+
+const std::string& ApplicationProcess::get_instance() const
+{
+		return instance_;
+}
+
+void ApplicationProcess::add_entity(const std::string& name, ApplicationEntity * entity)
+{
+		entities.put(name, entity);
+}
+
+ApplicationEntity * ApplicationProcess::remove_entity(const std::string& name)
+{
+		return entities.erase(name);
+}
+
+ApplicationEntity * ApplicationProcess::get_entity(const std::string& name)
+{
+		return entities.find(name);
+}
+
 }

--- a/librina/src/application.cc
+++ b/librina/src/application.cc
@@ -2,8 +2,7 @@
 // Application
 //
 //    Eduard Grasa          <eduard.grasa@i2cat.net>
-//    Leonardo Bergesio     <leonardo.bergesio@i2cat.net>
-//    Francesco Salvestrini <f.salvestrini@nextworks.it>
+//    Vincenzo Maffione     <v.maffione@nextworks.it>
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -21,9 +20,6 @@
 // MA  02110-1301  USA
 //
 
-#include <cstring>
-#include <stdexcept>
-
 #define RINA_PREFIX "application"
 
 #include "librina/logs.h"
@@ -33,802 +29,15 @@
 
 namespace rina {
 
-/* CLASS FLOW */
-Flow::Flow(const ApplicationProcessNamingInformation& localApplicationName,
-		const ApplicationProcessNamingInformation& remoteApplicationName,
-		const FlowSpecification& flowSpecification, FlowState flowState){
-	flowInformation.localAppName = localApplicationName;
-	flowInformation.remoteAppName = remoteApplicationName;
-	flowInformation.flowSpecification = flowSpecification;
-	flowInformation.portId = 0;
-	this->flowState = flowState;
-}
-
-Flow::Flow(const ApplicationProcessNamingInformation& localApplicationName,
-		const ApplicationProcessNamingInformation& remoteApplicationName,
-		const FlowSpecification& flowSpecification, FlowState flowState,
-		const ApplicationProcessNamingInformation& DIFName, int portId) {
-	flowInformation.localAppName = localApplicationName;
-	flowInformation.remoteAppName = remoteApplicationName;
-	flowInformation.flowSpecification = flowSpecification;
-	flowInformation.portId = portId;
-	flowInformation.difName = DIFName;
-	this->flowState = flowState;
-}
-
-void Flow::setPortId(int portId){
-	flowInformation.portId = portId;
-}
-
-void Flow::setDIFName(const ApplicationProcessNamingInformation& DIFName) {
-	flowInformation.difName = DIFName;
-}
-
-void Flow::setState(FlowState flowState) {
-	this->flowState = flowState;
-}
-
-const FlowState& Flow::getState() const {
-	return flowState;
-}
-
-int Flow::getPortId() const {
-	return flowInformation.portId;
-}
-
-const ApplicationProcessNamingInformation&
-Flow::getDIFName() const {
-	return flowInformation.difName;
-}
-
-const ApplicationProcessNamingInformation&
-Flow::getLocalApplicationName() const {
-	return flowInformation.localAppName;
-}
-
-const ApplicationProcessNamingInformation&
-Flow::getRemoteApplcationName() const {
-	return flowInformation.remoteAppName;
-}
-
-const FlowSpecification& Flow::getFlowSpecification() const {
-	return flowInformation.flowSpecification;
-}
-
-bool Flow::isAllocated() const{
-	return flowState == FLOW_ALLOCATED;
-}
-
-const FlowInformation& Flow::getFlowInformation() const {
-   return flowInformation;
-}
-
-int Flow::readSDU(void * sdu, int maxBytes) throw(Exception){
-	if (flowState != FLOW_ALLOCATED) {
-		throw FlowNotAllocatedException();
-	}
-
-#if STUB_API
-        memset(sdu, 'v', maxBytes);
-
-	return maxBytes;
-#else
-	int result = syscallReadSDU(flowInformation.portId, sdu, maxBytes);
-	if (result < 0){
-		throw ReadSDUException();
-	}
-
-	return result;
-#endif
-}
-
-void Flow::writeSDU(void * sdu, int size) throw(Exception) {
-	if (flowState != FLOW_ALLOCATED) {
-		throw FlowNotAllocatedException();
-	}
-
-#if STUB_API
-	/* Do nothing. */
-        (void)sdu;
-        (void)size;
-#else
-	int result = syscallWriteSDU(flowInformation.portId, sdu, size);
-	if (result < 0){
-		throw WriteSDUException();
-	}
-#endif
-}
-
-/* CLASS APPLICATION REGISTRATION */
-ApplicationRegistration::ApplicationRegistration(
-		const ApplicationProcessNamingInformation& applicationName) {
-	this->applicationName = applicationName;
-}
-
-void ApplicationRegistration::addDIFName(
-		const ApplicationProcessNamingInformation& DIFName) {
-	DIFNames.push_back(DIFName);
-}
-
-void ApplicationRegistration::removeDIFName(
-		const ApplicationProcessNamingInformation& DIFName) {
-	DIFNames.remove(DIFName);
-}
-
-/* CLASS IPC MANAGER */
-IPCManager::IPCManager() : Lockable() {
-}
-
-IPCManager::~IPCManager() throw(){
-}
-
-const std::string IPCManager::application_registered_error =
-		"The application is already registered in this DIF";
-const std::string IPCManager::application_not_registered_error =
-		"The application is not registered in this DIF";
-const std::string IPCManager::unknown_flow_error =
-		"There is no flow at the specified portId";
-const std::string IPCManager::error_registering_application =
-		"Error registering application";
-const std::string IPCManager::error_unregistering_application =
-		"Error unregistering application";
-const std::string IPCManager::error_requesting_flow_allocation =
-		"Error requesting flow allocation";
-const std::string IPCManager::error_requesting_flow_deallocation =
-		"Error requesting flow deallocation";
-const std::string IPCManager::error_getting_dif_properties =
-		"Error getting DIF properties";
-const std::string IPCManager::wrong_flow_state  =
-                "Wrong flow state";
-
-Flow * IPCManager::getPendingFlow(unsigned int seqNumber) {
-        std::map<unsigned int, Flow*>::iterator iterator;
-
-        iterator = pendingFlows.find(seqNumber);
-        if (iterator == pendingFlows.end()) {
-                return 0;
-        }
-
-        return iterator->second;
-}
-
-Flow * IPCManager::getAllocatedFlow(int portId) {
-        std::map<int, Flow*>::iterator iterator;
-
-        iterator = allocatedFlows.find(portId);
-        if (iterator == allocatedFlows.end()) {
-                return 0;
-        }
-
-        return iterator->second;
-}
-
-Flow * IPCManager::getFlowToRemoteApp(
-                ApplicationProcessNamingInformation remoteAppName) {
-        std::map<int, Flow*>::iterator iterator;
-
-        for(iterator = allocatedFlows.begin(); iterator != allocatedFlows.end();
-                        ++iterator) {
-                if (iterator->second->getRemoteApplcationName() ==
-                                remoteAppName) {
-                        return iterator->second;
-                }
-        }
-
-        return NULL;
-}
-
-ApplicationRegistrationInformation IPCManager::getRegistrationInfo(
-                        unsigned int seqNumber) {
-        std::map<unsigned int, ApplicationRegistrationInformation>::iterator iterator;
-
-        iterator = registrationInformation.find(seqNumber);
-        if (iterator == registrationInformation.end()) {
-                throw IPCException("Registration not found");
-        }
-
-        return iterator->second;
-}
-
-ApplicationRegistration * IPCManager::getApplicationRegistration(
-                const ApplicationProcessNamingInformation& appName) {
-        std::map<ApplicationProcessNamingInformation,
-        ApplicationRegistration*>::iterator iterator =
-                        applicationRegistrations.find(appName);
-
-        if (iterator == applicationRegistrations.end()){
-                return 0;
-        }
-
-        return iterator->second;
-}
-
-void IPCManager::putApplicationRegistration(
-                        const ApplicationProcessNamingInformation& key,
-                        ApplicationRegistration * value) {
-        applicationRegistrations[key] = value;
-}
-
-void IPCManager::removeApplicationRegistration(
-                        const ApplicationProcessNamingInformation& key) {
-        applicationRegistrations.erase(key);
-}
-
-unsigned int IPCManager::internalRequestFlowAllocation(
-                const ApplicationProcessNamingInformation& localAppName,
-                const ApplicationProcessNamingInformation& remoteAppName,
-                const FlowSpecification& flowSpec,
-                unsigned short sourceIPCProcessId) {
-        Flow * flow;
-
-#if STUB_API
-        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
-        pendingFlows[0] = flow;
-        (void)sourceIPCProcessId;
-        return 0;
-#else
-        AppAllocateFlowRequestMessage message;
-        message.setSourceAppName(localAppName);
-        message.setDestAppName(remoteAppName);
-        message.setSourceIpcProcessId(sourceIPCProcessId);
-        message.setFlowSpecification(flowSpec);
-        message.setRequestMessage(true);
-
-        try{
-                rinaManager->sendMessage(&message, true);
-        }catch(NetlinkException &e){
-                throw FlowAllocationException(e.what());
-        }
-
-        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
-        lock();
-        pendingFlows[message.getSequenceNumber()] = flow;
-        unlock();
-
-        return message.getSequenceNumber();
-#endif
-}
-
-unsigned int IPCManager::internalRequestFlowAllocationInDIF(
-                const ApplicationProcessNamingInformation& localAppName,
-                const ApplicationProcessNamingInformation& remoteAppName,
-                const ApplicationProcessNamingInformation& difName,
-                unsigned short sourceIPCProcessId,
-                const FlowSpecification& flowSpec) {
-        Flow * flow;
-
-#if STUB_API
-        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
-        pendingFlows[0] = flow;
-        (void)difName;
-        (void)sourceIPCProcessId;
-        return 0;
-#else
-        AppAllocateFlowRequestMessage message;
-        message.setSourceAppName(localAppName);
-        message.setDestAppName(remoteAppName);
-        message.setSourceIpcProcessId(sourceIPCProcessId);
-        message.setFlowSpecification(flowSpec);
-        message.setDifName(difName);
-        message.setRequestMessage(true);
-
-        try{
-                rinaManager->sendMessage(&message, true);
-        }catch(NetlinkException &e){
-                throw FlowAllocationException(e.what());
-        }
-
-        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
-        lock();
-        pendingFlows[message.getSequenceNumber()] = flow;
-        unlock();
-
-        return message.getSequenceNumber();
-#endif
-}
-
-Flow * IPCManager::internalAllocateFlowResponse(
-                const FlowRequestEvent& flowRequestEvent,
-                int result, bool notifySource, unsigned short ipcProcessId) {
-#if STUB_API
-        //Do nothing
-        (void)notifySource;
-        (void)ipcProcessId;
-#else
-        AppAllocateFlowResponseMessage responseMessage;
-        responseMessage.setResult(result);
-        responseMessage.setNotifySource(notifySource);
-        responseMessage.setSourceIpcProcessId(ipcProcessId);
-        responseMessage.setSequenceNumber(flowRequestEvent.sequenceNumber);
-        responseMessage.setResponseMessage(true);
-        try{
-                rinaManager->sendMessage(&responseMessage, false);
-        }catch(NetlinkException &e){
-                throw FlowAllocationException(e.what());
-        }
-#endif
-        if (result != 0) {
-                LOG_WARN("Flow was not accepted, error code: %d", result);
-                return 0;
-        }
-
-        Flow * flow = new Flow(flowRequestEvent.localApplicationName,
-                        flowRequestEvent.remoteApplicationName,
-                        flowRequestEvent.flowSpecification, FLOW_ALLOCATED,
-                        flowRequestEvent.DIFName, flowRequestEvent.portId);
-        lock();
-        allocatedFlows[flowRequestEvent.portId] = flow;
-        unlock();
-        return flow;
-}
-
-unsigned int IPCManager::getDIFProperties(
-		const ApplicationProcessNamingInformation& applicationName,
-		const ApplicationProcessNamingInformation& DIFName) {
-
-#if STUB_API
-        (void)applicationName;
-        (void)DIFName;
-	return 0;
-#else
-	AppGetDIFPropertiesRequestMessage message;
-	message.setApplicationName(applicationName);
-	message.setDifName(DIFName);
-	message.setRequestMessage(true);
-
-	try{
-		rinaManager->sendMessage(&message, true);
-	}catch(NetlinkException &e){
-		throw GetDIFPropertiesException(e.what());
-	}
-
-	return message.getSequenceNumber();
-#endif
-}
-
-unsigned int IPCManager::requestApplicationRegistration(
-                const ApplicationRegistrationInformation& appRegistrationInfo) {
-#if STUB_API
-        registrationInformation[0] = appRegistrationInfo;
-	return 0;
-#else
-	AppRegisterApplicationRequestMessage message;
-	message.setApplicationRegistrationInformation(appRegistrationInfo);
-	message.setRequestMessage(true);
-
-	try{
-	        rinaManager->sendMessage(&message, true);
-	}catch(NetlinkException &e){
-	        throw ApplicationRegistrationException(e.what());
-	}
-
-	lock();
-	registrationInformation[message.getSequenceNumber()] = appRegistrationInfo;
-	unlock();
-
-	return message.getSequenceNumber();
-#endif
-}
-
-ApplicationRegistration * IPCManager::commitPendingRegistration(
-                        unsigned int seqNumber,
-                        const ApplicationProcessNamingInformation& DIFName) {
-        ApplicationRegistrationInformation appRegInfo;
-        ApplicationRegistration * applicationRegistration;
-
-        lock();
-        try {
-        	appRegInfo = getRegistrationInfo(seqNumber);
-        } catch(IPCException &e){
-                unlock();
-                throw ApplicationRegistrationException("Unknown registration");
-        }
-
-        registrationInformation.erase(seqNumber);
-
-        applicationRegistration = getApplicationRegistration(
-                        appRegInfo.appName);
-
-        if (!applicationRegistration){
-                applicationRegistration = new ApplicationRegistration(
-                                appRegInfo.appName);
-                applicationRegistrations[appRegInfo.appName] =
-                                applicationRegistration;
-        }
-
-        applicationRegistration->addDIFName(DIFName);
-        unlock();
-
-        return applicationRegistration;
-}
-
-void IPCManager::withdrawPendingRegistration(unsigned int seqNumber) {
-        ApplicationRegistrationInformation appRegInfo;
-
-        lock();
-        try {
-        	appRegInfo = getRegistrationInfo(seqNumber);
-        } catch(IPCException &e){
-        	unlock();
-        	throw ApplicationRegistrationException("Unknown registration");
-        }
-
-        unlock();
-        registrationInformation.erase(seqNumber);
-}
-
-unsigned int IPCManager::requestApplicationUnregistration(
-		const ApplicationProcessNamingInformation& applicationName,
-		const ApplicationProcessNamingInformation& DIFName) {
-        ApplicationRegistration * applicationRegistration;
-        bool found = false;
-
-        lock();
-        applicationRegistration = getApplicationRegistration(applicationName);
-        if (!applicationRegistration){
-                unlock();
-                throw ApplicationUnregistrationException(
-                                IPCManager::application_not_registered_error);
-        }
-
-        std::list<ApplicationProcessNamingInformation>::const_iterator iterator;
-        for (iterator = applicationRegistration->DIFNames.begin();
-                        iterator != applicationRegistration->DIFNames.end();
-                        ++iterator) {
-                if (*iterator == DIFName) {
-                        found = true;
-                }
-        }
-
-        if (!found) {
-                unlock();
-                throw ApplicationUnregistrationException(
-                                IPCManager::application_not_registered_error);
-        }
-
-        ApplicationRegistrationInformation appRegInfo;
-        appRegInfo.appName = applicationName;
-        appRegInfo.difName = DIFName;
-
-#if STUB_API
-        registrationInformation[0] = appRegInfo;
-        unlock();
-	return 0;
-#else
-	AppUnregisterApplicationRequestMessage message;
-	message.setApplicationName(applicationName);
-	message.setDifName(DIFName);
-	message.setRequestMessage(true);
-
-	try{
-	        rinaManager->sendMessage(&message, true);
-	}catch(NetlinkException &e){
-	        unlock();
-	        throw ApplicationUnregistrationException(e.what());
-	}
-
-	registrationInformation[message.getSequenceNumber()] =
-	                appRegInfo;
-	unlock();
-	return message.getSequenceNumber();
-#endif
-
-}
-
-void IPCManager::appUnregistrationResult(unsigned int seqNumber, bool success) {
-        ApplicationRegistrationInformation appRegInfo;
-
-        lock();
-
-        try {
-                appRegInfo = getRegistrationInfo(seqNumber);
-        } catch (IPCException &e){
-                unlock();
-                throw ApplicationUnregistrationException(
-                                "Pending unregistration not found");
-        }
-
-       registrationInformation.erase(seqNumber);
-       ApplicationRegistration * applicationRegistration;
-
-       applicationRegistration = getApplicationRegistration(
-                       appRegInfo.appName);
-       if (!applicationRegistration){
-               unlock();
-               throw ApplicationUnregistrationException(
-                       IPCManager::application_not_registered_error);
-       }
-
-       if (!success) {
-    	   return;
-       }
-
-       std::list<ApplicationProcessNamingInformation>::const_iterator iterator;
-       for (iterator = applicationRegistration->DIFNames.begin();
-                       iterator != applicationRegistration->DIFNames.end();
-                       ++iterator) {
-               if (*iterator == appRegInfo.difName) {
-                       applicationRegistration->removeDIFName(
-                                       appRegInfo.difName);
-                       if (applicationRegistration->DIFNames.size() == 0) {
-                               applicationRegistrations.erase(
-                                       appRegInfo.appName);
-                       }
-
-                       break;
-               }
-       }
-
-       unlock();
-}
-
-unsigned int IPCManager::requestFlowAllocation(
-		const ApplicationProcessNamingInformation& localAppName,
-		const ApplicationProcessNamingInformation& remoteAppName,
-		const FlowSpecification& flowSpec) {
-        return internalRequestFlowAllocation(
-                        localAppName, remoteAppName, flowSpec, 0);
-}
-
-unsigned int IPCManager::requestFlowAllocationInDIF(
-                const ApplicationProcessNamingInformation& localAppName,
-                const ApplicationProcessNamingInformation& remoteAppName,
-                const ApplicationProcessNamingInformation& difName,
-                const FlowSpecification& flowSpec) {
-        return internalRequestFlowAllocationInDIF(localAppName,
-                        remoteAppName, difName, 0, flowSpec);
-}
-
-Flow * IPCManager::commitPendingFlow(unsigned int sequenceNumber, int portId,
-                        const ApplicationProcessNamingInformation& DIFName) {
-        Flow * flow;
-
-        lock();
-        flow = getPendingFlow(sequenceNumber);
-        if (flow == 0) {
-                unlock();
-                throw FlowDeallocationException(IPCManager::unknown_flow_error);
-        }
-
-        pendingFlows.erase(sequenceNumber);
-
-        flow->setPortId(portId);
-        flow->setDIFName(DIFName);
-        allocatedFlows[portId] = flow;
-        unlock();
-
-        return flow;
-}
-
-FlowInformation IPCManager::withdrawPendingFlow(unsigned int sequenceNumber) {
-        std::map<int, Flow*>::iterator iterator;
-        Flow * flow;
-        FlowInformation flowInformation;
-
-        lock();
-        flow = getPendingFlow(sequenceNumber);
-        if (flow == 0) {
-                unlock();
-                throw FlowDeallocationException(IPCManager::unknown_flow_error);
-        }
-
-        pendingFlows.erase(sequenceNumber);
-        flowInformation = flow->getFlowInformation();
-        delete flow;
-        unlock();
-
-        return flowInformation;
-}
-
-Flow * IPCManager::allocateFlowResponse(
-		const FlowRequestEvent& flowRequestEvent, int result,
-		bool notifySource) {
-        return internalAllocateFlowResponse(
-                        flowRequestEvent, result, notifySource, 0);
-}
-
-unsigned int IPCManager::requestFlowDeallocation(int portId) {
-        Flow * flow;
-
-        lock();
-        flow = getAllocatedFlow(portId);
-        if (flow == 0) {
-                unlock();
-                throw FlowDeallocationException(
-                                IPCManager::unknown_flow_error);
-        }
-
-        if (flow->getState() != FLOW_ALLOCATED) {
-                unlock();
-                throw FlowDeallocationException(
-                                IPCManager::wrong_flow_state);
-        }
-
-#if STUB_API
-        flow->setState(FLOW_DEALLOCATION_REQUESTED);
-        unlock();
-	return 0;
-#else
-
-	LOG_DBG("Application %s requested to deallocate flow with port-id %d",
-		flow->getLocalApplicationName().processName.c_str(),
-		flow->getPortId());
-	AppDeallocateFlowRequestMessage message;
-	message.setApplicationName(flow->getLocalApplicationName());
-	message.setPortId(flow->getPortId());
-	message.setRequestMessage(true);
-
-	try{
-	        rinaManager->sendMessage(&message, true);
-	}catch(NetlinkException &e){
-	        unlock();
-	        throw FlowDeallocationException(e.what());
-	}
-
-	flow->setState(FLOW_DEALLOCATION_REQUESTED);
-	unlock();
-
-	return message.getSequenceNumber();
-#endif
-}
-
-void IPCManager::flowDeallocationResult(int portId, bool success) {
-        Flow * flow;
-
-        lock();
-
-        flow = getAllocatedFlow(portId);
-        if (flow == 0) {
-                unlock();
-                throw FlowDeallocationException(
-                                IPCManager::unknown_flow_error);
-        }
-
-        if (flow->getState() != FLOW_DEALLOCATION_REQUESTED) {
-                unlock();
-                throw FlowDeallocationException(
-                                IPCManager::wrong_flow_state);
-        }
-
-        if (success) {
-                allocatedFlows.erase(portId);
-                delete flow;
-        } else {
-                flow->setState(FLOW_ALLOCATED);
-        }
-
-        unlock();
-}
-
-void IPCManager::flowDeallocated(int portId) {
-	lock();
-
-	Flow * flow = getAllocatedFlow(portId);
-
-	if (flow == 0) {
-		unlock();
-		throw FlowDeallocationException("Unknown flow");
-	}
-
-	allocatedFlows.erase(portId);
-	delete flow;
-
-	unlock();
-}
-
-std::vector<Flow *> IPCManager::getAllocatedFlows() {
-	std::vector<Flow *> response;
-
-	lock();
-	for (std::map<int, Flow*>::iterator it = allocatedFlows.begin();
-			it != allocatedFlows.end(); ++it) {
-		response.push_back(it->second);
-	}
-	unlock();
-
-	return response;
-}
-
-std::vector<ApplicationRegistration *> IPCManager::getRegisteredApplications() {
-	LOG_DBG("IPCManager.getRegisteredApplications called");
-	std::vector<ApplicationRegistration *> response;
-
-	lock();
-	for (std::map<ApplicationProcessNamingInformation,
-			ApplicationRegistration*>::iterator it = applicationRegistrations
-			.begin(); it != applicationRegistrations.end(); ++it) {
-		response.push_back(it->second);
-	}
-	unlock();
-
-	return response;
-}
-
-Singleton<IPCManager> ipcManager;
-
-/* CLASS APPLICATION UNREGISTERED EVENT */
-
-ApplicationUnregisteredEvent::ApplicationUnregisteredEvent(
-		const ApplicationProcessNamingInformation& appName,
-		const ApplicationProcessNamingInformation& DIFName,
-		unsigned int sequenceNumber) :
-				IPCEvent(APPLICATION_UNREGISTERED_EVENT,
-						sequenceNumber) {
-	this->applicationName = appName;
-	this->DIFName = DIFName;
-}
-
-/* CLASS APPLICATION REGISTRATION CANCELED EVENT*/
-AppRegistrationCanceledEvent::AppRegistrationCanceledEvent(int code,
-                const std::string& reason,
-                const ApplicationProcessNamingInformation& difName,
-                unsigned int sequenceNumber):
-			IPCEvent(
-				APPLICATION_REGISTRATION_CANCELED_EVENT,
-				sequenceNumber){
-        this->code = code;
-        this->reason = reason;
-        this->difName = difName;
-}
-
-/* CLASS AllocateFlowRequestResultEvent EVENT*/
-AllocateFlowRequestResultEvent::AllocateFlowRequestResultEvent(
-                        const ApplicationProcessNamingInformation& appName,
-                        const ApplicationProcessNamingInformation& difName,
-                        int portId,
-                        unsigned int sequenceNumber):
-                                IPCEvent(
-                                         ALLOCATE_FLOW_REQUEST_RESULT_EVENT,
-                                         sequenceNumber){
-        this->sourceAppName = appName;
-        this->difName = difName;
-        this->portId = portId;
-}
-
-/* CLASS Deallocate Flow Response EVENT*/
-DeallocateFlowResponseEvent::DeallocateFlowResponseEvent(
-                        const ApplicationProcessNamingInformation& appName,
-                        int portId, int result,
-                        unsigned int sequenceNumber):
-                                BaseResponseEvent(result,
-                                         DEALLOCATE_FLOW_RESPONSE_EVENT,
-                                         sequenceNumber){
-        this->appName = appName;
-        this->portId = portId;
-}
-
-/* CLASS Get DIF Properties Response EVENT*/
-GetDIFPropertiesResponseEvent::GetDIFPropertiesResponseEvent(
-                        const ApplicationProcessNamingInformation& appName,
-                        const std::list<DIFProperties>& difProperties,
-                        int result,
-                        unsigned int sequenceNumber):
-                                BaseResponseEvent(result,
-                                         GET_DIF_PROPERTIES_RESPONSE_EVENT,
-                                         sequenceNumber){
-        this->applicationName = appName;
-        this->difProperties = difProperties;
-}
-
-// DAF Related classes, with support for policies
+const std::string IPolicySet::DEFAULT_PS_SET_NAME = "default";
 
 // Class ApplicationEntityInstance
-ApplicationEntityInstance::ApplicationEntityInstance(const std::string& instance_id)
-{
-	instance_id_ = instance_id;
-}
-
 const std::string& ApplicationEntityInstance::get_instance_id() const
 {
 	return instance_id_;
 }
 
 // Class ApplicationEntity
-ApplicationEntity::ApplicationEntity(const std::string& name)
-{
-		name_ = name;
-}
-
 ApplicationEntity::~ApplicationEntity()
 {
 		instances.deleteValues();
@@ -839,15 +48,25 @@ const std::string& ApplicationEntity::get_name() const
 		return name_;
 }
 
-void ApplicationEntity::add_instance(const std::string& instance_id,
-									 ApplicationEntityInstance * instance)
+void ApplicationEntity::add_instance(ApplicationEntityInstance * instance)
 {
-		instances.put(instance_id, instance);
+		if (!instance) {
+				LOG_ERR("Bogus AE instance passed, returning");
+				return;
+		}
+
+		instance->set_application_entity(this);
+		instances.put(instance->get_instance_id(), instance);
 }
 
 ApplicationEntityInstance * ApplicationEntity::remove_instance(const std::string& instance_id)
 {
-		return instances.erase(instance_id);
+		ApplicationEntityInstance * aei = instances.erase(instance_id);
+		if (aei) {
+				aei->set_application_entity(NULL);
+		}
+
+		return aei;
 }
 
 ApplicationEntityInstance * ApplicationEntity::get_instance(const std::string& instance_id)
@@ -855,13 +74,75 @@ ApplicationEntityInstance * ApplicationEntity::get_instance(const std::string& i
 		return instances.find(instance_id);
 }
 
-//Class Application Process
-ApplicationProcess::ApplicationProcess(const std::string& name, const std::string& instance)
+int ApplicationEntity::select_policy_set_common(const std::string& component,
+                                           	   const std::string& path,
+                                           	   const std::string& ps_name)
 {
-		name_ = name;
-		instance_ = instance;
+        IPolicySet *candidate = NULL;
+
+        if (path != std::string()) {
+                LOG_ERR("No subcomponents to address");
+                return -1;
+        }
+
+        if (!app) {
+                LOG_ERR("bug: NULL app reference");
+                return -1;
+        }
+
+        if (ps_name == selected_ps_name) {
+                LOG_INFO("policy set %s already selected", ps_name.c_str());
+                return 0;
+        }
+
+        candidate = app->psCreate(component, ps_name, this);
+        if (!candidate) {
+                LOG_ERR("failed to allocate instance of policy set %s", ps_name.c_str());
+                return -1;
+        }
+
+        if (ps) {
+                // Remove the old one.
+                app->psDestroy(component, selected_ps_name, ps);
+        }
+
+        // Install the new one.
+        ps = candidate;
+        selected_ps_name = ps_name;
+        LOG_INFO("Policy-set %s selected for component %s",
+                        ps_name.c_str(), component.c_str());
+
+        return ps ? 0 : -1;
 }
 
+int ApplicationEntity::set_policy_set_param_common(const std::string& path,
+                                              const std::string& param_name,
+                                              const std::string& param_value)
+{
+        LOG_DBG("set_policy_set_param(%s, %s) called",
+                param_name.c_str(), param_value.c_str());
+
+        if (!app) {
+                LOG_ERR("bug: NULL app reference");
+                return -1;
+        }
+
+        if (path == selected_ps_name) {
+                // This request is for the currently selected
+                // policy set, forward to it
+                return ps->set_policy_set_param(param_name, param_value);
+        } else if (path != std::string()) {
+                LOG_ERR("Invalid component address '%s'", path.c_str());
+                return -1;
+        }
+
+        // This request is for the component itself
+        LOG_ERR("No such parameter '%s' exists", param_name.c_str());
+
+        return -1;
+}
+
+//Class Application Process
 ApplicationProcess::~ApplicationProcess()
 {
 	entities.deleteValues();
@@ -877,14 +158,25 @@ const std::string& ApplicationProcess::get_instance() const
 		return instance_;
 }
 
-void ApplicationProcess::add_entity(const std::string& name, ApplicationEntity * entity)
+void ApplicationProcess::add_entity(ApplicationEntity * entity)
 {
-		entities.put(name, entity);
+		if (!entity) {
+				LOG_ERR("Bogus entity passed, returning");
+				return;
+		}
+
+		entity->set_application_process(this);
+		entities.put(entity->get_name(), entity);
 }
 
 ApplicationEntity * ApplicationProcess::remove_entity(const std::string& name)
 {
-		return entities.erase(name);
+		ApplicationEntity * ae = entities.erase(name);
+		if (ae) {
+				ae->set_application_process(NULL);
+		}
+
+		return ae;
 }
 
 ApplicationEntity * ApplicationProcess::get_entity(const std::string& name)

--- a/librina/src/ipc-api.cc
+++ b/librina/src/ipc-api.cc
@@ -1,0 +1,813 @@
+//
+// Application
+//
+//    Eduard Grasa          <eduard.grasa@i2cat.net>
+//    Leonardo Bergesio     <leonardo.bergesio@i2cat.net>
+//    Francesco Salvestrini <f.salvestrini@nextworks.it>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA  02110-1301  USA
+//
+
+#include <cstring>
+#include <stdexcept>
+
+#define RINA_PREFIX "ipc-api"
+
+#include "librina/logs.h"
+#include "core.h"
+#include "rina-syscalls.h"
+#include "librina/ipc-api.h"
+
+namespace rina {
+
+/* CLASS FLOW */
+Flow::Flow(const ApplicationProcessNamingInformation& localApplicationName,
+		const ApplicationProcessNamingInformation& remoteApplicationName,
+		const FlowSpecification& flowSpecification, FlowState flowState){
+	flowInformation.localAppName = localApplicationName;
+	flowInformation.remoteAppName = remoteApplicationName;
+	flowInformation.flowSpecification = flowSpecification;
+	flowInformation.portId = 0;
+	this->flowState = flowState;
+}
+
+Flow::Flow(const ApplicationProcessNamingInformation& localApplicationName,
+		const ApplicationProcessNamingInformation& remoteApplicationName,
+		const FlowSpecification& flowSpecification, FlowState flowState,
+		const ApplicationProcessNamingInformation& DIFName, int portId) {
+	flowInformation.localAppName = localApplicationName;
+	flowInformation.remoteAppName = remoteApplicationName;
+	flowInformation.flowSpecification = flowSpecification;
+	flowInformation.portId = portId;
+	flowInformation.difName = DIFName;
+	this->flowState = flowState;
+}
+
+void Flow::setPortId(int portId){
+	flowInformation.portId = portId;
+}
+
+void Flow::setDIFName(const ApplicationProcessNamingInformation& DIFName) {
+	flowInformation.difName = DIFName;
+}
+
+void Flow::setState(FlowState flowState) {
+	this->flowState = flowState;
+}
+
+const FlowState& Flow::getState() const {
+	return flowState;
+}
+
+int Flow::getPortId() const {
+	return flowInformation.portId;
+}
+
+const ApplicationProcessNamingInformation&
+Flow::getDIFName() const {
+	return flowInformation.difName;
+}
+
+const ApplicationProcessNamingInformation&
+Flow::getLocalApplicationName() const {
+	return flowInformation.localAppName;
+}
+
+const ApplicationProcessNamingInformation&
+Flow::getRemoteApplcationName() const {
+	return flowInformation.remoteAppName;
+}
+
+const FlowSpecification& Flow::getFlowSpecification() const {
+	return flowInformation.flowSpecification;
+}
+
+bool Flow::isAllocated() const{
+	return flowState == FLOW_ALLOCATED;
+}
+
+const FlowInformation& Flow::getFlowInformation() const {
+   return flowInformation;
+}
+
+int Flow::readSDU(void * sdu, int maxBytes) throw(Exception){
+	if (flowState != FLOW_ALLOCATED) {
+		throw FlowNotAllocatedException();
+	}
+
+#if STUB_API
+        memset(sdu, 'v', maxBytes);
+
+	return maxBytes;
+#else
+	int result = syscallReadSDU(flowInformation.portId, sdu, maxBytes);
+	if (result < 0){
+		throw ReadSDUException();
+	}
+
+	return result;
+#endif
+}
+
+void Flow::writeSDU(void * sdu, int size) throw(Exception) {
+	if (flowState != FLOW_ALLOCATED) {
+		throw FlowNotAllocatedException();
+	}
+
+#if STUB_API
+	/* Do nothing. */
+        (void)sdu;
+        (void)size;
+#else
+	int result = syscallWriteSDU(flowInformation.portId, sdu, size);
+	if (result < 0){
+		throw WriteSDUException();
+	}
+#endif
+}
+
+/* CLASS APPLICATION REGISTRATION */
+ApplicationRegistration::ApplicationRegistration(
+		const ApplicationProcessNamingInformation& applicationName) {
+	this->applicationName = applicationName;
+}
+
+void ApplicationRegistration::addDIFName(
+		const ApplicationProcessNamingInformation& DIFName) {
+	DIFNames.push_back(DIFName);
+}
+
+void ApplicationRegistration::removeDIFName(
+		const ApplicationProcessNamingInformation& DIFName) {
+	DIFNames.remove(DIFName);
+}
+
+/* CLASS IPC MANAGER */
+IPCManager::IPCManager() : Lockable() {
+}
+
+IPCManager::~IPCManager() throw(){
+}
+
+const std::string IPCManager::application_registered_error =
+		"The application is already registered in this DIF";
+const std::string IPCManager::application_not_registered_error =
+		"The application is not registered in this DIF";
+const std::string IPCManager::unknown_flow_error =
+		"There is no flow at the specified portId";
+const std::string IPCManager::error_registering_application =
+		"Error registering application";
+const std::string IPCManager::error_unregistering_application =
+		"Error unregistering application";
+const std::string IPCManager::error_requesting_flow_allocation =
+		"Error requesting flow allocation";
+const std::string IPCManager::error_requesting_flow_deallocation =
+		"Error requesting flow deallocation";
+const std::string IPCManager::error_getting_dif_properties =
+		"Error getting DIF properties";
+const std::string IPCManager::wrong_flow_state  =
+                "Wrong flow state";
+
+Flow * IPCManager::getPendingFlow(unsigned int seqNumber) {
+        std::map<unsigned int, Flow*>::iterator iterator;
+
+        iterator = pendingFlows.find(seqNumber);
+        if (iterator == pendingFlows.end()) {
+                return 0;
+        }
+
+        return iterator->second;
+}
+
+Flow * IPCManager::getAllocatedFlow(int portId) {
+        std::map<int, Flow*>::iterator iterator;
+
+        iterator = allocatedFlows.find(portId);
+        if (iterator == allocatedFlows.end()) {
+                return 0;
+        }
+
+        return iterator->second;
+}
+
+Flow * IPCManager::getFlowToRemoteApp(
+                ApplicationProcessNamingInformation remoteAppName) {
+        std::map<int, Flow*>::iterator iterator;
+
+        for(iterator = allocatedFlows.begin(); iterator != allocatedFlows.end();
+                        ++iterator) {
+                if (iterator->second->getRemoteApplcationName() ==
+                                remoteAppName) {
+                        return iterator->second;
+                }
+        }
+
+        return NULL;
+}
+
+ApplicationRegistrationInformation IPCManager::getRegistrationInfo(
+                        unsigned int seqNumber) {
+        std::map<unsigned int, ApplicationRegistrationInformation>::iterator iterator;
+
+        iterator = registrationInformation.find(seqNumber);
+        if (iterator == registrationInformation.end()) {
+                throw IPCException("Registration not found");
+        }
+
+        return iterator->second;
+}
+
+ApplicationRegistration * IPCManager::getApplicationRegistration(
+                const ApplicationProcessNamingInformation& appName) {
+        std::map<ApplicationProcessNamingInformation,
+        ApplicationRegistration*>::iterator iterator =
+                        applicationRegistrations.find(appName);
+
+        if (iterator == applicationRegistrations.end()){
+                return 0;
+        }
+
+        return iterator->second;
+}
+
+void IPCManager::putApplicationRegistration(
+                        const ApplicationProcessNamingInformation& key,
+                        ApplicationRegistration * value) {
+        applicationRegistrations[key] = value;
+}
+
+void IPCManager::removeApplicationRegistration(
+                        const ApplicationProcessNamingInformation& key) {
+        applicationRegistrations.erase(key);
+}
+
+unsigned int IPCManager::internalRequestFlowAllocation(
+                const ApplicationProcessNamingInformation& localAppName,
+                const ApplicationProcessNamingInformation& remoteAppName,
+                const FlowSpecification& flowSpec,
+                unsigned short sourceIPCProcessId) {
+        Flow * flow;
+
+#if STUB_API
+        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
+        pendingFlows[0] = flow;
+        (void)sourceIPCProcessId;
+        return 0;
+#else
+        AppAllocateFlowRequestMessage message;
+        message.setSourceAppName(localAppName);
+        message.setDestAppName(remoteAppName);
+        message.setSourceIpcProcessId(sourceIPCProcessId);
+        message.setFlowSpecification(flowSpec);
+        message.setRequestMessage(true);
+
+        try{
+                rinaManager->sendMessage(&message, true);
+        }catch(NetlinkException &e){
+                throw FlowAllocationException(e.what());
+        }
+
+        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
+        lock();
+        pendingFlows[message.getSequenceNumber()] = flow;
+        unlock();
+
+        return message.getSequenceNumber();
+#endif
+}
+
+unsigned int IPCManager::internalRequestFlowAllocationInDIF(
+                const ApplicationProcessNamingInformation& localAppName,
+                const ApplicationProcessNamingInformation& remoteAppName,
+                const ApplicationProcessNamingInformation& difName,
+                unsigned short sourceIPCProcessId,
+                const FlowSpecification& flowSpec) {
+        Flow * flow;
+
+#if STUB_API
+        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
+        pendingFlows[0] = flow;
+        (void)difName;
+        (void)sourceIPCProcessId;
+        return 0;
+#else
+        AppAllocateFlowRequestMessage message;
+        message.setSourceAppName(localAppName);
+        message.setDestAppName(remoteAppName);
+        message.setSourceIpcProcessId(sourceIPCProcessId);
+        message.setFlowSpecification(flowSpec);
+        message.setDifName(difName);
+        message.setRequestMessage(true);
+
+        try{
+                rinaManager->sendMessage(&message, true);
+        }catch(NetlinkException &e){
+                throw FlowAllocationException(e.what());
+        }
+
+        flow = new Flow(localAppName, remoteAppName, flowSpec, FLOW_ALLOCATED);
+        lock();
+        pendingFlows[message.getSequenceNumber()] = flow;
+        unlock();
+
+        return message.getSequenceNumber();
+#endif
+}
+
+Flow * IPCManager::internalAllocateFlowResponse(
+                const FlowRequestEvent& flowRequestEvent,
+                int result, bool notifySource, unsigned short ipcProcessId) {
+#if STUB_API
+        //Do nothing
+        (void)notifySource;
+        (void)ipcProcessId;
+#else
+        AppAllocateFlowResponseMessage responseMessage;
+        responseMessage.setResult(result);
+        responseMessage.setNotifySource(notifySource);
+        responseMessage.setSourceIpcProcessId(ipcProcessId);
+        responseMessage.setSequenceNumber(flowRequestEvent.sequenceNumber);
+        responseMessage.setResponseMessage(true);
+        try{
+                rinaManager->sendMessage(&responseMessage, false);
+        }catch(NetlinkException &e){
+                throw FlowAllocationException(e.what());
+        }
+#endif
+        if (result != 0) {
+                LOG_WARN("Flow was not accepted, error code: %d", result);
+                return 0;
+        }
+
+        Flow * flow = new Flow(flowRequestEvent.localApplicationName,
+                        flowRequestEvent.remoteApplicationName,
+                        flowRequestEvent.flowSpecification, FLOW_ALLOCATED,
+                        flowRequestEvent.DIFName, flowRequestEvent.portId);
+        lock();
+        allocatedFlows[flowRequestEvent.portId] = flow;
+        unlock();
+        return flow;
+}
+
+unsigned int IPCManager::getDIFProperties(
+		const ApplicationProcessNamingInformation& applicationName,
+		const ApplicationProcessNamingInformation& DIFName) {
+
+#if STUB_API
+        (void)applicationName;
+        (void)DIFName;
+	return 0;
+#else
+	AppGetDIFPropertiesRequestMessage message;
+	message.setApplicationName(applicationName);
+	message.setDifName(DIFName);
+	message.setRequestMessage(true);
+
+	try{
+		rinaManager->sendMessage(&message, true);
+	}catch(NetlinkException &e){
+		throw GetDIFPropertiesException(e.what());
+	}
+
+	return message.getSequenceNumber();
+#endif
+}
+
+unsigned int IPCManager::requestApplicationRegistration(
+                const ApplicationRegistrationInformation& appRegistrationInfo) {
+#if STUB_API
+        registrationInformation[0] = appRegistrationInfo;
+	return 0;
+#else
+	AppRegisterApplicationRequestMessage message;
+	message.setApplicationRegistrationInformation(appRegistrationInfo);
+	message.setRequestMessage(true);
+
+	try{
+	        rinaManager->sendMessage(&message, true);
+	}catch(NetlinkException &e){
+	        throw ApplicationRegistrationException(e.what());
+	}
+
+	lock();
+	registrationInformation[message.getSequenceNumber()] = appRegistrationInfo;
+	unlock();
+
+	return message.getSequenceNumber();
+#endif
+}
+
+ApplicationRegistration * IPCManager::commitPendingRegistration(
+                        unsigned int seqNumber,
+                        const ApplicationProcessNamingInformation& DIFName) {
+        ApplicationRegistrationInformation appRegInfo;
+        ApplicationRegistration * applicationRegistration;
+
+        lock();
+        try {
+        	appRegInfo = getRegistrationInfo(seqNumber);
+        } catch(IPCException &e){
+                unlock();
+                throw ApplicationRegistrationException("Unknown registration");
+        }
+
+        registrationInformation.erase(seqNumber);
+
+        applicationRegistration = getApplicationRegistration(
+                        appRegInfo.appName);
+
+        if (!applicationRegistration){
+                applicationRegistration = new ApplicationRegistration(
+                                appRegInfo.appName);
+                applicationRegistrations[appRegInfo.appName] =
+                                applicationRegistration;
+        }
+
+        applicationRegistration->addDIFName(DIFName);
+        unlock();
+
+        return applicationRegistration;
+}
+
+void IPCManager::withdrawPendingRegistration(unsigned int seqNumber) {
+        ApplicationRegistrationInformation appRegInfo;
+
+        lock();
+        try {
+        	appRegInfo = getRegistrationInfo(seqNumber);
+        } catch(IPCException &e){
+        	unlock();
+        	throw ApplicationRegistrationException("Unknown registration");
+        }
+
+        unlock();
+        registrationInformation.erase(seqNumber);
+}
+
+unsigned int IPCManager::requestApplicationUnregistration(
+		const ApplicationProcessNamingInformation& applicationName,
+		const ApplicationProcessNamingInformation& DIFName) {
+        ApplicationRegistration * applicationRegistration;
+        bool found = false;
+
+        lock();
+        applicationRegistration = getApplicationRegistration(applicationName);
+        if (!applicationRegistration){
+                unlock();
+                throw ApplicationUnregistrationException(
+                                IPCManager::application_not_registered_error);
+        }
+
+        std::list<ApplicationProcessNamingInformation>::const_iterator iterator;
+        for (iterator = applicationRegistration->DIFNames.begin();
+                        iterator != applicationRegistration->DIFNames.end();
+                        ++iterator) {
+                if (*iterator == DIFName) {
+                        found = true;
+                }
+        }
+
+        if (!found) {
+                unlock();
+                throw ApplicationUnregistrationException(
+                                IPCManager::application_not_registered_error);
+        }
+
+        ApplicationRegistrationInformation appRegInfo;
+        appRegInfo.appName = applicationName;
+        appRegInfo.difName = DIFName;
+
+#if STUB_API
+        registrationInformation[0] = appRegInfo;
+        unlock();
+	return 0;
+#else
+	AppUnregisterApplicationRequestMessage message;
+	message.setApplicationName(applicationName);
+	message.setDifName(DIFName);
+	message.setRequestMessage(true);
+
+	try{
+	        rinaManager->sendMessage(&message, true);
+	}catch(NetlinkException &e){
+	        unlock();
+	        throw ApplicationUnregistrationException(e.what());
+	}
+
+	registrationInformation[message.getSequenceNumber()] =
+	                appRegInfo;
+	unlock();
+	return message.getSequenceNumber();
+#endif
+
+}
+
+void IPCManager::appUnregistrationResult(unsigned int seqNumber, bool success) {
+        ApplicationRegistrationInformation appRegInfo;
+
+        lock();
+
+        try {
+                appRegInfo = getRegistrationInfo(seqNumber);
+        } catch (IPCException &e){
+                unlock();
+                throw ApplicationUnregistrationException(
+                                "Pending unregistration not found");
+        }
+
+       registrationInformation.erase(seqNumber);
+       ApplicationRegistration * applicationRegistration;
+
+       applicationRegistration = getApplicationRegistration(
+                       appRegInfo.appName);
+       if (!applicationRegistration){
+               unlock();
+               throw ApplicationUnregistrationException(
+                       IPCManager::application_not_registered_error);
+       }
+
+       if (!success) {
+    	   return;
+       }
+
+       std::list<ApplicationProcessNamingInformation>::const_iterator iterator;
+       for (iterator = applicationRegistration->DIFNames.begin();
+                       iterator != applicationRegistration->DIFNames.end();
+                       ++iterator) {
+               if (*iterator == appRegInfo.difName) {
+                       applicationRegistration->removeDIFName(
+                                       appRegInfo.difName);
+                       if (applicationRegistration->DIFNames.size() == 0) {
+                               applicationRegistrations.erase(
+                                       appRegInfo.appName);
+                       }
+
+                       break;
+               }
+       }
+
+       unlock();
+}
+
+unsigned int IPCManager::requestFlowAllocation(
+		const ApplicationProcessNamingInformation& localAppName,
+		const ApplicationProcessNamingInformation& remoteAppName,
+		const FlowSpecification& flowSpec) {
+        return internalRequestFlowAllocation(
+                        localAppName, remoteAppName, flowSpec, 0);
+}
+
+unsigned int IPCManager::requestFlowAllocationInDIF(
+                const ApplicationProcessNamingInformation& localAppName,
+                const ApplicationProcessNamingInformation& remoteAppName,
+                const ApplicationProcessNamingInformation& difName,
+                const FlowSpecification& flowSpec) {
+        return internalRequestFlowAllocationInDIF(localAppName,
+                        remoteAppName, difName, 0, flowSpec);
+}
+
+Flow * IPCManager::commitPendingFlow(unsigned int sequenceNumber, int portId,
+                        const ApplicationProcessNamingInformation& DIFName) {
+        Flow * flow;
+
+        lock();
+        flow = getPendingFlow(sequenceNumber);
+        if (flow == 0) {
+                unlock();
+                throw FlowDeallocationException(IPCManager::unknown_flow_error);
+        }
+
+        pendingFlows.erase(sequenceNumber);
+
+        flow->setPortId(portId);
+        flow->setDIFName(DIFName);
+        allocatedFlows[portId] = flow;
+        unlock();
+
+        return flow;
+}
+
+FlowInformation IPCManager::withdrawPendingFlow(unsigned int sequenceNumber) {
+        std::map<int, Flow*>::iterator iterator;
+        Flow * flow;
+        FlowInformation flowInformation;
+
+        lock();
+        flow = getPendingFlow(sequenceNumber);
+        if (flow == 0) {
+                unlock();
+                throw FlowDeallocationException(IPCManager::unknown_flow_error);
+        }
+
+        pendingFlows.erase(sequenceNumber);
+        flowInformation = flow->getFlowInformation();
+        delete flow;
+        unlock();
+
+        return flowInformation;
+}
+
+Flow * IPCManager::allocateFlowResponse(
+		const FlowRequestEvent& flowRequestEvent, int result,
+		bool notifySource) {
+        return internalAllocateFlowResponse(
+                        flowRequestEvent, result, notifySource, 0);
+}
+
+unsigned int IPCManager::requestFlowDeallocation(int portId) {
+        Flow * flow;
+
+        lock();
+        flow = getAllocatedFlow(portId);
+        if (flow == 0) {
+                unlock();
+                throw FlowDeallocationException(
+                                IPCManager::unknown_flow_error);
+        }
+
+        if (flow->getState() != FLOW_ALLOCATED) {
+                unlock();
+                throw FlowDeallocationException(
+                                IPCManager::wrong_flow_state);
+        }
+
+#if STUB_API
+        flow->setState(FLOW_DEALLOCATION_REQUESTED);
+        unlock();
+	return 0;
+#else
+
+	LOG_DBG("Application %s requested to deallocate flow with port-id %d",
+		flow->getLocalApplicationName().processName.c_str(),
+		flow->getPortId());
+	AppDeallocateFlowRequestMessage message;
+	message.setApplicationName(flow->getLocalApplicationName());
+	message.setPortId(flow->getPortId());
+	message.setRequestMessage(true);
+
+	try{
+	        rinaManager->sendMessage(&message, true);
+	}catch(NetlinkException &e){
+	        unlock();
+	        throw FlowDeallocationException(e.what());
+	}
+
+	flow->setState(FLOW_DEALLOCATION_REQUESTED);
+	unlock();
+
+	return message.getSequenceNumber();
+#endif
+}
+
+void IPCManager::flowDeallocationResult(int portId, bool success) {
+        Flow * flow;
+
+        lock();
+
+        flow = getAllocatedFlow(portId);
+        if (flow == 0) {
+                unlock();
+                throw FlowDeallocationException(
+                                IPCManager::unknown_flow_error);
+        }
+
+        if (flow->getState() != FLOW_DEALLOCATION_REQUESTED) {
+                unlock();
+                throw FlowDeallocationException(
+                                IPCManager::wrong_flow_state);
+        }
+
+        if (success) {
+                allocatedFlows.erase(portId);
+                delete flow;
+        } else {
+                flow->setState(FLOW_ALLOCATED);
+        }
+
+        unlock();
+}
+
+void IPCManager::flowDeallocated(int portId) {
+	lock();
+
+	Flow * flow = getAllocatedFlow(portId);
+
+	if (flow == 0) {
+		unlock();
+		throw FlowDeallocationException("Unknown flow");
+	}
+
+	allocatedFlows.erase(portId);
+	delete flow;
+
+	unlock();
+}
+
+std::vector<Flow *> IPCManager::getAllocatedFlows() {
+	std::vector<Flow *> response;
+
+	lock();
+	for (std::map<int, Flow*>::iterator it = allocatedFlows.begin();
+			it != allocatedFlows.end(); ++it) {
+		response.push_back(it->second);
+	}
+	unlock();
+
+	return response;
+}
+
+std::vector<ApplicationRegistration *> IPCManager::getRegisteredApplications() {
+	LOG_DBG("IPCManager.getRegisteredApplications called");
+	std::vector<ApplicationRegistration *> response;
+
+	lock();
+	for (std::map<ApplicationProcessNamingInformation,
+			ApplicationRegistration*>::iterator it = applicationRegistrations
+			.begin(); it != applicationRegistrations.end(); ++it) {
+		response.push_back(it->second);
+	}
+	unlock();
+
+	return response;
+}
+
+Singleton<IPCManager> ipcManager;
+
+/* CLASS APPLICATION UNREGISTERED EVENT */
+
+ApplicationUnregisteredEvent::ApplicationUnregisteredEvent(
+		const ApplicationProcessNamingInformation& appName,
+		const ApplicationProcessNamingInformation& DIFName,
+		unsigned int sequenceNumber) :
+				IPCEvent(APPLICATION_UNREGISTERED_EVENT,
+						sequenceNumber) {
+	this->applicationName = appName;
+	this->DIFName = DIFName;
+}
+
+/* CLASS APPLICATION REGISTRATION CANCELED EVENT*/
+AppRegistrationCanceledEvent::AppRegistrationCanceledEvent(int code,
+                const std::string& reason,
+                const ApplicationProcessNamingInformation& difName,
+                unsigned int sequenceNumber):
+			IPCEvent(
+				APPLICATION_REGISTRATION_CANCELED_EVENT,
+				sequenceNumber){
+        this->code = code;
+        this->reason = reason;
+        this->difName = difName;
+}
+
+/* CLASS AllocateFlowRequestResultEvent EVENT*/
+AllocateFlowRequestResultEvent::AllocateFlowRequestResultEvent(
+                        const ApplicationProcessNamingInformation& appName,
+                        const ApplicationProcessNamingInformation& difName,
+                        int portId,
+                        unsigned int sequenceNumber):
+                                IPCEvent(
+                                         ALLOCATE_FLOW_REQUEST_RESULT_EVENT,
+                                         sequenceNumber){
+        this->sourceAppName = appName;
+        this->difName = difName;
+        this->portId = portId;
+}
+
+/* CLASS Deallocate Flow Response EVENT*/
+DeallocateFlowResponseEvent::DeallocateFlowResponseEvent(
+                        const ApplicationProcessNamingInformation& appName,
+                        int portId, int result,
+                        unsigned int sequenceNumber):
+                                BaseResponseEvent(result,
+                                         DEALLOCATE_FLOW_RESPONSE_EVENT,
+                                         sequenceNumber){
+        this->appName = appName;
+        this->portId = portId;
+}
+
+/* CLASS Get DIF Properties Response EVENT*/
+GetDIFPropertiesResponseEvent::GetDIFPropertiesResponseEvent(
+                        const ApplicationProcessNamingInformation& appName,
+                        const std::list<DIFProperties>& difProperties,
+                        int result,
+                        unsigned int sequenceNumber):
+                                BaseResponseEvent(result,
+                                         GET_DIF_PROPERTIES_RESPONSE_EVENT,
+                                         sequenceNumber){
+        this->applicationName = appName;
+        this->difProperties = difProperties;
+}
+
+}

--- a/rinad/src/ipcp/Makefile.am
+++ b/rinad/src/ipcp/Makefile.am
@@ -50,15 +50,16 @@ default_la_CPPFLAGS =				\
 	$(COMMONCPPFLAGS)
 default_la_LIBADD = $(COMMONLIBS) -ldl
 default_la_LDFLAGS = -module
-default_la_SOURCES =				\
-		default-plugin.cc		\
-		components.h			\
-		default-security-manager-ps.cc	\
-		default-flow-allocator-ps.cc    \
-        default-namespace-manager-ps.cc \
-        default-resource-allocator-ps.cc \
-        link-state-routing-ps.h \
-        link-state-routing-ps.cc
+default_la_SOURCES =				 \
+		default-plugin.cc		 \
+		components.h			 \
+		components.cc			 \
+		default-security-manager-ps.cc	 \
+		default-flow-allocator-ps.cc     \
+        	default-namespace-manager-ps.cc  \
+        	default-resource-allocator-ps.cc \
+        	link-state-routing-ps.h 	 \
+        	link-state-routing-ps.cc
 
 plugins_LTLIBRARIES += default.la
 

--- a/rinad/src/ipcp/components.cc
+++ b/rinad/src/ipcp/components.cc
@@ -29,6 +29,14 @@
 
 namespace rinad {
 
+const std::string IPCProcessComponent::ENROLLMENT_TASK_AE_NAME = "enrollment task";
+const std::string IPCProcessComponent::FLOW_ALLOCATOR_AE_NAME = "flow-allocator";
+const std::string IPCProcessComponent::NAMESPACE_MANAGER_AE_NAME = "namespace-manager";
+const std::string IPCProcessComponent::RESOURCE_ALLOCATOR_AE_NAME = "resource-allocator";
+const std::string IPCProcessComponent::SECURITY_MANAGER_AE_NAME = "security-manager";
+const std::string IPCProcessComponent::ROUTING_COMPONENT_AE_NAME = "routing";
+const std::string IPCProcessComponent::RIB_DAEMON_AE_NAME = "rib daemon";
+
 //	CLASS EnrollmentRequest
 EnrollmentRequest::EnrollmentRequest(rina::Neighbor * neighbor) {
 	neighbor_ = neighbor;
@@ -223,7 +231,8 @@ void SimpleSetMemberIPCPRIBObject::deleteObject(const void* objectValue)
 }
 
 //Class IPCProcess
-IPCProcess::IPCProcess()
+IPCProcess::IPCProcess(const std::string& name, const std::string& instance)
+			: rina::ApplicationProcess(name, instance)
 {
 	delimiter_ = 0;
 	encoder_ = 0;
@@ -236,77 +245,5 @@ IPCProcess::IPCProcess()
 	rib_daemon_ = 0;
 	routing_component_ = 0;
 }
-
-//Class IPCProcessComponent
-int IPCProcessComponent::select_policy_set_common(IPCProcess * ipcp,
-                                           const std::string& component,
-                                           const std::string& path,
-                                           const std::string& ps_name)
-{
-        IPolicySet *candidate = NULL;
-
-        if (path != std::string()) {
-                LOG_ERR("No subcomponents to address");
-                return -1;
-        }
-
-        if (!ipcp) {
-                LOG_ERR("bug: NULL ipcp reference");
-                return -1;
-        }
-
-        if (ps_name == selected_ps_name) {
-                LOG_INFO("policy set %s already selected", ps_name.c_str());
-                return 0;
-        }
-
-        candidate = ipcp->psCreate(component, ps_name, this);
-        if (!candidate) {
-                LOG_ERR("failed to allocate instance of policy set %s", ps_name.c_str());
-                return -1;
-        }
-
-        if (ps) {
-                // Remove the old one.
-                ipcp->psDestroy(component, selected_ps_name, ps);
-        }
-
-        // Install the new one.
-        ps = candidate;
-        selected_ps_name = ps_name;
-        LOG_INFO("Policy-set %s selected for component %s",
-                        ps_name.c_str(), component.c_str());
-
-        return ps ? 0 : -1;
-}
-
-int IPCProcessComponent::set_policy_set_param_common(IPCProcess * ipcp,
-                                              const std::string& path,
-                                              const std::string& param_name,
-                                              const std::string& param_value)
-{
-        LOG_DBG("set_policy_set_param(%s, %s) called",
-                param_name.c_str(), param_value.c_str());
-
-        if (!ipcp) {
-                LOG_ERR("bug: NULL ipcp reference");
-                return -1;
-        }
-
-        if (path == selected_ps_name) {
-                // This request is for the currently selected
-                // policy set, forward to it
-                return ps->set_policy_set_param(param_name, param_value);
-        } else if (path != std::string()) {
-                LOG_ERR("Invalid component address '%s'", path.c_str());
-                return -1;
-        }
-
-        // This request is for the component itself
-        LOG_ERR("No such parameter '%s' exists", param_name.c_str());
-
-        return -1;
-}
-
 
 }

--- a/rinad/src/ipcp/default-flow-allocator-ps.cc
+++ b/rinad/src/ipcp/default-flow-allocator-ps.cc
@@ -141,8 +141,8 @@ int FlowAllocatorPs::set_policy_set_param(const std::string& name,
         return -1;
 }
 
-extern "C" IPolicySet *
-createFlowAllocatorPs(IPCProcessComponent * ctx)
+extern "C" rina::IPolicySet *
+createFlowAllocatorPs(rina::ApplicationEntity * ctx)
 {
         IFlowAllocator * sm = dynamic_cast<IFlowAllocator *>(ctx);
 
@@ -154,7 +154,7 @@ createFlowAllocatorPs(IPCProcessComponent * ctx)
 }
 
 extern "C" void
-destroyFlowAllocatorPs(IPolicySet * ps)
+destroyFlowAllocatorPs(rina::IPolicySet * ps)
 {
         if (ps) {
                 delete ps;

--- a/rinad/src/ipcp/default-namespace-manager-ps.cc
+++ b/rinad/src/ipcp/default-namespace-manager-ps.cc
@@ -176,8 +176,8 @@ int NamespaceManagerPs::set_policy_set_param(const std::string& name,
         return -1;
 }
 
-extern "C" IPolicySet *
-createNamespaceManagerPs(IPCProcessComponent * ctx)
+extern "C" rina::IPolicySet *
+createNamespaceManagerPs(rina::ApplicationEntity * ctx)
 {
 		INamespaceManager * nsm = dynamic_cast<INamespaceManager *>(ctx);
 
@@ -189,7 +189,7 @@ createNamespaceManagerPs(IPCProcessComponent * ctx)
 }
 
 extern "C" void
-destroyNamespaceManagerPs(IPolicySet * ps)
+destroyNamespaceManagerPs(rina::IPolicySet * ps)
 {
         if (ps) {
                 delete ps;

--- a/rinad/src/ipcp/default-plugin.cc
+++ b/rinad/src/ipcp/default-plugin.cc
@@ -43,7 +43,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
         int ret;
 
         sm_factory.plugin_name = plugin_name;
-        sm_factory.name = "default";
+        sm_factory.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         sm_factory.app_entity = IPCProcessComponent::SECURITY_MANAGER_AE_NAME;
         sm_factory.create = createSecurityManagerPs;
         sm_factory.destroy = destroySecurityManagerPs;
@@ -54,7 +54,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
         }
 
         fa_factory.plugin_name = plugin_name;
-        fa_factory.name = "default";
+        fa_factory.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         fa_factory.app_entity = IPCProcessComponent::FLOW_ALLOCATOR_AE_NAME;
         fa_factory.create = createFlowAllocatorPs;
         fa_factory.destroy = destroyFlowAllocatorPs;
@@ -65,7 +65,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
         }
 
         nsm_factory.plugin_name = plugin_name;
-        nsm_factory.name = "default";
+        nsm_factory.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         nsm_factory.app_entity = IPCProcessComponent::NAMESPACE_MANAGER_AE_NAME;
         nsm_factory.create = createNamespaceManagerPs;
         nsm_factory.destroy = destroyNamespaceManagerPs;
@@ -76,7 +76,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
         }
 
         ra_factory.plugin_name = plugin_name;
-        ra_factory.name = "default";
+        ra_factory.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         ra_factory.app_entity = IPCProcessComponent::RESOURCE_ALLOCATOR_AE_NAME;
         ra_factory.create = createResourceAllocatorPs;
         ra_factory.destroy = destroyResourceAllocatorPs;

--- a/rinad/src/ipcp/default-plugin.cc
+++ b/rinad/src/ipcp/default-plugin.cc
@@ -2,49 +2,49 @@
 
 namespace rinad {
 
-extern "C" IPolicySet *
-createSecurityManagerPs(IPCProcessComponent * context);
+extern "C" rina::IPolicySet *
+createSecurityManagerPs(rina::ApplicationEntity * context);
 
 extern "C" void
-destroySecurityManagerPs(IPolicySet * instance);
+destroySecurityManagerPs(rina::IPolicySet * instance);
 
-extern "C" IPolicySet *
-createFlowAllocatorPs(IPCProcessComponent * context);
-
-extern "C" void
-destroyFlowAllocatorPs(IPolicySet * instance);
-
-extern "C" IPolicySet *
-createNamespaceManagerPs(IPCProcessComponent * context);
+extern "C" rina::IPolicySet *
+createFlowAllocatorPs(rina::ApplicationEntity * context);
 
 extern "C" void
-destroyNamespaceManagerPs(IPolicySet * instance);
+destroyFlowAllocatorPs(rina::IPolicySet * instance);
 
-extern "C" IPolicySet *
-createResourceAllocatorPs(IPCProcessComponent * context);
-
-extern "C" void
-destroyResourceAllocatorPs(IPolicySet * instance);
-
-extern "C" IPolicySet *
-createRoutingComponentPs(IPCProcessComponent * context);
+extern "C" rina::IPolicySet *
+createNamespaceManagerPs(rina::ApplicationEntity * context);
 
 extern "C" void
-destroyRoutingComponentPs(IPolicySet * instance);
+destroyNamespaceManagerPs(rina::IPolicySet * instance);
+
+extern "C" rina::IPolicySet *
+createResourceAllocatorPs(rina::ApplicationEntity * context);
+
+extern "C" void
+destroyResourceAllocatorPs(rina::IPolicySet * instance);
+
+extern "C" rina::IPolicySet *
+createRoutingComponentPs(rina::ApplicationEntity * context);
+
+extern "C" void
+destroyRoutingComponentPs(rina::IPolicySet * instance);
 
 extern "C" int
 init(IPCProcess * ipc_process, const std::string& plugin_name)
 {
-        struct PsFactory sm_factory;
-        struct PsFactory fa_factory;
-        struct PsFactory nsm_factory;
-        struct PsFactory ra_factory;
-        struct PsFactory rc_factory;
+        struct rina::PsFactory sm_factory;
+        struct rina::PsFactory fa_factory;
+        struct rina::PsFactory nsm_factory;
+        struct rina::PsFactory ra_factory;
+        struct rina::PsFactory rc_factory;
         int ret;
 
         sm_factory.plugin_name = plugin_name;
         sm_factory.name = "default";
-        sm_factory.component = "security-manager";
+        sm_factory.app_entity = IPCProcessComponent::SECURITY_MANAGER_AE_NAME;
         sm_factory.create = createSecurityManagerPs;
         sm_factory.destroy = destroySecurityManagerPs;
 
@@ -55,7 +55,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
 
         fa_factory.plugin_name = plugin_name;
         fa_factory.name = "default";
-        fa_factory.component = "flow-allocator";
+        fa_factory.app_entity = IPCProcessComponent::FLOW_ALLOCATOR_AE_NAME;
         fa_factory.create = createFlowAllocatorPs;
         fa_factory.destroy = destroyFlowAllocatorPs;
 
@@ -66,7 +66,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
 
         nsm_factory.plugin_name = plugin_name;
         nsm_factory.name = "default";
-        nsm_factory.component = "namespace-manager";
+        nsm_factory.app_entity = IPCProcessComponent::NAMESPACE_MANAGER_AE_NAME;
         nsm_factory.create = createNamespaceManagerPs;
         nsm_factory.destroy = destroyNamespaceManagerPs;
 
@@ -77,7 +77,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
 
         ra_factory.plugin_name = plugin_name;
         ra_factory.name = "default";
-        ra_factory.component = "resource-allocator";
+        ra_factory.app_entity = IPCProcessComponent::RESOURCE_ALLOCATOR_AE_NAME;
         ra_factory.create = createResourceAllocatorPs;
         ra_factory.destroy = destroyResourceAllocatorPs;
 
@@ -88,7 +88,7 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
 
         rc_factory.plugin_name = plugin_name;
         rc_factory.name = "link-state";
-        rc_factory.component = "routing";
+        rc_factory.app_entity = IPCProcessComponent::ROUTING_COMPONENT_AE_NAME;
         rc_factory.create = createRoutingComponentPs;
         rc_factory.destroy = destroyRoutingComponentPs;
 

--- a/rinad/src/ipcp/default-resource-allocator-ps.cc
+++ b/rinad/src/ipcp/default-resource-allocator-ps.cc
@@ -88,8 +88,8 @@ int ResourceAllocatorPs::set_policy_set_param(const std::string& name,
         return -1;
 }
 
-extern "C" IPolicySet *
-createResourceAllocatorPs(IPCProcessComponent * ctx)
+extern "C" rina::IPolicySet *
+createResourceAllocatorPs(rina::ApplicationEntity * ctx)
 {
 		IResourceAllocator * ra = dynamic_cast<IResourceAllocator *>(ctx);
 
@@ -101,7 +101,7 @@ createResourceAllocatorPs(IPCProcessComponent * ctx)
 }
 
 extern "C" void
-destroyResourceAllocatorPs(IPolicySet * ps)
+destroyResourceAllocatorPs(rina::IPolicySet * ps)
 {
         if (ps) {
                 delete ps;

--- a/rinad/src/ipcp/default-security-manager-ps.cc
+++ b/rinad/src/ipcp/default-security-manager-ps.cc
@@ -69,8 +69,8 @@ int SecurityManagerPs::set_policy_set_param(const std::string& name,
         return -1;
 }
 
-extern "C" IPolicySet *
-createSecurityManagerPs(IPCProcessComponent * ctx)
+extern "C" rina::IPolicySet *
+createSecurityManagerPs(rina::ApplicationEntity * ctx)
 {
         ISecurityManager * sm = dynamic_cast<ISecurityManager *>(ctx);
 
@@ -82,7 +82,7 @@ createSecurityManagerPs(IPCProcessComponent * ctx)
 }
 
 extern "C" void
-destroySecurityManagerPs(IPolicySet * ps)
+destroySecurityManagerPs(rina::IPolicySet * ps)
 {
         if (ps) {
                 delete ps;

--- a/rinad/src/ipcp/enrollment-task.h
+++ b/rinad/src/ipcp/enrollment-task.h
@@ -365,7 +365,7 @@ class EnrollmentTask: public IEnrollmentTask, public EventListener {
 public:
 	EnrollmentTask();
 	~EnrollmentTask();
-	void set_ipc_process(IPCProcess * ipc_process);
+	void set_application_process(rina::ApplicationProcess * ap);
 	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
 	const std::list<rina::Neighbor *> get_neighbors() const;
 	BaseEnrollmentStateMachine * getEnrollmentStateMachine(const std::string& apName,

--- a/rinad/src/ipcp/flow-allocator.cc
+++ b/rinad/src/ipcp/flow-allocator.cc
@@ -189,7 +189,7 @@ const void* QoSCubeSetRIBObject::get_value() const
 }
 
 //Class Flow Allocator
-FlowAllocator::FlowAllocator()
+FlowAllocator::FlowAllocator() : IFlowAllocator()
 {
   ipcp = 0;
   rib_daemon_ = 0;
@@ -207,9 +207,16 @@ IFlowAllocatorInstance * FlowAllocator::getFAI(int portId) {
 	return flow_allocator_instances_.find(portId);
 }
 
-void FlowAllocator::set_ipc_process(IPCProcess * ipc_process)
-{
-  ipcp = ipc_process;
+void FlowAllocator::set_application_process(rina::ApplicationProcess * ap) {
+	if (!ap)
+			return;
+
+	app = ap;
+	ipcp = dynamic_cast<IPCProcess*>(app);
+	if (!ipcp) {
+			LOG_ERR("Bogus instance of IPCP passed, return");
+			return;
+	}
   rib_daemon_ = ipcp->rib_daemon_;
   encoder_ = ipcp->encoder_;
   cdap_session_manager_ = ipcp->cdap_session_manager_;
@@ -240,15 +247,14 @@ void FlowAllocator::set_dif_configuration(
 int FlowAllocator::select_policy_set(const std::string& path,
                                      const std::string& name)
 {
-  return select_policy_set_common(ipcp, "flow-allocator",
-                                  path, name);
+  return select_policy_set_common(get_name(), path, name);
 }
 
 int FlowAllocator::set_policy_set_param(const std::string& path,
                                         const std::string& name,
                                         const std::string& value)
 {
-  return set_policy_set_param_common(ipcp, path, name, value);
+  return set_policy_set_param_common(path, name, value);
 }
 
 void FlowAllocator::populateRIB()

--- a/rinad/src/ipcp/flow-allocator.cc
+++ b/rinad/src/ipcp/flow-allocator.cc
@@ -40,20 +40,20 @@ FlowRIBObject::FlowRIBObject(
         ipc_process, object_class, object_name,
         flow_allocator_instance->get_flow())
 {
-  flow_allocator_instance_ = flow_allocator_instance;
+		flow_allocator_instance_ = flow_allocator_instance;
 }
 
 void FlowRIBObject::remoteDeleteObject(
     int invoke_id, rina::CDAPSessionDescriptor * session_descriptor)
 {
-  (void) invoke_id;
-  (void) session_descriptor;
-  flow_allocator_instance_->deleteFlowRequestMessageReceived();
+		(void) invoke_id;
+		(void) session_descriptor;
+		flow_allocator_instance_->deleteFlowRequestMessageReceived();
 }
 
 std::string FlowRIBObject::get_displayable_value()
 {
-  return flow_allocator_instance_->get_flow()->toString();
+		return flow_allocator_instance_->get_flow()->toString();
 }
 
 //Class Flow Set RIB Object
@@ -64,35 +64,37 @@ FlowSetRIBObject::FlowSetRIBObject(IPCProcess * ipc_process,
         rina::objectInstanceGenerator->getObjectInstance(),
         EncoderConstants::FLOW_SET_RIB_OBJECT_NAME)
 {
-  flow_allocator_ = flow_allocator;
+		flow_allocator_ = flow_allocator;
 }
 
 void FlowSetRIBObject::remoteCreateObject(
     void * object_value, const std::string& object_name,
     int invoke_id, rina::CDAPSessionDescriptor * session_descriptor)
 {
-  flow_allocator_->createFlowRequestMessageReceived(
-      (Flow *) object_value, object_name, invoke_id,
-      session_descriptor->port_id_);
+		flow_allocator_->createFlowRequestMessageReceived((Flow *) object_value,
+														  object_name,
+														  invoke_id,
+														  session_descriptor->port_id_);
 }
 
 void FlowSetRIBObject::createObject(const std::string& objectClass,
                                     const std::string& objectName,
                                     const void* objectValue)
 {
-  FlowRIBObject * flowRIBObject;
+		FlowRIBObject * flowRIBObject;
 
-  void * fai = const_cast<void *>(objectValue);
-  flowRIBObject = new FlowRIBObject(ipc_process_, objectName,
-                                    objectClass,
-                                    (FlowAllocatorInstance *) fai);
-  add_child(flowRIBObject);
-  rib_daemon_->addRIBObject(flowRIBObject);
+		void * fai = const_cast<void *>(objectValue);
+		flowRIBObject = new FlowRIBObject(ipc_process_,
+										 objectName,
+                                         objectClass,
+                                         (FlowAllocatorInstance *) fai);
+		add_child(flowRIBObject);
+		rib_daemon_->addRIBObject(flowRIBObject);
 }
 
 const void* FlowSetRIBObject::get_value() const
 {
-  return flow_allocator_;
+		return flow_allocator_;
 }
 
 // Class Neighbor RIB object
@@ -107,27 +109,27 @@ QoSCubeRIBObject::QoSCubeRIBObject(IPCProcess* ipc_process,
 
 std::string QoSCubeRIBObject::get_displayable_value()
 {
-  const rina::QoSCube * cube = (const rina::QoSCube *) get_value();
-  std::stringstream ss;
-  ss << "Name: " << name_ << "; Id: " << cube->id_;
-  ss << "; Jitter: " << cube->jitter_ << "; Delay: " << cube->delay_
-     << std::endl;
-  ss << "In oder delivery: " << cube->ordered_delivery_;
-  ss << "; Partial delivery allowed: " << cube->partial_delivery_
-     << std::endl;
-  ss << "Max allowed gap between SDUs: " << cube->max_allowable_gap_;
-  ss << "; Undetected bit error rate: "
-     << cube->undetected_bit_error_rate_ << std::endl;
-  ss << "Average bandwidth (bytes/s): " << cube->average_bandwidth_;
-  ss << "; Average SDU bandwidth (bytes/s): "
-     << cube->average_sdu_bandwidth_ << std::endl;
-  ss << "Peak bandwidth duration (ms): "
-     << cube->peak_bandwidth_duration_;
-  ss << "; Peak SDU bandwidth duration (ms): "
-     << cube->peak_sdu_bandwidth_duration_ << std::endl;
-  rina::ConnectionPolicies con = cube->efcp_policies_;
-  ss << "EFCP policies: " << con.toString();
-  return ss.str();
+		const rina::QoSCube * cube = (const rina::QoSCube *) get_value();
+		std::stringstream ss;
+		ss << "Name: " << name_ << "; Id: " << cube->id_;
+		ss << "; Jitter: " << cube->jitter_ << "; Delay: " << cube->delay_
+		   << std::endl;
+		ss << "In oder delivery: " << cube->ordered_delivery_;
+		ss << "; Partial delivery allowed: " << cube->partial_delivery_
+           << std::endl;
+		ss << "Max allowed gap between SDUs: " << cube->max_allowable_gap_;
+		ss << "; Undetected bit error rate: "
+		   << cube->undetected_bit_error_rate_ << std::endl;
+		ss << "Average bandwidth (bytes/s): " << cube->average_bandwidth_;
+		ss << "; Average SDU bandwidth (bytes/s): "
+		   << cube->average_sdu_bandwidth_ << std::endl;
+		ss << "Peak bandwidth duration (ms): "
+	       << cube->peak_bandwidth_duration_;
+		ss << "; Peak SDU bandwidth duration (ms): "
+		   << cube->peak_sdu_bandwidth_duration_ << std::endl;
+		rina::ConnectionPolicies con = cube->efcp_policies_;
+		ss << "EFCP policies: " << con.toString();
+		return ss.str();
 }
 
 //Class QoS Cube Set RIB Object
@@ -143,472 +145,467 @@ void QoSCubeSetRIBObject::remoteCreateObject(
     void * object_value, const std::string& object_name,
     int invoke_id, rina::CDAPSessionDescriptor * session_descriptor)
 {
-  //TODO, depending on IEncoder
-  (void) object_value;
-  (void) object_name;
-  (void) invoke_id;
-  (void) session_descriptor;
-  LOG_ERR("Missing code");
+		//TODO, depending on IEncoder
+		(void) object_value;
+		(void) object_name;
+		(void) invoke_id;
+		(void) session_descriptor;
+		LOG_ERR("Missing code");
 }
 
 void QoSCubeSetRIBObject::createObject(const std::string& objectClass,
                                        const std::string& objectName,
                                        const void* objectValue)
 {
-  QoSCubeRIBObject * ribObject = new QoSCubeRIBObject(
-      ipc_process_, objectClass, objectName,
-      (const rina::QoSCube*) objectValue);
-  add_child(ribObject);
-  rib_daemon_->addRIBObject(ribObject);
+		QoSCubeRIBObject * ribObject = new QoSCubeRIBObject(ipc_process_,
+															objectClass,
+															objectName,
+															(const rina::QoSCube*) objectValue);
+		add_child(ribObject);
+		rib_daemon_->addRIBObject(ribObject);
 }
 
 void QoSCubeSetRIBObject::deleteObject(const void* objectValue)
 {
-  if (objectValue) {
-    LOG_WARN("Object value should have been NULL");
-  }
+		if (objectValue) {
+				LOG_WARN("Object value should have been NULL");
+		}
 
-  std::list<std::string> childNames;
-  std::list<BaseRIBObject*>::const_iterator childrenIt;
-  std::list<std::string>::const_iterator namesIt;
+		std::list<std::string> childNames;
+		std::list<BaseRIBObject*>::const_iterator childrenIt;
+		std::list<std::string>::const_iterator namesIt;
 
-  for (childrenIt = get_children().begin();
-      childrenIt != get_children().end(); ++childrenIt) {
-    childNames.push_back((*childrenIt)->name_);
-  }
+		for (childrenIt = get_children().begin();
+				childrenIt != get_children().end(); ++childrenIt) {
+				childNames.push_back((*childrenIt)->name_);
+		}
 
-  for (namesIt = childNames.begin(); namesIt != childNames.end();
-      ++namesIt) {
-    remove_child(*namesIt);
-  }
+		for (namesIt = childNames.begin(); namesIt != childNames.end();
+					++namesIt) {
+				remove_child(*namesIt);
+		}
 }
 
 const void* QoSCubeSetRIBObject::get_value() const
 {
-  return 0;
+		return 0;
 }
 
 //Class Flow Allocator
 FlowAllocator::FlowAllocator() : IFlowAllocator()
 {
-  ipcp = 0;
-  rib_daemon_ = 0;
-  cdap_session_manager_ = 0;
-  encoder_ = 0;
-  namespace_manager_ = 0;
+		ipcp = 0;
+		rib_daemon_ = 0;
+		cdap_session_manager_ = 0;
+		encoder_ = 0;
+		namespace_manager_ = 0;
 }
 
-FlowAllocator::~FlowAllocator()
+IFlowAllocatorInstance * FlowAllocator::getFAI(int portId)
 {
-  flow_allocator_instances_.deleteValues();
+		std::stringstream ss;
+		ss << portId;
+		IFlowAllocatorInstance * fai =
+				dynamic_cast<IFlowAllocatorInstance*>(get_instance(ss.str()));
+		return fai;
 }
 
-IFlowAllocatorInstance * FlowAllocator::getFAI(int portId) {
-	return flow_allocator_instances_.find(portId);
-}
+void FlowAllocator::set_application_process(rina::ApplicationProcess * ap)
+{
+		if (!ap)
+				return;
 
-void FlowAllocator::set_application_process(rina::ApplicationProcess * ap) {
-	if (!ap)
-			return;
-
-	app = ap;
-	ipcp = dynamic_cast<IPCProcess*>(app);
-	if (!ipcp) {
-			LOG_ERR("Bogus instance of IPCP passed, return");
-			return;
-	}
-  rib_daemon_ = ipcp->rib_daemon_;
-  encoder_ = ipcp->encoder_;
-  cdap_session_manager_ = ipcp->cdap_session_manager_;
-  namespace_manager_ = ipcp->namespace_manager_;
-  populateRIB();
+		app = ap;
+		ipcp = dynamic_cast<IPCProcess*>(app);
+		if (!ipcp) {
+				LOG_ERR("Bogus instance of IPCP passed, return");
+				return;
+		}
+		rib_daemon_ = ipcp->rib_daemon_;
+		encoder_ = ipcp->encoder_;
+		cdap_session_manager_ = ipcp->cdap_session_manager_;
+		namespace_manager_ = ipcp->namespace_manager_;
+		populateRIB();
 }
 
 void FlowAllocator::set_dif_configuration(
     const rina::DIFConfiguration& dif_configuration)
 {
-  //Create QoS cubes RIB objects
-  std::list<rina::QoSCube*>::const_iterator it;
-  std::stringstream ss;
-  const std::list<rina::QoSCube*>& cubes = dif_configuration
-      .efcp_configuration_.qos_cubes_;
-  for (it = cubes.begin(); it != cubes.end(); ++it) {
-    ss << EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_NAME
-       << EncoderConstants::SEPARATOR;
-    ss << (*it)->name_;
-    rib_daemon_->createObject(
-        EncoderConstants::QOS_CUBE_RIB_OBJECT_CLASS, ss.str(), (*it),
-        0);
-    ss.str(std::string());
-    ss.clear();
-  }
+		//Create QoS cubes RIB objects
+		std::list<rina::QoSCube*>::const_iterator it;
+		std::stringstream ss;
+		const std::list<rina::QoSCube*>& cubes = dif_configuration
+				.efcp_configuration_.qos_cubes_;
+		for (it = cubes.begin(); it != cubes.end(); ++it) {
+				ss << EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_NAME
+				   << EncoderConstants::SEPARATOR;
+				ss << (*it)->name_;
+				rib_daemon_->createObject(EncoderConstants::QOS_CUBE_RIB_OBJECT_CLASS,
+										  ss.str(), (*it), 0);
+				ss.str(std::string());
+				ss.clear();
+		}
 }
 
 int FlowAllocator::select_policy_set(const std::string& path,
                                      const std::string& name)
 {
-  return select_policy_set_common(get_name(), path, name);
+		return select_policy_set_common(get_name(), path, name);
 }
 
 int FlowAllocator::set_policy_set_param(const std::string& path,
                                         const std::string& name,
                                         const std::string& value)
 {
-  return set_policy_set_param_common(path, name, value);
+		return set_policy_set_param_common(path, name, value);
 }
 
 void FlowAllocator::populateRIB()
 {
-  try {
-    BaseIPCPRIBObject * object = new FlowSetRIBObject(ipcp,
-                                                      this);
-    rib_daemon_->addRIBObject(object);
-    object = new QoSCubeSetRIBObject(ipcp);
-    rib_daemon_->addRIBObject(object);
-    object = new DataTransferConstantsRIBObject(ipcp);
-    rib_daemon_->addRIBObject(object);
-  } catch (rina::Exception &e) {
-    LOG_ERR("Problems adding object to the RIB : %s", e.what());
-  }
+		try {
+				BaseIPCPRIBObject * object = new FlowSetRIBObject(ipcp, this);
+				rib_daemon_->addRIBObject(object);
+				object = new QoSCubeSetRIBObject(ipcp);
+				rib_daemon_->addRIBObject(object);
+				object = new DataTransferConstantsRIBObject(ipcp);
+				rib_daemon_->addRIBObject(object);
+		} catch (rina::Exception &e) {
+				LOG_ERR("Problems adding object to the RIB : %s", e.what());
+		}
 }
 
 void FlowAllocator::createFlowRequestMessageReceived(
     Flow * flow, const std::string& object_name, int invoke_id,
     int underlyingPortId)
 {
-  IFlowAllocatorInstance * flowAllocatorInstance = 0;
-  unsigned int myAddress = 0;
-  int portId = 0;
+		IFlowAllocatorInstance * fai = 0;
+		unsigned int myAddress = 0;
+		int portId = 0;
 
-  unsigned int address = namespace_manager_->getDFTNextHop(
-      flow->destination_naming_info);
-  myAddress = ipcp->get_address();
-  if (address == 0) {
-    LOG_ERR(
-        "The directory forwarding table returned no entries when looking up %s",
-        flow->destination_naming_info.toString().c_str());
-    return;
-  }
+		unsigned int address = namespace_manager_->getDFTNextHop(flow->destination_naming_info);
+		myAddress = ipcp->get_address();
+		if (address == 0) {
+				LOG_ERR("The directory forwarding table returned no entries when looking up %s",
+						flow->destination_naming_info.toString().c_str());
+				return;
+		}
 
-  if (address == myAddress) {
-    //There is an entry and the address is this IPC Process, create a FAI, extract the Flow
-    //object from the CDAP message and call the FAI
-    try {
-      portId = rina::extendedIPCManager->allocatePortId(
-          flow->destination_naming_info);
-    } catch (rina::Exception &e) {
-      LOG_ERR(
-          "Problems requesting an available port-id: %s. Ignoring the Flow allocation request",
-          e.what());
-      return;
-    }
+		if (address == myAddress) {
+				//There is an entry and the address is this IPC Process, create a FAI, extract
+				//the Flow object from the CDAP message and call the FAI
+				try {
+						portId = rina::extendedIPCManager->allocatePortId(
+									flow->destination_naming_info);
+				} catch (rina::Exception &e) {
+						LOG_ERR("Problems requesting a port-id: %s. Ignoring the Flow allocation request",
+								e.what());
+						return;
+				}
 
-    LOG_DBG(
-        "The destination application process is reachable through me. Assigning the local port-id %d to the flow",
-        portId);
-    flowAllocatorInstance = new FlowAllocatorInstance(
-    		ipcp, this, cdap_session_manager_, portId);
-    flow_allocator_instances_.put(portId, flowAllocatorInstance);
+				LOG_DBG("The destination AP is reachable through me. Assigning port-id %d", portId);
+				std::stringstream ss;
+				ss << portId;
+				fai = new FlowAllocatorInstance(ipcp, this, cdap_session_manager_, portId, ss.str());
+				add_instance(fai);
 
-    //TODO check if this operation throws an exception an react accordingly
-    flowAllocatorInstance->createFlowRequestMessageReceived(
-        flow, object_name, invoke_id, underlyingPortId);
-    return;
-  }
+				//TODO check if this operation throws an exception an react accordingly
+				fai->createFlowRequestMessageReceived(flow, object_name, invoke_id, underlyingPortId);
+				return;
+		}
 
-  //The address is not this IPC process, forward the CDAP message to that address increment the hop
-  //count of the Flow object extract the flow object from the CDAP message
-  flow->hop_count = flow->hop_count - 1;
-  if (flow->hop_count <= 0) {
-    //TODO send negative create Flow response CDAP message to the source IPC process, specifying
-    //that the application process could not be found before the hop count expired
-    LOG_ERR("Missing code");
-  }
+		//The address is not this IPC process, forward the CDAP message to that address increment the hop
+		//count of the Flow object extract the flow object from the CDAP message
+		flow->hop_count = flow->hop_count - 1;
+		if (flow->hop_count <= 0) {
+				//TODO send negative create Flow response CDAP message to the source IPC process,
+				//saying that the application process could not be found before the hop count expired
+				LOG_ERR("Missing code");
+		}
 
-  LOG_ERR("Missing code");
+		LOG_ERR("Missing code");
 }
 
 void FlowAllocator::replyToIPCManager(
     const rina::FlowRequestEvent& event, int result)
 {
-  try {
-    rina::extendedIPCManager->allocateFlowRequestResult(event,
+		try {
+			rina::extendedIPCManager->allocateFlowRequestResult(event,
                                                         result);
-  } catch (rina::Exception &e) {
-    LOG_ERR("Problems communicating with the IPC Manager Daemon: %s",
-            e.what());
-  }
+		} catch (rina::Exception &e) {
+			LOG_ERR("Problems communicating with the IPC Manager Daemon: %s",
+					e.what());
+		}
 }
 
 void FlowAllocator::submitAllocateRequest(
     rina::FlowRequestEvent& event)
 {
-  int portId = 0;
-  IFlowAllocatorInstance * flowAllocatorInstance;
+		int portId = 0;
+		IFlowAllocatorInstance * fai;
 
-  try {
-    portId = rina::extendedIPCManager->allocatePortId(
-        event.localApplicationName);
-    LOG_DBG("Got assigned port-id %d", portId);
-  } catch (rina::Exception &e) {
-    LOG_ERR(
-        "Problems requesting an available port-id to the Kernel IPC Manager: %s",
-        e.what());
-    replyToIPCManager(event, -1);
-  }
+		try {
+				portId = rina::extendedIPCManager->allocatePortId(
+						event.localApplicationName);
+				LOG_DBG("Got assigned port-id %d", portId);
+		} catch (rina::Exception &e) {
+				LOG_ERR("Problems requesting an available port-id to the Kernel IPC Manager: %s",
+						e.what());
+				replyToIPCManager(event, -1);
+		}
 
-  event.portId = portId;
-  flowAllocatorInstance = new FlowAllocatorInstance(
-		  ipcp, this, cdap_session_manager_, portId);
-  flow_allocator_instances_.put(portId, flowAllocatorInstance);
+		event.portId = portId;
+		std::stringstream ss;
+		ss << portId;
+		fai = new FlowAllocatorInstance(ipcp, this, cdap_session_manager_, portId, ss.str());
+		add_instance(fai);
 
-  try {
-    flowAllocatorInstance->submitAllocateRequest(event);
-  } catch (rina::Exception &e) {
-    LOG_ERR("Problems allocating flow: %s", e.what());
-    flow_allocator_instances_.erase(portId);
-    delete flowAllocatorInstance;
+		try {
+				fai->submitAllocateRequest(event);
+		} catch (rina::Exception &e) {
+				LOG_ERR("Problems allocating flow: %s", e.what());
+				remove_instance(ss.str());
+				delete fai;
 
-    try {
-      rina::extendedIPCManager->deallocatePortId(portId);
-    } catch (rina::Exception &e) {
-      LOG_ERR("Problems releasing port-id %d: %s", portId, e.what());
-    }
-    replyToIPCManager(event, -1);
-  }
+				try {
+						rina::extendedIPCManager->deallocatePortId(portId);
+				} catch (rina::Exception &e) {
+						LOG_ERR("Problems releasing port-id %d: %s", portId, e.what());
+				}
+				replyToIPCManager(event, -1);
+		}
 }
 
 void FlowAllocator::processCreateConnectionResponseEvent(
     const rina::CreateConnectionResponseEvent& event)
 {
-  IFlowAllocatorInstance * flowAllocatorInstance;
-
-  flowAllocatorInstance = flow_allocator_instances_.find(
-      event.getPortId());
-  if (flowAllocatorInstance) {
-    flowAllocatorInstance->processCreateConnectionResponseEvent(
-        event);
-  } else {
-    LOG_ERR(
-        "Received create connection response event associated to unknown port-id %d",
-        event.getPortId());
-  }
+		std::stringstream ss;
+		ss << event.portId;
+		IFlowAllocatorInstance * fai =
+				dynamic_cast<IFlowAllocatorInstance*>(get_instance(ss.str()));
+		if (fai) {
+				fai->processCreateConnectionResponseEvent(event);
+		} else {
+				LOG_ERR("Received create connection response event associated to unknown port-id %d",
+						event.portId);
+		}
 }
 
 void FlowAllocator::submitAllocateResponse(
     const rina::AllocateFlowResponseEvent& event)
 {
-  IFlowAllocatorInstance * flowAllocatorInstance;
+		IFlowAllocatorInstance * fai;
 
-  LOG_DBG(
-      "Local application invoked allocate response with seq num %ud and result %d, ",
-      event.sequenceNumber, event.result);
+		LOG_DBG(
+				"Local application invoked allocate response with seq num %ud and result %d, ",
+				event.sequenceNumber, event.result);
 
-  std::list<IFlowAllocatorInstance *> fais = flow_allocator_instances_
-      .getEntries();
-  std::list<IFlowAllocatorInstance *>::iterator iterator;
-  for (iterator = fais.begin(); iterator != fais.end(); ++iterator) {
-    if ((*iterator)->get_allocate_response_message_handle()
-        == event.sequenceNumber) {
-      flowAllocatorInstance = *iterator;
-      flowAllocatorInstance->submitAllocateResponse(event);
-      return;
-    }
-  }
+		std::list<rina::ApplicationEntityInstance *> fais = get_all_instances();
+		std::list<rina::ApplicationEntityInstance *>::iterator iterator;
+		for (iterator = fais.begin(); iterator != fais.end(); ++iterator) {
+				fai = dynamic_cast<IFlowAllocatorInstance*>(*iterator);
+				if (!fai)
+						continue;
+				if (fai->get_allocate_response_message_handle() == event.sequenceNumber) {
+						fai->submitAllocateResponse(event);
+						return;
+				}
+		}
 
-  LOG_ERR("Could not find FAI with handle %ud", event.sequenceNumber);
+		LOG_ERR("Could not find FAI with handle %ud", event.sequenceNumber);
 }
 
 void FlowAllocator::processCreateConnectionResultEvent(
     const rina::CreateConnectionResultEvent& event)
 {
-  IFlowAllocatorInstance * flowAllocatorInstance;
-
-  flowAllocatorInstance = flow_allocator_instances_.find(
-      event.getPortId());
-  if (!flowAllocatorInstance) {
-    LOG_ERR("Problems looking for FAI at portId %d",
-            event.getPortId());
-    try {
-      rina::extendedIPCManager->deallocatePortId(event.getPortId());
-    } catch (rina::Exception &e) {
-      LOG_ERR(
-          "Problems requesting IPC Manager to deallocate port-id %d: %s",
-          event.getPortId(), e.what());
-    }
-  } else {
-    flowAllocatorInstance->processCreateConnectionResultEvent(event);
-  }
+		std::stringstream ss;
+		ss << event.portId;
+		IFlowAllocatorInstance * fai =
+				dynamic_cast<IFlowAllocatorInstance*>(get_instance(ss.str()));
+		if (!fai) {
+				LOG_ERR("Problems looking for FAI at portId %d", event.portId);
+				try {
+						rina::extendedIPCManager->deallocatePortId(event.getPortId());
+				} catch (rina::Exception &e) {
+						LOG_ERR("Problems requesting IPC Manager to deallocate port-id %d: %s",
+								event.portId, e.what());
+				}
+		} else {
+				fai->processCreateConnectionResultEvent(event);
+		}
 }
 
 void FlowAllocator::processUpdateConnectionResponseEvent(
     const rina::UpdateConnectionResponseEvent& event)
 {
-  IFlowAllocatorInstance * flowAllocatorInstance;
-
-  flowAllocatorInstance = flow_allocator_instances_.find(
-      event.getPortId());
-  if (!flowAllocatorInstance) {
-    LOG_ERR("Problems looking for FAI at portId %d",
-            event.getPortId());
-    try {
-      rina::extendedIPCManager->deallocatePortId(event.getPortId());
-    } catch (rina::Exception &e) {
-      LOG_ERR(
-          "Problems requesting IPC Manager to deallocate port-id %d: %s",
-          event.getPortId(), e.what());
-    }
-  } else {
-    flowAllocatorInstance->processUpdateConnectionResponseEvent(
-        event);
-  }
+		std::stringstream ss;
+		ss << event.portId;
+		IFlowAllocatorInstance * fai =
+				dynamic_cast<IFlowAllocatorInstance*>(get_instance(ss.str()));
+		if (!fai) {
+				LOG_ERR("Problems looking for FAI at portId %d", event.portId);
+				try {
+						rina::extendedIPCManager->deallocatePortId(event.portId);
+				} catch (rina::Exception &e) {
+						LOG_ERR("Problems requesting IPC Manager to deallocate port-id %d: %s",
+								event.portId, e.what());
+				}
+		} else {
+				fai->processUpdateConnectionResponseEvent(event);
+		}
 }
 
 void FlowAllocator::submitDeallocate(
     const rina::FlowDeallocateRequestEvent& event)
 {
-  IFlowAllocatorInstance * flowAllocatorInstance;
+		std::stringstream ss;
+		ss << event.portId;
+		IFlowAllocatorInstance * fai =
+				dynamic_cast<IFlowAllocatorInstance*>(get_instance(ss.str()));
 
-  flowAllocatorInstance = flow_allocator_instances_.find(
-      event.portId);
-  if (!flowAllocatorInstance) {
-    LOG_ERR("Problems looking for FAI at portId %d", event.portId);
-    try {
-      rina::extendedIPCManager->deallocatePortId(event.portId);
-    } catch (rina::Exception &e) {
-      LOG_ERR(
-          "Problems requesting IPC Manager to deallocate port-id %d: %s",
-          event.portId, e.what());
-    }
+		if (!fai) {
+				LOG_ERR("Problems looking for FAI at portId %d", event.portId);
+				try {
+						rina::extendedIPCManager->deallocatePortId(event.portId);
+				} catch (rina::Exception &e) {
+						LOG_ERR(
+								"Problems requesting IPC Manager to deallocate port-id %d: %s",
+								event.portId, e.what());
+				}
 
-    try {
-      rina::extendedIPCManager->notifyflowDeallocated(event, -1);
-    } catch (rina::Exception &e) {
-      LOG_ERR("Error communicating with the IPC Manager: %s",
-              e.what());
-    }
-  } else {
-    flowAllocatorInstance->submitDeallocate(event);
-    try {
-      rina::extendedIPCManager->notifyflowDeallocated(event, 0);
-    } catch (rina::Exception &e) {
-      LOG_ERR("Error communicating with the IPC Manager: %s",
-              e.what());
-    }
-  }
+				try {
+						rina::extendedIPCManager->notifyflowDeallocated(event, -1);
+				} catch (rina::Exception &e) {
+						LOG_ERR("Error communicating with the IPC Manager: %s",
+						e.what());
+				}
+		} else {
+				fai->submitDeallocate(event);
+				try {
+						rina::extendedIPCManager->notifyflowDeallocated(event, 0);
+				} catch (rina::Exception &e) {
+						LOG_ERR("Error communicating with the IPC Manager: %s",
+						e.what());
+				}
+		}
 }
 
 void FlowAllocator::removeFlowAllocatorInstance(int portId)
 {
-  IFlowAllocatorInstance * fai = flow_allocator_instances_.erase(
-      portId);
-  if (fai) {
-    delete fai;
-  }
+		std::stringstream ss;
+		ss << portId;
+		IFlowAllocatorInstance * fai =
+				dynamic_cast<IFlowAllocatorInstance*>(remove_instance(ss.str()));
+		if (fai) {
+				delete fai;
+		}
 }
 
 std::list<rina::QoSCube*> FlowAllocator::getQoSCubes()
 {
-  std::list<rina::QoSCube *> qosCubes;
-  std::list<rina::BaseRIBObject *> children;
+		std::list<rina::QoSCube *> qosCubes;
+		std::list<rina::BaseRIBObject *> children;
 
-  rina::BaseRIBObject * ribObject = 0;
-  ribObject = ipcp->rib_daemon_->readObject(
-      EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_CLASS,
-      EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_NAME);
-  if (ribObject != 0) {
-    children = ribObject->get_children();
-    for (std::list<rina::BaseRIBObject *>::const_iterator it =
-        children.begin(); it != children.end(); ++it) {
-      qosCubes.push_back((rina::QoSCube *) (*it)->get_value());
-    }
-  }
+		rina::BaseRIBObject * ribObject = 0;
+		ribObject = ipcp->rib_daemon_->readObject(
+					EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_CLASS,
+					EncoderConstants::QOS_CUBE_SET_RIB_OBJECT_NAME);
+		if (ribObject != 0) {
+				children = ribObject->get_children();
+				for (std::list<rina::BaseRIBObject *>::const_iterator it =
+						children.begin(); it != children.end(); ++it) {
+						qosCubes.push_back((rina::QoSCube *) (*it)->get_value());
+				}
+		}
 
-  return qosCubes;
+		return qosCubes;
 }
 
 //Class Flow Allocator Instance
 FlowAllocatorInstance::FlowAllocatorInstance(
     IPCProcess * ipc_process, IFlowAllocator * flow_allocator,
     rina::CDAPSessionManagerInterface * cdap_session_manager,
-    int port_id)
+    int port_id, const std::string& instance_id) : IFlowAllocatorInstance(instance_id)
 {
-  initialize(ipc_process, flow_allocator, port_id);
-  cdap_session_manager_ = cdap_session_manager;
-  LOG_DBG(
-      "Created flow allocator instance to manage the flow identified by portId %d ",
-      port_id);
+		initialize(ipc_process, flow_allocator, port_id);
+		cdap_session_manager_ = cdap_session_manager;
+		LOG_DBG("Created flow allocator instance to manage the flow identified by portId %d ",
+				port_id);
 }
 
 FlowAllocatorInstance::FlowAllocatorInstance(
     IPCProcess * ipc_process, IFlowAllocator * flow_allocator,
-    int port_id)
+    int port_id, const std::string& instance_id) : IFlowAllocatorInstance(instance_id)
 {
-  initialize(ipc_process, flow_allocator, port_id);
-  LOG_DBG(
-      "Created flow allocator instance to manage the flow identified by portId %d ",
-      port_id);
+		initialize(ipc_process, flow_allocator, port_id);
+		LOG_DBG(
+				"Created flow allocator instance to manage the flow identified by portId %d ",
+				port_id);
 }
 
 FlowAllocatorInstance::~FlowAllocatorInstance()
 {
-	if (flow_) {
-		delete flow_;
-	}
+		if (flow_) {
+			delete flow_;
+		}
 
-	if (lock_) {
-		delete lock_;
-	}
+		if (lock_) {
+			delete lock_;
+		}
 
-	if (timer_) {
-		delete timer_;
-	}
+		if (timer_) {
+			delete timer_;
+		}
 }
 
 void FlowAllocatorInstance::initialize(
     IPCProcess * ipc_process, IFlowAllocator * flow_allocator,
     int port_id)
 {
-  flow_allocator_ = flow_allocator;
-  ipc_process_ = ipc_process;
-  port_id_ = port_id;
-  rib_daemon_ = ipc_process->rib_daemon_;
-  encoder_ = ipc_process->encoder_;
-  namespace_manager_ = ipc_process->namespace_manager_;
-  security_manager_ = ipc_process->security_manager_;
-  state = NO_STATE;
-  allocate_response_message_handle_ = 0;
-  underlying_port_id_ = 0;
-  flow_ = 0;
-  lock_ = new rina::Lockable();
-  timer_ = new rina::Timer();
+		flow_allocator_ = flow_allocator;
+		ipc_process_ = ipc_process;
+		port_id_ = port_id;
+		rib_daemon_ = ipc_process->rib_daemon_;
+		encoder_ = ipc_process->encoder_;
+		namespace_manager_ = ipc_process->namespace_manager_;
+		security_manager_ = ipc_process->security_manager_;
+		state = NO_STATE;
+		allocate_response_message_handle_ = 0;
+		underlying_port_id_ = 0;
+		flow_ = 0;
+		lock_ = new rina::Lockable();
+		timer_ = new rina::Timer();
+}
+
+void FlowAllocatorInstance::set_application_entity(rina::ApplicationEntity * app_entity)
+{
+		ae = app_entity;
 }
 
 int FlowAllocatorInstance::get_port_id() const
 {
-  return port_id_;
+		return port_id_;
 }
 
 Flow * FlowAllocatorInstance::get_flow() const
 {
-  return flow_;
+		return flow_;
 }
 
 bool FlowAllocatorInstance::isFinished() const
 {
-  return state == FINISHED;
+		return state == FINISHED;
 }
 
 unsigned int FlowAllocatorInstance::get_allocate_response_message_handle() const
 {
-  unsigned int t;
+		unsigned int t;
 
-  {
-    rina::ScopedLock g(*lock_);
-    t = allocate_response_message_handle_;
-  }
+		{
+				rina::ScopedLock g(*lock_);
+				t = allocate_response_message_handle_;
+		}
 
-  return t;
+		return t;
 }
 
 void FlowAllocatorInstance::set_allocate_response_message_handle(

--- a/rinad/src/ipcp/flow-allocator.h
+++ b/rinad/src/ipcp/flow-allocator.h
@@ -32,8 +32,11 @@
 namespace rinad {
 
 /// Flow Allocator Instance Interface
-class IFlowAllocatorInstance : public rina::BaseCDAPResponseMessageHandler {
+class IFlowAllocatorInstance : public rina::BaseCDAPResponseMessageHandler,
+							   public rina::ApplicationEntityInstance {
 public:
+	IFlowAllocatorInstance(const std::string& instance_id) :
+		rina::ApplicationEntityInstance(instance_id) { };
 	virtual ~IFlowAllocatorInstance() {
 	}
 	;
@@ -173,7 +176,7 @@ public:
 class FlowAllocator: public IFlowAllocator {
 public:
 	FlowAllocator();
-	~FlowAllocator();
+	~FlowAllocator() { };
 	IFlowAllocatorInstance * getFAI(int portId);
 	void set_application_process(rina::ApplicationProcess * ap);
 	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
@@ -200,9 +203,6 @@ public:
         void destroyFlow(Flow *flow) { if (flow) delete flow; }
 
 private:
-	/// Flow allocator instances, each one associated to a port-id
-	rina::ThreadSafeMapOfPointers<int, IFlowAllocatorInstance> flow_allocator_instances_;
-
 	IPCPRIBDaemon * rib_daemon_;
 	rina::CDAPSessionManagerInterface * cdap_session_manager_;
 	rina::IMasterEncoder * encoder_;
@@ -233,10 +233,12 @@ public:
 	FlowAllocatorInstance(IPCProcess * ipc_process,
 			IFlowAllocator * flow_allocator,
 			rina::CDAPSessionManagerInterface * cdap_session_manager,
-			int port_id);
+			int port_id, const std::string& instance_id);
 	FlowAllocatorInstance(IPCProcess * ipc_process,
-			IFlowAllocator * flow_allocator, int port_id);
+			IFlowAllocator * flow_allocator, int port_id,
+			const std::string& instance_id);
 	~FlowAllocatorInstance();
+	void set_application_entity(rina::ApplicationEntity * ae);
 	int get_port_id() const;
 	Flow * get_flow() const;
 	bool isFinished() const;

--- a/rinad/src/ipcp/flow-allocator.h
+++ b/rinad/src/ipcp/flow-allocator.h
@@ -175,7 +175,7 @@ public:
 	FlowAllocator();
 	~FlowAllocator();
 	IFlowAllocatorInstance * getFAI(int portId);
-	void set_ipc_process(IPCProcess * ipc_process);
+	void set_application_process(rina::ApplicationProcess * ap);
 	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
         int select_policy_set(const std::string& path, const std::string& name);
         int set_policy_set_param(const std::string& path,

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -40,67 +40,67 @@ namespace rinad {
 //Class IPCProcessImpl
 IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& nm,
 		unsigned short id, unsigned int ipc_manager_port,
-		std::string log_level, std::string log_file) {
-	try {
-		std::stringstream ss;
-		ss << IPCP_LOG_FILE_PREFIX << "-" << id;
-		rina::initialize(log_level, log_file);
-		rina::extendedIPCManager->ipcManagerPort = ipc_manager_port;
-		rina::extendedIPCManager->ipcProcessId = id;
-		rina::kernelIPCProcess->ipcProcessId = id;
-		LOG_INFO("Librina initialized");
-	} catch (rina::Exception &e) {
-        std::cerr << "Cannot initialize librina" << std::endl;
-        exit(EXIT_FAILURE);
-	}
+		std::string log_level, std::string log_file) : IPCProcess(nm.processName, nm.processInstance)
+{
+		try {
+				std::stringstream ss;
+				ss << IPCP_LOG_FILE_PREFIX << "-" << id;
+				rina::initialize(log_level, log_file);
+				rina::extendedIPCManager->ipcManagerPort = ipc_manager_port;
+				rina::extendedIPCManager->ipcProcessId = id;
+				rina::kernelIPCProcess->ipcProcessId = id;
+				LOG_INFO("Librina initialized");
+		} catch (rina::Exception &e) {
+			std::cerr << "Cannot initialize librina" << std::endl;
+			exit(EXIT_FAILURE);
+		}
 
-	name_ = nm;
-	state = NOT_INITIALIZED;
-	lock_ = new rina::Lockable();
+		state = NOT_INITIALIZED;
+		lock_ = new rina::Lockable();
 
-        // Load the default pluggable components
+        	// Load the default pluggable components
         if (plugin_load("default")) {
-                throw rina::Exception("Failed to load default plugin");
+        		throw rina::Exception("Failed to load default plugin");
         }
 
-	// Initialize subcomponents
-	init_cdap_session_manager();
-	init_encoder();
+        // Initialize application entities
+        init_cdap_session_manager();
+        init_encoder();
 
-	delimiter_ = 0; //TODO initialize Delimiter once it is implemented
-	enrollment_task_ = new EnrollmentTask();
-	flow_allocator_ = new FlowAllocator();
-	namespace_manager_ = new NamespaceManager();
-	resource_allocator_ = new ResourceAllocator();
-	security_manager_ = new SecurityManager();
-	routing_component_ = new RoutingComponent();
-	rib_daemon_ = new IPCPRIBDaemonImpl();
+        delimiter_ = 0; //TODO initialize Delimiter once it is implemented
+        enrollment_task_ = new EnrollmentTask();
+        flow_allocator_ = new FlowAllocator();
+        namespace_manager_ = new NamespaceManager();
+        resource_allocator_ = new ResourceAllocator();
+        security_manager_ = new SecurityManager();
+        routing_component_ = new RoutingComponent();
+        rib_daemon_ = new IPCPRIBDaemonImpl();
 
-	rib_daemon_->set_ipc_process(this);
-	enrollment_task_->set_ipc_process(this);
-	resource_allocator_->set_ipc_process(this);
-	namespace_manager_->set_ipc_process(this);
-	flow_allocator_->set_ipc_process(this);
-	security_manager_->set_ipc_process(this);
-	routing_component_->set_ipc_process(this);
+		add_entity(rib_daemon_);
+		add_entity(enrollment_task_);
+		add_entity(resource_allocator_);
+		add_entity(namespace_manager_);
+		add_entity(flow_allocator_);
+		add_entity(security_manager_);
+		add_entity(routing_component_);
 
         // Select the default policy sets
-        security_manager_->select_policy_set(std::string(), "default");
+        security_manager_->select_policy_set(std::string(), rina::IPolicySet::DEFAULT_PS_SET_NAME);
         if (!security_manager_->ps) {
                 throw rina::Exception("Cannot create security manager policy-set");
         }
 
-        flow_allocator_->select_policy_set(std::string(), "default");
+        flow_allocator_->select_policy_set(std::string(), rina::IPolicySet::DEFAULT_PS_SET_NAME);
         if (!flow_allocator_->ps) {
                 throw rina::Exception("Cannot create flow allocator policy-set");
         }
 
-        namespace_manager_->select_policy_set(std::string(), "default");
+        namespace_manager_->select_policy_set(std::string(), rina::IPolicySet::DEFAULT_PS_SET_NAME);
         if (!namespace_manager_->ps) {
                 throw rina::Exception("Cannot create namespace manager policy-set");
         }
 
-        resource_allocator_->select_policy_set(std::string(), "default");
+        resource_allocator_->select_policy_set(std::string(), rina::IPolicySet::DEFAULT_PS_SET_NAME);
         if (!resource_allocator_->ps) {
                 throw rina::Exception("Cannot create resource allocator policy-set");
         }
@@ -110,17 +110,18 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
                 throw rina::Exception("Cannot create routing component policy-set");
         }
 
-	try {
-		rina::extendedIPCManager->notifyIPCProcessInitialized(name_);
-	} catch (rina::Exception &e) {
-		LOG_ERR("Problems communicating with IPC Manager: %s. Exiting... ", e.what());
-		exit(EXIT_FAILURE);
-	}
+        try {
+        		rina::ApplicationProcessNamingInformation naming_info(name_, instance_);
+        		rina::extendedIPCManager->notifyIPCProcessInitialized(naming_info);
+        } catch (rina::Exception &e) {
+        		LOG_ERR("Problems communicating with IPC Manager: %s. Exiting... ", e.what());
+        		exit(EXIT_FAILURE);
+        }
 
-	state = INITIALIZED;
+        state = INITIALIZED;
 
-	LOG_INFO("Initialized IPC Process with name: %s, instance %s, id %hu ",
-			name_.processName.c_str(), name_.processInstance.c_str(), id);
+        LOG_INFO("Initialized IPC Process with name: %s, instance %s, id %hu ",
+        		name_.c_str(), instance_.c_str(), id);
 }
 
 IPCProcessImpl::~IPCProcessImpl() {
@@ -618,7 +619,7 @@ int IPCProcessImpl::plugin_load(const std::string& plugin_name)
 {
         std::string plugin_path = PLUGINSDIR;
         void *handle = NULL;
-        plugin_init_function_t init_func;
+        rina::plugin_init_function_t init_func;
         char *errstr;
         int ret;
 
@@ -641,7 +642,7 @@ int IPCProcessImpl::plugin_load(const std::string& plugin_name)
         dlerror();
 
         /* Try to load the init() function. */
-        init_func = (plugin_init_function_t)dlsym(handle, "init");
+        init_func = (rina::plugin_init_function_t)dlsym(handle, "init");
 
         /* Check if an error occurred in dlsym(). */
         errstr = dlerror();
@@ -672,7 +673,7 @@ int IPCProcessImpl::plugin_load(const std::string& plugin_name)
 int IPCProcessImpl::plugin_unload(const std::string& plugin_name)
 {
         std::map< std::string, void * >::iterator mit;
-        std::vector< std::vector<PsFactory>::iterator > unpublish_list;
+        std::vector< std::vector<rina::PsFactory>::iterator > unpublish_list;
 
         mit = plugins_handles.find(plugin_name);
         if (mit == plugins_handles.end()) {
@@ -683,9 +684,9 @@ int IPCProcessImpl::plugin_unload(const std::string& plugin_name)
         // Look for all the policy-sets published by the plugin
         // Note: Here we assume the plugin name is used as the "name"
         // argument in the psFactoryPublish() calls.
-        for (std::vector<PsFactory>::iterator
-                it = components_factories.begin();
-                        it != components_factories.end(); it++) {
+        for (std::vector<rina::PsFactory>::iterator
+                it = ae_policy_factories.begin();
+                        it != ae_policy_factories.end(); it++) {
                 if (it->plugin_name == plugin_name) {
                         if (it->refcnt > 0) {
                                 LOG_ERR("Cannot unload plugin %s: it is "
@@ -698,7 +699,7 @@ int IPCProcessImpl::plugin_unload(const std::string& plugin_name)
 
         // Unpublish all the policy sets published by this plugin
         for (unsigned int i = 0; i < unpublish_list.size(); i++) {
-                psFactoryUnpublish(unpublish_list[i]->component,
+                psFactoryUnpublish(unpublish_list[i]->app_entity,
                                    unpublish_list[i]->name);
         }
 
@@ -709,54 +710,54 @@ int IPCProcessImpl::plugin_unload(const std::string& plugin_name)
         return 0;
 }
 
-std::vector<PsFactory>::iterator
-IPCProcessImpl::psFactoryLookup(const std::string& component,
-                                       const std::string& name)
+std::vector<rina::PsFactory>::iterator
+IPCProcessImpl::psFactoryLookup(const std::string& ae_name,
+                                const std::string& name)
 {
-        for (std::vector<PsFactory>::iterator
-                it = components_factories.begin();
-                        it != components_factories.end(); it++) {
-                if (it->component == component &&
+        for (std::vector<rina::PsFactory>::iterator
+                it = ae_policy_factories.begin();
+                        it != ae_policy_factories.end(); it++) {
+                if (it->app_entity == ae_name &&
                                 it->name == name) {
                         return it;
                 }
         }
 
-        return components_factories.end();
+        return ae_policy_factories.end();
 }
 
-int IPCProcessImpl::psFactoryPublish(const PsFactory& factory)
+int IPCProcessImpl::psFactoryPublish(const rina::PsFactory& factory)
 {
         // TODO check that factory.component is an existing component
 
         // Check if the (name, component) couple specified by 'factory'
         // has not already been published.
-        if (psFactoryLookup(factory.component, factory.name) !=
-                                                components_factories.end()) {
+        if (psFactoryLookup(factory.app_entity, factory.name) !=
+        							ae_policy_factories.end()) {
                 LOG_ERR("Factory %s for component %s already "
                                 "published", factory.name.c_str(),
-                                factory.component.c_str());
+                                factory.app_entity.c_str());
                 return -1;
         }
 
         // Add the new factory
-        components_factories.push_back(factory);
-        components_factories.back().refcnt = 0;
+        ae_policy_factories.push_back(factory);
+        ae_policy_factories.back().refcnt = 0;
 
         LOG_INFO("Pluggable component '%s'/'%s' [%s] published",
-                 factory.component.c_str(), factory.name.c_str(),
+                 factory.app_entity.c_str(), factory.name.c_str(),
                  factory.plugin_name.c_str());
 
         return 0;
 }
 
 int IPCProcessImpl::psFactoryUnpublish(const std::string& component,
-                                              const std::string& name)
+                                       const std::string& name)
 {
-        std::vector<PsFactory>::iterator fi;
+        std::vector<rina::PsFactory>::iterator fi;
 
         fi = psFactoryLookup(component, name);
-        if (fi == components_factories.end()) {
+        if (fi == ae_policy_factories.end()) {
                 LOG_ERR("Factory %s for component %s not "
                                 "published", name.c_str(),
                                 component.c_str());
@@ -764,24 +765,24 @@ int IPCProcessImpl::psFactoryUnpublish(const std::string& component,
         }
 
         LOG_INFO("Pluggable component '%s'/'%s' [%s] unpublished",
-                 fi->component.c_str(), fi->name.c_str(),
+                 fi->app_entity.c_str(), fi->name.c_str(),
                  fi->plugin_name.c_str());
 
-        components_factories.erase(fi);
+        ae_policy_factories.erase(fi);
 
         return 0;
 }
 
-IPolicySet *
+rina::IPolicySet *
 IPCProcessImpl::psCreate(const std::string& component,
-                                       const std::string& name,
-                                       IPCProcessComponent * context)
+                         const std::string& name,
+                         rina::ApplicationEntity * context)
 {
-        std::vector<PsFactory>::iterator it;
-        IPolicySet *ps = NULL;
+        std::vector<rina::PsFactory>::iterator it;
+        rina::IPolicySet *ps = NULL;
 
         it = psFactoryLookup(component, name);
-        if (it == components_factories.end()) {
+        if (it == ae_policy_factories.end()) {
                 LOG_ERR("Pluggable component %s/%s not found",
                         component.c_str(), name.c_str());
                 return NULL;
@@ -796,13 +797,13 @@ IPCProcessImpl::psCreate(const std::string& component,
 }
 
 int IPCProcessImpl::psDestroy(const std::string& component,
-                                            const std::string& name,
-                                            IPolicySet * instance)
+                              const std::string& name,
+                              rina::IPolicySet * instance)
 {
-        std::vector<PsFactory>::iterator it;
+        std::vector<rina::PsFactory>::iterator it;
 
         it = psFactoryLookup(component, name);
-        if (it == components_factories.end()) {
+        if (it == ae_policy_factories.end()) {
                 LOG_ERR("Pluggable component %s/%s not found",
                         component.c_str(), name.c_str());
                 return -1;

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -146,35 +146,35 @@ IPCProcessImpl::~IPCProcessImpl() {
 	}
 
 	if (flow_allocator_) {
-		psDestroy("flow-allocator",
+		psDestroy(IPCProcessComponent::FLOW_ALLOCATOR_AE_NAME,
                    flow_allocator_->selected_ps_name,
                    flow_allocator_->ps);
 		delete flow_allocator_;
 	}
 
 	if (namespace_manager_) {
-		psDestroy("namespace-manager",
+		psDestroy(IPCProcessComponent::NAMESPACE_MANAGER_AE_NAME,
                    namespace_manager_->selected_ps_name,
                    namespace_manager_->ps);
 		delete namespace_manager_;
 	}
 
 	if (resource_allocator_) {
-		psDestroy("resource-allocator",
+		psDestroy(IPCProcessComponent::RESOURCE_ALLOCATOR_AE_NAME,
 					resource_allocator_->selected_ps_name,
 					resource_allocator_->ps);
 		delete resource_allocator_;
 	}
 
 	if (security_manager_) {
-		psDestroy("security-manager",
+		psDestroy(IPCProcessComponent::SECURITY_MANAGER_AE_NAME,
                    security_manager_->selected_ps_name,
                    security_manager_->ps);
         delete security_manager_;
 	}
 
 	if (routing_component_) {
-		psDestroy("routing",
+		psDestroy(IPCProcessComponent::ROUTING_COMPONENT_AE_NAME,
 				routing_component_->selected_ps_name,
 				routing_component_->ps);
         delete routing_component_;

--- a/rinad/src/ipcp/ipc-process.h
+++ b/rinad/src/ipcp/ipc-process.h
@@ -49,6 +49,8 @@ public:
 		void processAssignToDIFResponseEvent(const rina::AssignToDIFResponseEvent& event);
 		void requestPDUFTEDump();
 		void logPDUFTE(const rina::DumpFTResponseEvent& event);
+
+		// Policy Management
         void processSetPolicySetParamRequestEvent(
                 const rina::SetPolicySetParamRequestEvent& event);
         void processSetPolicySetParamResponseEvent(
@@ -60,18 +62,18 @@ public:
         void processPluginLoadRequestEvent(
                 const rina::PluginLoadRequestEvent& event);
 
-        std::vector<PsFactory>::iterator
-                        psFactoryLookup(const std::string& component,
-                                       const std::string& name);
-        int psFactoryPublish(const PsFactory& factory);
-        int psFactoryUnpublish(const std::string& component,
-                                              const std::string& name);
-        IPolicySet * psCreate(const std::string& component,
-                                            const std::string& name,
-                                            IPCProcessComponent* context);
-        int psDestroy(const std::string& component,
+        std::vector<rina::PsFactory>::iterator
+        psFactoryLookup(const std::string& ae_name,
+                        const std::string& name);
+        int psFactoryPublish(const rina::PsFactory& factory);
+        int psFactoryUnpublish(const std::string& ae_name,
+                               const std::string& name);
+        rina::IPolicySet * psCreate(const std::string& ae_name,
                                     const std::string& name,
-                                    IPolicySet * instance);
+                                    rina::ApplicationEntity * context);
+        int psDestroy(const std::string& ae_name,
+                      const std::string& name,
+                      rina::IPolicySet * instance);
 
 private:
         void init_cdap_session_manager();
@@ -88,7 +90,7 @@ private:
         rina::Lockable * lock_;
 		rina::DIFInformation dif_information_;
         std::map< std::string, void * > plugins_handles;
-        std::vector<PsFactory> components_factories;
+        std::vector<rina::PsFactory> ae_policy_factories;
 };
 
 void register_handlers_all(EventLoop& loop);

--- a/rinad/src/ipcp/link-state-routing-ps.cc
+++ b/rinad/src/ipcp/link-state-routing-ps.cc
@@ -67,8 +67,8 @@ int LinkStateRoutingPs::set_policy_set_param(const std::string& name,
         return -1;
 }
 
-extern "C" IPolicySet *
-createRoutingComponentPs(IPCProcessComponent * ctx)
+extern "C" rina::IPolicySet *
+createRoutingComponentPs(rina::ApplicationEntity * ctx)
 {
 		IRoutingComponent * rc = dynamic_cast<IRoutingComponent *>(ctx);
 
@@ -80,7 +80,7 @@ createRoutingComponentPs(IPCProcessComponent * ctx)
 }
 
 extern "C" void
-destroyRoutingComponentPs(IPolicySet * ps)
+destroyRoutingComponentPs(rina::IPolicySet * ps)
 {
         if (ps) {
                 delete ps;

--- a/rinad/src/ipcp/namespace-manager.cc
+++ b/rinad/src/ipcp/namespace-manager.cc
@@ -392,14 +392,22 @@ const void* DirectoryForwardingTableEntrySetRIBObject::get_value() const {
 }
 
 //Class Namespace Manager
-NamespaceManager::NamespaceManager() {
-	ipcp = 0;
+NamespaceManager::NamespaceManager() : INamespaceManager() {
 	rib_daemon_ = 0;
 }
 
-void NamespaceManager::set_ipc_process(IPCProcess * ipc_process) {
-	ipcp = ipc_process;
-	rib_daemon_ = ipc_process->rib_daemon_;
+void NamespaceManager::set_application_process(rina::ApplicationProcess * ap) {
+	if (!ap)
+			return;
+
+	app = ap;
+	ipcp = dynamic_cast<IPCProcess*>(app);
+	if (!ipcp) {
+			LOG_ERR("Bogus instance of IPCP passed, return");
+			return;
+	}
+
+	rib_daemon_ = ipcp->rib_daemon_;
 	populateRIB();
 }
 
@@ -587,15 +595,14 @@ unsigned int NamespaceManager::getAdressByname(const rina::ApplicationProcessNam
 int NamespaceManager::select_policy_set(const std::string& path,
                                      const std::string& name)
 {
-  return select_policy_set_common(ipcp, "namespace-manager",
-                                  path, name);
+  return select_policy_set_common(get_name(), path, name);
 }
 
 int NamespaceManager::set_policy_set_param(const std::string& path,
                                         const std::string& name,
                                         const std::string& value)
 {
-  return set_policy_set_param_common(ipcp, path, name, value);
+  return set_policy_set_param_common(path, name, value);
 }
 
 }

--- a/rinad/src/ipcp/namespace-manager.h
+++ b/rinad/src/ipcp/namespace-manager.h
@@ -102,7 +102,7 @@ private:
 class NamespaceManager: public INamespaceManager {
 public:
 	NamespaceManager();
-	void set_ipc_process(IPCProcess * ipc_process);
+	void set_application_process(rina::ApplicationProcess * ap);
 	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
 	unsigned int getDFTNextHop(const rina::ApplicationProcessNamingInformation& apNamingInfo);
 	void addDFTEntry(rina::DirectoryForwardingTableEntry * entry);

--- a/rinad/src/ipcp/plugins/security-manager-passwd.cc
+++ b/rinad/src/ipcp/plugins/security-manager-passwd.cc
@@ -66,8 +66,8 @@ int SecurityManagerPasswdPs::set_policy_set_param(const std::string& name,
         return 0;
 }
 
-extern "C" IPolicySet *
-createSecurityManagerPasswdPs(IPCProcessComponent * ctx)
+extern "C" rina::IPolicySet *
+createSecurityManagerPasswdPs(rina::ApplicationEntity * ctx)
 {
         ISecurityManager * sm = dynamic_cast<ISecurityManager *>(ctx);
 
@@ -79,7 +79,7 @@ createSecurityManagerPasswdPs(IPCProcessComponent * ctx)
 }
 
 extern "C" void
-destroySecurityManagerPasswdPs(IPolicySet * ps)
+destroySecurityManagerPasswdPs(rina::IPolicySet * ps)
 {
         if (ps) {
                 delete ps;
@@ -89,12 +89,12 @@ destroySecurityManagerPasswdPs(IPolicySet * ps)
 extern "C" int
 init(IPCProcess * ipc_process, const std::string& plugin_name)
 {
-        struct PsFactory factory;
+        struct rina::PsFactory factory;
         int ret;
 
         factory.plugin_name = plugin_name;
         factory.name = "passwd";
-        factory.component = "security-manager";
+        factory.app_entity = IPCProcessComponent::SECURITY_MANAGER_AE_NAME;
         factory.create = createSecurityManagerPasswdPs;
         factory.destroy = destroySecurityManagerPasswdPs;
 

--- a/rinad/src/ipcp/resource-allocator.h
+++ b/rinad/src/ipcp/resource-allocator.h
@@ -64,7 +64,7 @@ class ResourceAllocator: public IResourceAllocator {
 public:
 	ResourceAllocator();
 	~ResourceAllocator();
-	void set_ipc_process(IPCProcess * ipc_process);
+	void set_application_process(rina::ApplicationProcess * ap);
 	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
 	INMinusOneFlowManager * get_n_minus_one_flow_manager() const;
 	int select_policy_set(const std::string& path, const std::string& name);

--- a/rinad/src/ipcp/rib-daemon.h
+++ b/rinad/src/ipcp/rib-daemon.h
@@ -46,7 +46,7 @@ void * doManagementSDUReaderWork(void* data);
 
 class BaseRIBDaemon: public IPCPRIBDaemon {
 public:
-        BaseRIBDaemon();
+        BaseRIBDaemon() : IPCPRIBDaemon() { };
         void subscribeToEvent(const IPCProcessEventType& eventId, EventListener * eventListener);
         void unsubscribeFromEvent(const IPCProcessEventType& eventId, EventListener * eventListener);
         void deliverEvent(Event * event);
@@ -60,7 +60,7 @@ private:
 class IPCPRIBDaemonImpl : public BaseRIBDaemon, public EventListener {
 public:
         IPCPRIBDaemonImpl();
-	void set_ipc_process(IPCProcess * ipc_process);
+        void set_application_process(rina::ApplicationProcess * ap);
 	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
 	void eventHappened(Event * event);
 	void processQueryRIBRequestEvent(const rina::QueryRIBRequestEvent& event);
@@ -69,7 +69,6 @@ public:
 	void cdapMessageDelivered(char* message, int length, int portId);
 
 private:
-	IPCProcess * ipc_process_;
 	INMinusOneFlowManager * n_minus_one_flow_manager_;
 	rina::Thread * management_sdu_reader_;
 

--- a/rinad/src/ipcp/routing.cc
+++ b/rinad/src/ipcp/routing.cc
@@ -32,7 +32,15 @@ namespace rinad {
 //Class RoutingComponent
 void RoutingComponent::set_application_process(rina::ApplicationProcess * ap)
 {
+	if (!ap)
+			return;
+
 	app = ap;
+	ipcp = dynamic_cast<IPCProcess*>(app);
+	if (!ipcp) {
+			LOG_ERR("Bogus instance of IPCP passed, return");
+			return;
+	}
 }
 
 void RoutingComponent::set_dif_configuration(const rina::DIFConfiguration& dif_configuration) {

--- a/rinad/src/ipcp/routing.cc
+++ b/rinad/src/ipcp/routing.cc
@@ -30,13 +30,9 @@
 namespace rinad {
 
 //Class RoutingComponent
-RoutingComponent::RoutingComponent() {
-	ipcp = 0;
-}
-
-void RoutingComponent::set_ipc_process(IPCProcess * ipc_process)
+void RoutingComponent::set_application_process(rina::ApplicationProcess * ap)
 {
-	ipcp = ipc_process;
+	app = ap;
 }
 
 void RoutingComponent::set_dif_configuration(const rina::DIFConfiguration& dif_configuration) {
@@ -52,14 +48,14 @@ void RoutingComponent::set_dif_configuration(const rina::DIFConfiguration& dif_c
 int RoutingComponent::select_policy_set(const std::string& path,
                                        const std::string& name)
 {
-        return select_policy_set_common(ipcp, "routing", path, name);
+        return select_policy_set_common(get_name(), path, name);
 }
 
 int RoutingComponent::set_policy_set_param(const std::string& path,
                                           const std::string& name,
                                           const std::string& value)
 {
-        return set_policy_set_param_common(ipcp, path, name, value);
+        return set_policy_set_param_common(path, name, value);
 }
 
 }

--- a/rinad/src/ipcp/security-manager.cc
+++ b/rinad/src/ipcp/security-manager.cc
@@ -28,13 +28,9 @@
 namespace rinad {
 
 //Class SecurityManager
-SecurityManager::SecurityManager() {
-	ipcp = 0;
-}
-
-void SecurityManager::set_ipc_process(IPCProcess * ipc_process)
+void SecurityManager::set_application_process(rina::ApplicationProcess * ap)
 {
-	ipcp = ipc_process;
+	app = ap;
 }
 
 void SecurityManager::set_dif_configuration(const rina::DIFConfiguration& dif_configuration) {
@@ -44,14 +40,14 @@ void SecurityManager::set_dif_configuration(const rina::DIFConfiguration& dif_co
 int SecurityManager::select_policy_set(const std::string& path,
                                        const std::string& name)
 {
-        return select_policy_set_common(ipcp, "security-manager", path, name);
+        return select_policy_set_common(get_name(), path, name);
 }
 
 int SecurityManager::set_policy_set_param(const std::string& path,
                                           const std::string& name,
                                           const std::string& value)
 {
-        return set_policy_set_param_common(ipcp, path, name, value);
+        return set_policy_set_param_common(path, name, value);
 }
 
 }

--- a/rinad/src/ipcp/security-manager.cc
+++ b/rinad/src/ipcp/security-manager.cc
@@ -30,7 +30,15 @@ namespace rinad {
 //Class SecurityManager
 void SecurityManager::set_application_process(rina::ApplicationProcess * ap)
 {
+	if (!ap)
+			return;
+
 	app = ap;
+	ipcp = dynamic_cast<IPCProcess*>(app);
+	if (!ipcp) {
+			LOG_ERR("Bogus instance of IPCP passed, return");
+			return;
+	}
 }
 
 void SecurityManager::set_dif_configuration(const rina::DIFConfiguration& dif_configuration) {


### PR DESCRIPTION
* Moved former librina-application to librina-ipc-api (this is what there was there)
* librina-application holds now the daf components to build programmable distributed applications (policy set base classes and base ApplicationProcess classes are there)
* IPCP extends from that

More stuff needs to be moved to librina-application, but for the moment we should merge since a number of classes have changed, to prevent conflicts later on.