### PR TITLE
Pristine 1.2

### DIFF
--- a/librina/include/librina/irm.h
+++ b/librina/include/librina/irm.h
@@ -74,13 +74,18 @@ protected:
 	void cleanFlowAndNotify(int portId);
 };
 
-class DIFRegistrationRIBObject: public SimpleSetMemberRIBObject {
+class DIFRegistrationRIBObject: public BaseRIBObject {
 public:
 	DIFRegistrationRIBObject(IRIBDaemon * rib_daemon,
 				 const std::string& object_class,
 				 const std::string& object_name,
-				 const std::string* dif_name);
+				 const std::string& dif_name_);
+	const void* get_value() const;
+	void deleteObject(const void* objectValue);
 	std::string get_displayable_value();
+
+private:
+	std::string dif_name;
 };
 
 class DIFRegistrationSetRIBObject: public BaseRIBObject {
@@ -96,13 +101,18 @@ public:
                           const void* objectValue);
 };
 
-class NMinusOneFlowRIBObject: public SimpleSetMemberRIBObject {
+class NMinusOneFlowRIBObject: public BaseRIBObject {
 public:
 	NMinusOneFlowRIBObject(IRIBDaemon * rib_daemon,
 			       const std::string& object_class,
 			       const std::string& object_name,
-			       const rina::FlowInformation* flow_info);
+			       const rina::FlowInformation& flow_info);
+	const void* get_value() const;
+	void deleteObject(const void* objectValue);
 	std::string get_displayable_value();
+
+private:
+	FlowInformation flow_information;
 };
 
 class NMinusOneFlowSetRIBObject: public BaseRIBObject {

--- a/librina/include/librina/irm.h
+++ b/librina/include/librina/irm.h
@@ -81,7 +81,6 @@ public:
 				 const std::string& object_name,
 				 const std::string* dif_name);
 	std::string get_displayable_value();
-	void deleteObject(const void* objectValue);
 };
 
 class DIFRegistrationSetRIBObject: public BaseRIBObject {
@@ -104,7 +103,6 @@ public:
 			       const std::string& object_name,
 			       const rina::FlowInformation* flow_info);
 	std::string get_displayable_value();
-	void deleteObject(const void* objectValue);
 };
 
 class NMinusOneFlowSetRIBObject: public BaseRIBObject {

--- a/librina/src/irm.cc
+++ b/librina/src/irm.cc
@@ -373,15 +373,6 @@ std::string DIFRegistrationRIBObject::get_displayable_value() {
 	return ss.str();
 }
 
-void DIFRegistrationRIBObject::deleteObject(const void* objectValue) {
-	(void) objectValue; // Stop compiler barfs
-
-	parent_->remove_child(name_);
-	base_rib_daemon_->removeRIBObject(name_);
-	const std::string * value = (const std::string *) get_value();
-	delete value;
-}
-
 // Class DIF registration set RIB Object
 const std::string DIFRegistrationSetRIBObject::DIF_REGISTRATION_SET_RIB_OBJECT_CLASS =
 		"DIF registration set";
@@ -439,19 +430,6 @@ std::string NMinusOneFlowRIBObject::get_displayable_value()
 	FlowSpecification flowSpec = flow_info->flowSpecification;
 	ss << "Flow characteristics: " << flowSpec.toString();
 	return ss.str();
-}
-
-void NMinusOneFlowRIBObject::deleteObject(const void* objectValue)
-{
-	(void) objectValue; // Stop compiler barfs
-
-	parent_->remove_child(name_);
-	base_rib_daemon_->removeRIBObject(name_);
-	const FlowInformation * flow_info =
-				(const FlowInformation *) get_value();
-	if (flow_info) {
-		delete flow_info;
-	}
 }
 
 // Class N-1 Flow set RIB Object

--- a/librina/src/irm.cc
+++ b/librina/src/irm.cc
@@ -139,7 +139,6 @@ void IPCResourceManager::allocateRequestResult(const AllocateFlowRequestResultEv
 		return;
 	}
 
