### PR TITLE
Allow IPCM configuration file to specify policy-sets for userspace components

### DIFF
--- a/librina/include/librina/configuration.h
+++ b/librina/include/librina/configuration.h
@@ -891,6 +891,9 @@ public:
 	/// Configuration of the security manager
 	SecurityManagerConfiguration sm_configuration_;
 
+        /// Policy sets
+        std::list<Parameter> policy_sets;
+
 	/// Other configuration parameters of the DIF
 	std::list<Parameter> parameters_;
 

--- a/librina/src/application.cc
+++ b/librina/src/application.cc
@@ -96,7 +96,8 @@ int ApplicationEntity::select_policy_set_common(const std::string& component,
         }
 
         if (ps_name == selected_ps_name) {
-                LOG_INFO("policy set %s already selected", ps_name.c_str());
+                LOG_INFO("policy set %s already selected for component %s",
+                         ps_name.c_str(), component.c_str());
                 return 0;
         }
 

--- a/librina/src/netlink-parsers.cc
+++ b/librina/src/netlink-parsers.cc
@@ -1334,6 +1334,31 @@ int parseListOfDIFConfigurationParameters(nlattr *nested,
 	return 0;
 }
 
+int parseListOfDIFConfigurationPolicySets(nlattr *nested,
+		DIFConfiguration * difConfiguration){
+	nlattr * nla;
+	int rem;
+	Parameter * parameter;
+
+	for (nla = (nlattr*) nla_data(nested), rem = nla_len(nested);
+		     nla_ok(nla, rem);
+		     nla = nla_next(nla, &(rem))){
+		/* validate & parse attribute */
+		parameter = parseParameter(nla);
+		if (parameter == 0){
+			return -1;
+		}
+		difConfiguration->policy_sets.push_back(*parameter);
+		delete parameter;
+	}
+
+	if (rem > 0){
+		LOG_WARN("Missing bits to parse");
+	}
+
+	return 0;
+}
+
 int putNeighborObject(nl_msg* netlinkMessage,
                 const Neighbor& object) {
         struct nlattr *name, *supportingDIFName;
@@ -3977,7 +4002,7 @@ int putDIFConfigurationObject(nl_msg* netlinkMessage,
                 const DIFConfiguration& object,
                 bool normalIPCProcess){
 	struct nlattr *parameters, *efcpConfig, *rmtConfig, *smConfig,
-		*etConfig, *faConfig, *nsmConfig, *pduftConfig;
+		*etConfig, *faConfig, *nsmConfig, *pduftConfig, *policySets;
 
 	if  (object.get_parameters().size() > 0) {
 	        if (!(parameters = nla_nest_start(
@@ -4061,6 +4086,19 @@ int putDIFConfigurationObject(nl_msg* netlinkMessage,
 	        	goto nla_put_failure;
 	        }
 	        nla_nest_end(netlinkMessage, smConfig);
+
+                if  (object.policy_sets.size() > 0) {
+                        if (!(policySets = nla_nest_start(netlinkMessage,
+                                                        DCONF_ATTR_POLICY_SETS))) {
+                                goto nla_put_failure;
+                        }
+                        if (putListOfParameters(netlinkMessage,
+                                                object.policy_sets) < 0) {
+                                goto nla_put_failure;
+                        }
+                        nla_nest_end(netlinkMessage, policySets);
+                }
+
 	}
 
 	NLA_PUT_U32(netlinkMessage, DCONF_ATTR_ADDRESS,
@@ -6779,13 +6817,15 @@ DIFConfiguration * parseDIFConfigurationObject(nlattr *nested){
 	attr_policy[DCONF_ATTR_SM_CONF].type = NLA_NESTED;
 	attr_policy[DCONF_ATTR_SM_CONF].minlen = 0;
 	attr_policy[DCONF_ATTR_SM_CONF].maxlen = 0;
+	attr_policy[DCONF_ATTR_POLICY_SETS].type = NLA_NESTED;
+	attr_policy[DCONF_ATTR_POLICY_SETS].minlen = 0;
+	attr_policy[DCONF_ATTR_POLICY_SETS].maxlen = 0;
 	struct nlattr *attrs[DCONF_ATTR_MAX + 1];
 
 	int err = nla_parse_nested(attrs, DCONF_ATTR_MAX, nested, attr_policy);
 	if (err < 0) {
-		LOG_ERR(
-				"Error parsing DIFConfiguration information from Netlink message: %d",
-				err);
+		LOG_ERR("Error parsing DIFConfiguration information from Netlink message: %d",
+			err);
 		return 0;
 	}
 
@@ -6895,6 +6935,15 @@ DIFConfiguration * parseDIFConfigurationObject(nlattr *nested){
 		} else {
 			result->sm_configuration_ = *smConfig;
 			delete smConfig;
+		}
+	}
+
+	if (attrs[DCONF_ATTR_POLICY_SETS]) {
+		status = parseListOfDIFConfigurationPolicySets(
+				attrs[DCONF_ATTR_POLICY_SETS], result);
+		if (status != 0){
+			delete result;
+			return 0;
 		}
 	}
 

--- a/librina/src/netlink-parsers.h
+++ b/librina/src/netlink-parsers.h
@@ -650,6 +650,7 @@ enum DIFConfigurationAttributes {
 	DCONF_ATTR_ET_CONF,
 	DCONF_ATTR_NSM_CONF,
 	DCONF_ATTR_SM_CONF,
+        DCONF_ATTR_POLICY_SETS,
 	__DCONF_ATTR_MAX,
 };
 

--- a/rinad/etc/ipcmanager.conf.in
+++ b/rinad/etc/ipcmanager.conf.in
@@ -134,6 +134,12 @@
         "declaredDeadIntervalInMs" : 120000,
         "neighborsEnrollerPeriodInMs" : 30000,
         "maxEnrollmentRetries" : 3
-     }
+     },
+     "policySets" : {
+        "security-manager" : "default",
+        "flow-allocator" : "default",
+        "namespace-manager" : "default",
+        "resource-allocator" : "default"
+    }
   } ]
 }

--- a/rinad/etc/ipcmanager.conf.in
+++ b/rinad/etc/ipcmanager.conf.in
@@ -139,6 +139,7 @@
         "security-manager" : "default",
         "flow-allocator" : "default",
         "namespace-manager" : "default",
+        "routing" : "link-state",
         "resource-allocator" : "default"
     }
   } ]

