### PR TITLE
Ignore SIGINT in IPC processes

### DIFF
--- a/rinad/src/ipcp/main.cc
+++ b/rinad/src/ipcp/main.cc
@@ -117,13 +117,14 @@ int main(int argc, char * argv[])
 
         LOG_IPCP_DBG("SIGSEGV handler installed successfully");
 
-        if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
+        if (signal(SIGPIPE, SIG_IGN) == SIG_ERR){
                 LOG_IPCP_WARN("Cannot ignore SIGPIPE, bailing out");
-
+		return EXIT_FAILURE;
+	}
         LOG_IPCP_DBG("SIGPIPE handler installed successfully");
 
         if (signal(SIGINT, SIG_IGN) == SIG_ERR)
-                LOG_IPCP_WARN("Cannot ignore SIGINT, bailing out");
+                LOG_IPCP_WARN("Cannot ignore SIGINT!");
 
         LOG_IPCP_DBG("SIGINT handler installed successfully");
 

--- a/rinad/src/ipcp/main.cc
+++ b/rinad/src/ipcp/main.cc
@@ -112,16 +112,21 @@ int main(int argc, char * argv[])
                 return EXIT_FAILURE;
         }
 
-        if (signal(SIGSEGV, sighandler_segv) == SIG_ERR) {
+        if (signal(SIGSEGV, sighandler_segv) == SIG_ERR)
                 LOG_IPCP_WARN("Cannot install SIGSEGV handler!");
-        }
+
         LOG_IPCP_DBG("SIGSEGV handler installed successfully");
 
-        if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+        if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
                 LOG_IPCP_WARN("Cannot ignore SIGPIPE, bailing out");
-                return EXIT_FAILURE;
-        }
+
         LOG_IPCP_DBG("SIGPIPE handler installed successfully");
+
+        if (signal(SIGINT, SIG_IGN) == SIG_ERR)
+                LOG_IPCP_WARN("Cannot ignore SIGINT, bailing out");
+
+        LOG_IPCP_DBG("SIGINT handler installed successfully");
+
 
         try {
                 retval = wrapped_main(argc, argv);


### PR DESCRIPTION
When debugging the IPCM in gdb, if SIGINT is not ignored, a Ctrl+C in the
debugger signals the child process and, since it is not captured, it dies.

This patch sets SIGINT to be ignored by IPCPs.

This patch requires commit 698eb30198226ac4b3e3d264af1183a5206a7fd1 PR to be
integrated first.