-	FlowInformation * flowInformation = 0;
 	FlowInformation flow;
 	if (ipcp) {
 		flow = extendedIPCManager->commitPendingFlow(event.sequenceNumber,
@@ -155,22 +154,14 @@ void IPCResourceManager::allocateRequestResult(const AllocateFlowRequestResultEv
 		std::stringstream ss;
 		ss<<NMinusOneFlowSetRIBObject::N_MINUS_ONE_FLOW_SET_RIB_OBJECT_NAME;
 		ss<<RIBNamingConstants::SEPARATOR<<event.portId;
-		flowInformation = new FlowInformation();
-		flowInformation->localAppName = flow.localAppName;
-		flowInformation->remoteAppName = flow.remoteAppName;
-		flowInformation->difName = flow.difName;
-		flowInformation->flowSpecification = flow.flowSpecification;
-		flowInformation->state = flow.state;
-		flowInformation->portId = flow.portId;
 		rib_daemon_->createObject(NMinusOneFlowSetRIBObject::N_MINUS_ONE_FLOW_RIB_OBJECT_CLASS,
-					  ss.str(), flowInformation, 0);
+					  ss.str(), &flow, 0);
 	} catch (Exception &e) {
 		LOG_ERR("Problems creating RIB object: %s", e.what());
 	}
 
 	InternalEvent * flowAllocatedEvent =
-			new NMinusOneFlowAllocatedEvent(event.sequenceNumber,
-							*flowInformation);
+			new NMinusOneFlowAllocatedEvent(event.sequenceNumber, flow);
 	event_manager_->deliverEvent(flowAllocatedEvent);
 }
 
@@ -211,7 +202,6 @@ void IPCResourceManager::flowAllocationRequested(const FlowRequestEvent& event)
 		}
 	}
 
-	FlowInformation * flowInformation = 0;
 	FlowInformation flow;
 	try {
 		if (ipcp) {
@@ -231,21 +221,14 @@ void IPCResourceManager::flowAllocationRequested(const FlowRequestEvent& event)
 		std::stringstream ss;
 		ss<<NMinusOneFlowSetRIBObject::N_MINUS_ONE_FLOW_SET_RIB_OBJECT_NAME;
 		ss<<RIBNamingConstants::SEPARATOR<<event.portId;
-		flowInformation = new FlowInformation();
-		flowInformation->localAppName = flow.localAppName;
-		flowInformation->remoteAppName = flow.remoteAppName;
-		flowInformation->difName = flow.difName;
-		flowInformation->flowSpecification = flow.flowSpecification;
-		flowInformation->state = flow.state;
-		flowInformation->portId = flow.portId;
 		rib_daemon_->createObject(NMinusOneFlowSetRIBObject::N_MINUS_ONE_FLOW_RIB_OBJECT_CLASS,
-					  ss.str(), flowInformation, 0);
+					  ss.str(), &flow, 0);
 	} catch (Exception &e){
 		LOG_ERR("Error creating RIB object: %s", e.what());
 	}
 
 	InternalEvent * flowAllocatedEvent =
-			new NMinusOneFlowAllocatedEvent(event.sequenceNumber,*flowInformation);
+			new NMinusOneFlowAllocatedEvent(event.sequenceNumber, flow);
 	event_manager_->deliverEvent(flowAllocatedEvent);
 }
 
@@ -360,17 +343,32 @@ std::list<FlowInformation> IPCResourceManager::getAllNMinusOneFlowInformation() 
 DIFRegistrationRIBObject::DIFRegistrationRIBObject(IRIBDaemon* rib_daemon,
 						   const std::string& object_class,
 						   const std::string& object_name,
-						   const std::string* dif_name) :
-			SimpleSetMemberRIBObject(rib_daemon, object_class, object_name, dif_name)
+						   const std::string& dif_name_) :
+			BaseRIBObject(rib_daemon, object_class, objectInstanceGenerator->getObjectInstance(),
+				      object_name)
 {
+	dif_name = dif_name_;
 }
 