--- a/rinad/src/common/rina-configuration.h
+++ b/rinad/src/common/rina-configuration.h
@@ -110,8 +110,8 @@ struct DIFProperties {
         rina::DataTransferConstants dataTransferConstants;
         std::list<rina::QoSCube> qosCubes;
         rina::RMTConfiguration rmtConfiguration;
-        std::map<std::string, std::string> policies;
-        std::map<std::string, std::string> policyParameters;
+        std::map<std::string, std::string> policySets;
+        std::map<std::string, std::string> policySetParameters;
         rina::EnrollmentTaskConfiguration etConfiguration;
 
         /* Only for normal DIFs */

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -452,12 +452,12 @@ void parse_dif_configs(const Json::Value   & root,
                                      j < members.size();
                                      j++) {
                                         string value =
-                                                policy_sets.get(members[i],
+                                                policy_sets.get(members[j],
                                                              string())
                                                 .asString();
                                         props.policySets.insert
                                                 (pair<string, string>
-                                                 (members[i], value));
+                                                 (members[j], value));
                                 }
                         }
 
@@ -471,11 +471,11 @@ void parse_dif_configs(const Json::Value   & root,
                                      j < members.size();
                                      j++) {
                                         string value = policy_set_params
-							.get(members[i],
+							.get(members[j],
                                                         string()).asString();
                                         props.policySetParameters.insert
                                                 (pair<string, string>
-                                                 (members[i], value));
+                                                 (members[j], value));
                                 }
                         }
 

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -443,38 +443,37 @@ void parse_dif_configs(const Json::Value   & root,
                                 props.rmtConfiguration = rc;
                         }
 
