### PR TITLE
Fix ipcm deadlock when no events are received

### DIFF
--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1474,14 +1474,14 @@ void IPCManager_::io_loop(){
 		event = rina::ipcEventProducer->eventTimedWait(
 						IPCM_EVENT_TIMEOUT_S,
 						IPCM_EVENT_TIMEOUT_NS);
-		if(!event)
-			continue;
-
 		if(req_to_stop){
 			//Signal the main thread to start
 			//the stop procedure
 			stop_cond.signal();
 		}
+
+		if(!event)
+			continue;
 
 		if (!keep_running)
 			break;


### PR DESCRIPTION
Fixing (self-introduced) bug during IPCM shutdown process. Condition needs to
be signaled even if librina is not producing ANY event.