-std::string DIFRegistrationRIBObject::get_displayable_value() {
-	const std::string * dif_name = (const std::string *) get_value();
+const void* DIFRegistrationRIBObject::get_value() const
+{
+	return &dif_name;
+}
+
+std::string DIFRegistrationRIBObject::get_displayable_value()
+{
 	std::stringstream ss;
-	ss << "N-1 DIF name: " << *dif_name;
+	ss << "N-1 DIF name: " << dif_name;
 
 	return ss.str();
+}
+
+void DIFRegistrationRIBObject::deleteObject(const void* objectValue)
+{
+        (void) objectValue; // Stop compiler barfs
+
+        parent_->remove_child(name_);
+        base_rib_daemon_->removeRIBObject(name_);
 }
 
 // Class DIF registration set RIB Object
@@ -396,12 +394,14 @@ const void* DIFRegistrationSetRIBObject::get_value() const
 
 void DIFRegistrationSetRIBObject::createObject(const std::string& objectClass,
 	const std::string& objectName,
-	const void* objectValue) {
+	const void* objectValue)
+{
+	const std::string * dif_name = (const std::string *) objectValue;
 	DIFRegistrationRIBObject * ribObject =
 		new DIFRegistrationRIBObject(base_rib_daemon_,
 					     objectClass,
 					     objectName,
-					     (const std::string *) objectValue);
+					     *dif_name);
 	add_child(ribObject);
 	base_rib_daemon_->addRIBObject(ribObject);
 }
@@ -410,26 +410,39 @@ void DIFRegistrationSetRIBObject::createObject(const std::string& objectClass,
 NMinusOneFlowRIBObject::NMinusOneFlowRIBObject(IRIBDaemon * rib_daemon,
 				 	       const std::string& object_class,
 					       const std::string& object_name,
-					       const rina::FlowInformation* flow_info)
-		: SimpleSetMemberRIBObject(rib_daemon, object_class, object_name, flow_info)
+					       const rina::FlowInformation& flow_info)
+		: BaseRIBObject(rib_daemon, object_class, objectInstanceGenerator->getObjectInstance(),
+				object_name)
 {
+	flow_information = flow_info;
 }
 
 std::string NMinusOneFlowRIBObject::get_displayable_value()
 {
-	const FlowInformation * flow_info =
-			(const FlowInformation *) get_value();
 	std::stringstream ss;
 	ApplicationProcessNamingInformation name;
-	name = flow_info->localAppName;
+	name = flow_information.localAppName;
 	ss << "Local app name: " << name.getEncodedString();
-	name = flow_info->remoteAppName;
+	name = flow_information.remoteAppName;
 	ss << "Remote app name: " << name.getEncodedString() << std::endl;
-	ss << "N-1 DIF name: " << flow_info->difName.processName;
-	ss << "; port-id: " << flow_info->portId << std::endl;
-	FlowSpecification flowSpec = flow_info->flowSpecification;
+	ss << "N-1 DIF name: " << flow_information.difName.processName;
+	ss << "; port-id: " << flow_information.portId << std::endl;
+	FlowSpecification flowSpec = flow_information.flowSpecification;
 	ss << "Flow characteristics: " << flowSpec.toString();
 	return ss.str();
+}
+
+const void* NMinusOneFlowRIBObject::get_value() const
+{
+	return &flow_information;
+}
+
+void NMinusOneFlowRIBObject::deleteObject(const void* objectValue)
+{
+        (void) objectValue; // Stop compiler barfs
+
+        parent_->remove_child(name_);
+        base_rib_daemon_->removeRIBObject(name_);
 }
 
 // Class N-1 Flow set RIB Object