-                        // std::map<std::string, std::string> policies
-                        Json::Value policies = dif_configs[i]["policies"];
-                        if (policies != 0) {
+                        // std::map<std::string, std::string> policy_sets
+                        Json::Value policy_sets = dif_configs[i]["policySets"];
+                        if (policy_sets != 0) {
                                 Json::Value::Members members =
-                                        policies.getMemberNames();
+                                        policy_sets.getMemberNames();
                                 for (unsigned int j = 0;
                                      j < members.size();
                                      j++) {
                                         string value =
-                                                policies.get(members[i],
+                                                policy_sets.get(members[i],
                                                              string())
                                                 .asString();
-                                        props.policies.insert
+                                        props.policySets.insert
                                                 (pair<string, string>
                                                  (members[i], value));
                                 }
                         }
 
                         // std::map<std::string, std::string> policyParameters
-                        Json::Value policyParams =
+                        Json::Value policy_set_params =
                                 dif_configs[i]["policyParameters"];
-                        if (policyParams != 0) {
+                        if (policy_set_params != 0) {
                                 Json::Value::Members members =
-                                        policyParams.getMemberNames();
+                                        policy_set_params.getMemberNames();
                                 for (unsigned int j = 0;
                                      j < members.size();
                                      j++) {
-                                        string value =
-                                                policyParams.get(members[i],
-                                                                 string())
-                                                .asString();
-                                        props.policyParameters.insert
+                                        string value = policy_set_params
+							.get(members[i],
+                                                        string()).asString();
+                                        props.policySetParameters.insert
                                                 (pair<string, string>
                                                  (members[i], value));
                                 }

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -389,6 +389,15 @@ IPCManager_::assign_to_dif(Promise* promise, const unsigned short ipcp_id,
 			}
 			nsm_config.addressing_configuration_ = address_config;
 
+                        // Copy the por-component policy set names from the configuration
+                        // structure to the dif_config struct
+                        for (map<string, string>::iterator
+                                        it = dif_props.policySets.begin();
+                                        it != dif_props.policySets.end(); it++) {
+                                dif_config.policy_sets.push_back(
+                                                rina::Parameter(it->first, it->second));
+                        }
+
 			found = dif_props.
 				lookup_ipcp_address(ipcp->get_name(),
 						address);

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -463,6 +463,10 @@ void IPCProcessImpl::processSetPolicySetParamRequestEvent(
                 result = rib_daemon_->set_policy_set_param(remainder,
                                                           event.name,
                                                           event.value);
+        } else if (component == "routing") {
+                result = routing_component_->set_policy_set_param(remainder,
+                                                                  event.name,
+                                                                  event.value);
         } else {
                 got_in_userspace = false;
         }
@@ -559,6 +563,9 @@ int IPCProcessImpl::dispatchSelectPolicySet(const std::string& path,
         } else if (component == "rib-daemon") {
                 result = rib_daemon_->select_policy_set(remainder,
                                                         name);
+        } else if (component == "routing") {
+                result = routing_component_->select_policy_set(remainder,
+                                                               name);
         } else {
                 got_in_userspace = false;
         }

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -337,6 +337,16 @@ void IPCProcessImpl::processAssignToDIFResponseEvent(const rina::AssignToDIFResp
 
 	//TODO do stuff
 	LOG_DBG("The kernel processed successfully the Assign to DIF request");
+
+        std::list<rina::Parameter>& policy_sets_config =
+                                dif_information_.dif_configuration_.policy_sets;
+        for (std::list<rina::Parameter>::iterator
+                        it = policy_sets_config.begin();
+                                it != policy_sets_config.end(); it++) {
+                LOG_DBG("POLICY SET CONFIG: Component=%s, PSName=%s",
+                                it->name.c_str(), it->value.c_str());
+        }
+
 	try{
 		rib_daemon_->set_dif_configuration(dif_information_.dif_configuration_);
 		resource_allocator_->set_dif_configuration(dif_information_.dif_configuration_);

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -42,23 +42,23 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
 		unsigned short id, unsigned int ipc_manager_port,
 		std::string log_level, std::string log_file) : IPCProcess(nm.processName, nm.processInstance)
 {
-		try {
-				std::stringstream ss;
-				ss << IPCP_LOG_FILE_PREFIX << "-" << id;
-				rina::initialize(log_level, log_file);
-				rina::extendedIPCManager->ipcManagerPort = ipc_manager_port;
-				rina::extendedIPCManager->ipcProcessId = id;
-				rina::kernelIPCProcess->ipcProcessId = id;
-				LOG_INFO("Librina initialized");
-		} catch (rina::Exception &e) {
-			std::cerr << "Cannot initialize librina" << std::endl;
-			exit(EXIT_FAILURE);
-		}
+        try {
+                std::stringstream ss;
+                ss << IPCP_LOG_FILE_PREFIX << "-" << id;
+                rina::initialize(log_level, log_file);
+                rina::extendedIPCManager->ipcManagerPort = ipc_manager_port;
+                rina::extendedIPCManager->ipcProcessId = id;
+                rina::kernelIPCProcess->ipcProcessId = id;
+                LOG_INFO("Librina initialized");
+        } catch (rina::Exception &e) {
+                std::cerr << "Cannot initialize librina" << std::endl;
+                exit(EXIT_FAILURE);
+        }
 
-		state = NOT_INITIALIZED;
-		lock_ = new rina::Lockable();
+        state = NOT_INITIALIZED;
+        lock_ = new rina::Lockable();
 
-        	// Load the default pluggable components
+        // Load the default pluggable components
         if (plugin_load("default")) {
         		throw rina::Exception("Failed to load default plugin");
         }
@@ -76,13 +76,13 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
         routing_component_ = new RoutingComponent();
         rib_daemon_ = new IPCPRIBDaemonImpl();
 
-		add_entity(rib_daemon_);
-		add_entity(enrollment_task_);
-		add_entity(resource_allocator_);
-		add_entity(namespace_manager_);
-		add_entity(flow_allocator_);
-		add_entity(security_manager_);
-		add_entity(routing_component_);
+        add_entity(rib_daemon_);
+        add_entity(enrollment_task_);
+        add_entity(resource_allocator_);
+        add_entity(namespace_manager_);
+        add_entity(flow_allocator_);
+        add_entity(security_manager_);
+        add_entity(routing_component_);
 
         // Select the default policy sets
         security_manager_->select_policy_set(std::string(), rina::IPolicySet::DEFAULT_PS_SET_NAME);
@@ -111,8 +111,8 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
         }
 
         try {
-        		rina::ApplicationProcessNamingInformation naming_info(name_, instance_);
-        		rina::extendedIPCManager->notifyIPCProcessInitialized(naming_info);
+                rina::ApplicationProcessNamingInformation naming_info(name_, instance_);
+                rina::extendedIPCManager->notifyIPCProcessInitialized(naming_info);
         } catch (rina::Exception &e) {
         		LOG_ERR("Problems communicating with IPC Manager: %s. Exiting... ", e.what());
         		exit(EXIT_FAILURE);

--- a/rinad/src/ipcp/ipc-process.h
+++ b/rinad/src/ipcp/ipc-process.h
@@ -32,23 +32,23 @@ namespace rinad {
 
 class IPCProcessImpl: public IPCProcess, public EventLoopData {
 public:
-		IPCProcessImpl(const rina::ApplicationProcessNamingInformation& name,
-			unsigned short id, unsigned int ipc_manager_port,
-			std::string log_level, std::string log_file);
-		~IPCProcessImpl();
-		unsigned short get_id();
-		const std::list<rina::Neighbor*> get_neighbors() const;
-		const IPCProcessOperationalState& get_operational_state() const;
-		void set_operational_state(const IPCProcessOperationalState& operational_state);
-		const rina::DIFInformation& get_dif_information() const;
-		void set_dif_information(const rina::DIFInformation& dif_information);
-		unsigned int get_address() const;
-		void set_address(unsigned int address);
-		unsigned int getAdressByname(const rina::ApplicationProcessNamingInformation& name);
-		void processAssignToDIFRequestEvent(const rina::AssignToDIFRequestEvent& event);
-		void processAssignToDIFResponseEvent(const rina::AssignToDIFResponseEvent& event);
-		void requestPDUFTEDump();
-		void logPDUFTE(const rina::DumpFTResponseEvent& event);
+        IPCProcessImpl(const rina::ApplicationProcessNamingInformation& name,
+                        unsigned short id, unsigned int ipc_manager_port,
+                        std::string log_level, std::string log_file);
+        ~IPCProcessImpl();
+        unsigned short get_id();
+        const std::list<rina::Neighbor*> get_neighbors() const;
+        const IPCProcessOperationalState& get_operational_state() const;
+        void set_operational_state(const IPCProcessOperationalState& operational_state);
+        const rina::DIFInformation& get_dif_information() const;
+        void set_dif_information(const rina::DIFInformation& dif_information);
+        unsigned int get_address() const;
+        void set_address(unsigned int address);
+        unsigned int getAdressByname(const rina::ApplicationProcessNamingInformation& name);
+        void processAssignToDIFRequestEvent(const rina::AssignToDIFRequestEvent& event);
+        void processAssignToDIFResponseEvent(const rina::AssignToDIFResponseEvent& event);
+        void requestPDUFTEDump();
+        void logPDUFTE(const rina::DumpFTResponseEvent& event);
 
 	// Policy Management
         int dispatchSelectPolicySet(const std::string& path,

--- a/rinad/src/ipcp/ipc-process.h
+++ b/rinad/src/ipcp/ipc-process.h
@@ -50,7 +50,10 @@ public:
 		void requestPDUFTEDump();
 		void logPDUFTE(const rina::DumpFTResponseEvent& event);
 
-		// Policy Management
+	// Policy Management
+        int dispatchSelectPolicySet(const std::string& path,
+                                    const std::string& name,
+                                    bool& got_in_userspace);
         void processSetPolicySetParamRequestEvent(
                 const rina::SetPolicySetParamRequestEvent& event);
         void processSetPolicySetParamResponseEvent(

--- a/tests/conf/ipcmanager.conf-normaloverdummy
+++ b/tests/conf/ipcmanager.conf-normaloverdummy
@@ -121,7 +121,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normaloverdummy
+++ b/tests/conf/ipcmanager.conf-normaloverdummy
@@ -126,6 +126,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovereth1
+++ b/tests/conf/ipcmanager.conf-normalovereth1
@@ -124,6 +124,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovereth1
+++ b/tests/conf/ipcmanager.conf-normalovereth1
@@ -119,7 +119,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovereth2
+++ b/tests/conf/ipcmanager.conf-normalovereth2
@@ -120,7 +120,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovereth2
+++ b/tests/conf/ipcmanager.conf-normalovereth2
@@ -125,6 +125,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovereth2cubes
+++ b/tests/conf/ipcmanager.conf-normalovereth2cubes
@@ -149,7 +149,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovereth2cubes
+++ b/tests/conf/ipcmanager.conf-normalovereth2cubes
@@ -154,6 +154,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovernormalovereth1
+++ b/tests/conf/ipcmanager.conf-normalovernormalovereth1
@@ -175,6 +175,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovernormalovereth1
+++ b/tests/conf/ipcmanager.conf-normalovernormalovereth1
@@ -170,7 +170,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovernormalovereth2
+++ b/tests/conf/ipcmanager.conf-normalovernormalovereth2
@@ -173,7 +173,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovernormalovereth2
+++ b/tests/conf/ipcmanager.conf-normalovernormalovereth2
@@ -178,6 +178,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovershimhv1
+++ b/tests/conf/ipcmanager.conf-normalovershimhv1
@@ -140,6 +140,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovershimhv1
+++ b/tests/conf/ipcmanager.conf-normalovershimhv1
@@ -135,7 +135,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovershimhv2
+++ b/tests/conf/ipcmanager.conf-normalovershimhv2
@@ -140,6 +140,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovershimhv2
+++ b/tests/conf/ipcmanager.conf-normalovershimhv2
@@ -135,7 +135,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovertcpudp1
+++ b/tests/conf/ipcmanager.conf-normalovertcpudp1
@@ -121,7 +121,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovertcpudp1
+++ b/tests/conf/ipcmanager.conf-normalovertcpudp1
@@ -126,6 +126,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/ipcmanager.conf-normalovertcpudp2
+++ b/tests/conf/ipcmanager.conf-normalovertcpudp2
@@ -121,7 +121,13 @@
         		"declaredDeadIntervalInMs" : 120000,
         		"neighborsEnrollerPeriodInMs" : 30000,
         		"maxEnrollmentRetries" : 3
-     		}
+     		},
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
+            }
         }
     ]
 }

--- a/tests/conf/ipcmanager.conf-normalovertcpudp2
+++ b/tests/conf/ipcmanager.conf-normalovertcpudp2
@@ -126,6 +126,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/vm-to-vm/ipcmanager.conf-pm
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-pm
@@ -153,6 +153,12 @@
                     "declaredDeadIntervalInMs" : 120000,
                     "neighborsEnrollerPeriodInMs" : 30000,
                     "maxEnrollmentRetries" : 3
+            },
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
             }
         }
     ]

--- a/tests/conf/vm-to-vm/ipcmanager.conf-pm
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-pm
@@ -158,6 +158,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
@@ -140,6 +140,12 @@
                     "declaredDeadIntervalInMs" : 120000,
                     "neighborsEnrollerPeriodInMs" : 30000,
                     "maxEnrollmentRetries" : 3
+            },
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
             }
         }
     ]

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
@@ -145,6 +145,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
@@ -140,6 +140,12 @@
                     "declaredDeadIntervalInMs" : 120000,
                     "neighborsEnrollerPeriodInMs" : 30000,
                     "maxEnrollmentRetries" : 3
+            },
+            "policySets" : {
+                "security-manager" : "default",
+                "flow-allocator" : "default",
+                "namespace-manager" : "default",
+                "resource-allocator" : "default"
             }
         }
     ]

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
@@ -145,6 +145,7 @@
                 "security-manager" : "default",
                 "flow-allocator" : "default",
                 "namespace-manager" : "default",
+                "routing" : "link-state",
                 "resource-allocator" : "default"
             }
         }


### PR DESCRIPTION
Allow IPCM configuration file to specify the name of policy sets to be selected at assign-to-dif time, for userspace IPCP components.

Pull request also includes update to test configuration files