### PR TITLE
Fix RMT policy set compilation warning

### DIFF
--- a/linux/net/rina/rmt-ps-default.c
+++ b/linux/net/rina/rmt-ps-default.c
@@ -52,13 +52,13 @@ struct rmt_ps_data {
 static void
 default_max_q_policy_tx(struct rmt_ps * ps,
                         struct pdu *    pdu,
-                        struct rfifo *  queue)
+                        struct rmt_n1_port * n1_port)
 { }
 
 static void
 default_max_q_policy_rx(struct rmt_ps * ps,
                         struct sdu *    sdu,
-                        struct rfifo *  queue)
+                        struct rmt_n1_port * n1_port)
 { }
 
 static void


### PR DESCRIPTION
Just a simple fix in argument pointer type.