@@ -457,11 +470,12 @@ void NMinusOneFlowSetRIBObject::createObject(const std::string& objectClass,
 		const std::string& objectName,
 		const void* objectValue)
 {
+	const FlowInformation * flow_info = (const FlowInformation *) objectValue;
 	NMinusOneFlowRIBObject * ribObject =
 		new NMinusOneFlowRIBObject(base_rib_daemon_,
 					   objectClass,
 					   objectName,
-					   (const rina::FlowInformation *) objectValue);
+					   *flow_info);
 	add_child(ribObject);
 	base_rib_daemon_->addRIBObject(ribObject);
 }

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -536,7 +536,7 @@ IPCMConsole::register_at_dif(vector<string>& args)
 int
 IPCMConsole::unregister_from_dif(std::vector<std::string>& args)
 {
-	int ipcp_id, slave_ipcp_id;
+	int ipcp_id;
 	Promise promise;
 
 	if (args.size() < 3) {
@@ -544,7 +544,7 @@ IPCMConsole::unregister_from_dif(std::vector<std::string>& args)
 		return CMDRETCONT;
 	}
 
-	std::string dif_name(args[2]);
+	rina::ApplicationProcessNamingInformation dif_name(args[2], string());
 
 	if(string2int(args[1], ipcp_id)){
 		outstream << "Invalid IPC process id" << endl;
@@ -555,15 +555,9 @@ IPCMConsole::unregister_from_dif(std::vector<std::string>& args)
 		return CMDRETCONT;
 	}
 
-	slave_ipcp_id = IPCManager->get_ipcp_by_dif_name(dif_name);
-	if (!IPCManager->ipcp_exists(slave_ipcp_id) ) {
-		outstream << "No IPC process in that DIF" << endl;
-		return CMDRETCONT;
-	}
-
 	//Call IPCManager
 	if(IPCManager->unregister_ipcp_from_ipcp(&promise, ipcp_id,
-			slave_ipcp_id) == IPCM_FAILURE || promise.wait() != IPCM_SUCCESS) {
+			dif_name) == IPCM_FAILURE || promise.wait() != IPCM_SUCCESS) {
 		outstream << "Unregistration failed" << endl;
 		return CMDRETCONT;
 	}

