### PR TITLE
librina: concurrency: use reinterpret_cast<> to avoid compiler errors

### DIFF
--- a/librina/src/concurrency.cc
+++ b/librina/src/concurrency.cc
@@ -359,7 +359,7 @@ void * do_simple_thread_work(void * arg)
 		return (void *) -1;
 	}
 
-	return (void *) simple_thread->run();
+	return reinterpret_cast<void *>(simple_thread->run());
 }
 
 SimpleThread::SimpleThread(ThreadAttributes * threadAttributes) :


### PR DESCRIPTION
This was resulting in a compilation error induced by -Werror.