--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -286,7 +286,10 @@ void IPCManager_::app_reg_response_handler(rina::IpcmRegisterApplicationResponse
         ostringstream ss;
 	APPregTransState* t1;
 	IPCPregTransState* t2;
-	ipcm_res_t ret = IPCM_SUCCESS;
+	ipcm_res_t ret = IPCM_FAILURE;
+	if (e->result == 0) {
+		ret = IPCM_SUCCESS;
+	}
 	IPCPTransState* trans = get_transaction_state<IPCPTransState>(e->sequenceNumber);
 
 	if(!trans){
@@ -320,7 +323,7 @@ void IPCManager_::app_reg_response_handler(rina::IpcmRegisterApplicationResponse
 			ipcm_register_response_app(e, ipcp, t1->req);
 		}else{
 			//IPCP registration
-			ipcm_register_response_ipcp(e);
+			ipcm_register_response_ipcp(ipcp, e);
 		}
 	}catch(...){
 		ret = IPCM_FAILURE;

--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -441,7 +441,10 @@ void IPCManager_::unreg_app_response_handler(rina::IpcmUnregisterApplicationResp
 {
 	ostringstream ss;
 	IPCMIPCProcess* ipcp;
-	ipcm_res_t ret = IPCM_SUCCESS;
+	ipcm_res_t ret = IPCM_FAILURE;
+	if (e->result == 0) {
+		ret = IPCM_SUCCESS;
+	}
 
 	//First check if this de-reg was a pending
 	APPUnregTransState* t1;
@@ -480,7 +483,7 @@ void IPCManager_::unreg_app_response_handler(rina::IpcmUnregisterApplicationResp
 		} else {
 			t2 = get_transaction_state<IPCPregTransState>(e->sequenceNumber);
 			if (t2){
-				ipcm_unregister_response_ipcp(e, t2);
+				ipcm_unregister_response_ipcp(ipcp, e, t2);
 			}
 			else {
 				//This is the case when the app unreg has been requested by the IPCM

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -605,7 +605,7 @@ protected:
 		const rina::ApplicationRegistrationRequestEvent& req_event);
 
 	//IPCP mgmt
-	int ipcm_register_response_ipcp(
+	void ipcm_register_response_ipcp(IPCMIPCProcess * ipcp,
 		rina::IpcmRegisterApplicationResponseEvent *event);
 	void ipcm_unregister_response_ipcp(IPCMIPCProcess * ipcp,
 				rina::IpcmUnregisterApplicationResponseEvent *event,

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -388,7 +388,7 @@ public:
 	// @ret IPCM_FAILURE on failure, otherwise the IPCM_PENDING
 	ipcm_res_t unregister_ipcp_from_ipcp(Promise* promise,
 						const unsigned short ipcp_id,
-						const unsigned short slave_ipcp_id);
+						const rina::ApplicationProcessNamingInformation& dif_name);
 	//
 	// Update the DIF configuration
 	//TODO: What is really this for?
@@ -607,7 +607,7 @@ protected:
 	//IPCP mgmt
 	int ipcm_register_response_ipcp(
 		rina::IpcmRegisterApplicationResponseEvent *event);
-	int ipcm_unregister_response_ipcp(
+	void ipcm_unregister_response_ipcp(IPCMIPCProcess * ipcp,
 				rina::IpcmUnregisterApplicationResponseEvent *event,
 				TransactionState *trans);
 

--- a/rinad/src/ipcm/ipcp-handlers.cc
+++ b/rinad/src/ipcm/ipcp-handlers.cc
@@ -97,7 +97,7 @@ void IPCManager_::ipc_process_daemon_initialized_event_handler(
 	return;
 }
 
-int IPCManager_::ipcm_register_response_ipcp(
+void IPCManager_::ipcm_register_response_ipcp(IPCMIPCProcess * ipcp,
 	rina::IpcmRegisterApplicationResponseEvent *e)
 {
 	ostringstream ss;
@@ -106,18 +106,16 @@ int IPCManager_::ipcm_register_response_ipcp(
 	IPCPregTransState* trans = get_transaction_state<IPCPregTransState>(e->sequenceNumber);
 
 	if(!trans){
-		return ret;
+		LOG_ERR("Transaction not of valid type");
+		throw rina::Exception();
 	}
 
-	rinad::IPCMIPCProcess *ipcp = lookup_ipcp_by_id(trans->ipcp_id);
-	if(!ipcp)
-		return ret;
-	//Auto release the read lock
-	rina::ReadScopedLock readlock(ipcp->rwlock, false);
-
 	rinad::IPCMIPCProcess *slave_ipcp = lookup_ipcp_by_id(trans->slave_ipcp_id);
-	if(!slave_ipcp)
-		return ret;
+	if(!slave_ipcp) {
+		LOG_ERR("Could not find slave IPCP");
+		throw rina::Exception();
+	}
+
 	//Auto release the read lock
 	rina::ReadScopedLock sreadlock(slave_ipcp->rwlock, false);
 
@@ -137,8 +135,6 @@ int IPCManager_::ipcm_register_response_ipcp(
 				"to N-1 DIF " <<
 				slave_dif_name.toString() << endl;
 			FLUSH_LOG(INFO, ss);
-
-			ret = IPCM_SUCCESS;
 		} catch (rina::NotifyRegistrationToDIFException& e) {
 			ss  << ": Error while notifying "
 				"IPC process " <<
@@ -146,15 +142,15 @@ int IPCManager_::ipcm_register_response_ipcp(
 				" about registration to N-1 DIF"
 				<< slave_dif_name.toString() << endl;
 			FLUSH_LOG(ERR, ss);
+			throw e;
 		}
 	} else {
 		ss  << "Cannot register IPC process "
 			<< ipcp->get_name().toString() <<
 			" to DIF " << slave_dif_name.toString() << endl;
 		FLUSH_LOG(ERR, ss);
+		throw rina::Exception();
 	}
-
-	return ret;
 }
 
 void IPCManager_::ipcm_unregister_response_ipcp(IPCMIPCProcess * ipcp,

--- a/rinad/src/ipcp/resource-allocator.cc
+++ b/rinad/src/ipcp/resource-allocator.cc
@@ -76,9 +76,8 @@ void NMinusOneFlowManager::processRegistrationNotification(const rina::IPCProces
 			std::stringstream ss;
 			ss<<rina::DIFRegistrationSetRIBObject::DIF_REGISTRATION_SET_RIB_OBJECT_NAME;
 			ss<<rina::RIBNamingConstants::SEPARATOR<<event.getDIFName().processName;
-			std::string * dif_name = new std::string(event.getDIFName().processName);
 			rib_daemon_->createObject(rina::DIFRegistrationSetRIBObject::DIF_REGISTRATION_RIB_OBJECT_CLASS,
-					ss.str(), dif_name, 0);
+					ss.str(), &(event.getDIFName().processName), 0);
 		}catch(rina::Exception &e){
 			LOG_IPCP_ERR("Problems creating RIB object: %s", e.what());;
 		}


### PR DESCRIPTION
Fixed a couple of bugs:

* Fixed handling of object value in IRM RIB objects, before could lead to seg faults
* Fixed IPCM deadlocks when processing unregister-from-dif and register-at-dif operations
* Fixed bug in IPCM register-at-dif respone handler