### PR TITLE
Fixed bug on not releasing port_ids after failed flow allocation resulting in port_ids exhaustion

### DIFF
--- a/linux/net/rina/efcp.c
+++ b/linux/net/rina/efcp.c
@@ -887,6 +887,7 @@ int efcp_connection_destroy(struct efcp_container * container,
                 }
                 return 0;
         }
+        LOG_DBG("efcp_connection_destroy con pending ops");
         spin_unlock_irqrestore(&container->lock, flags);
 
         return 0;

--- a/linux/net/rina/efcp.c
+++ b/linux/net/rina/efcp.c
@@ -296,7 +296,7 @@ static int efcp_destroy(struct efcp * instance)
 
         rkfree(instance);
 
-        LOG_DBG("Instance %pK finalized successfully", instance);
+        LOG_DBG("EFCP instance %pK finalized successfully", instance);
 
         return 0;
 }
@@ -581,8 +581,8 @@ int efcp_container_receive(struct efcp_container * container,
         spin_lock_irqsave(&container->lock, flags);
         if (atomic_dec_and_test(&tmp->pending_ops) &&
             tmp->state == EFCP_DEALLOCATED) {
-                spin_unlock_irqrestore(&container->lock, flags);
                 efcp_destroy(tmp);
+                spin_unlock_irqrestore(&container->lock, flags);
 
                 return ret;
         }

--- a/linux/net/rina/ipcp-instances.c
+++ b/linux/net/rina/ipcp-instances.c
@@ -101,6 +101,7 @@ bool ipcp_instance_is_normal(struct ipcp_instance_ops * ops)
             ops->pft_add                   ||
             ops->pft_remove                ||
             ops->pft_dump                  ||
+            ops->flow_prebind              ||
             ops->flow_binding_ipcp         ||
             ops->flow_unbinding_ipcp       ||
             ops->flow_deallocate           ||

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -180,6 +180,9 @@ struct ipcp_instance_ops {
                                       cep_id_t                    dst_cep_id,
                                       struct conn_policies *      cp_params);
 
+        int      (* flow_prebind)(struct ipcp_instance_data * data,
+                                  port_id_t                   port_id);
+
         int      (* flow_binding_ipcp)(struct ipcp_instance_data * user_data,
                                        port_id_t                   port_id,
                                        struct ipcp_instance *      n1_ipcp);

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -181,6 +181,7 @@ struct ipcp_instance_ops {
                                       struct conn_policies *      cp_params);
 
         int      (* flow_prebind)(struct ipcp_instance_data * data,
+                                  struct ipcp_instance *      user_ipcp,
                                   port_id_t                   port_id);
 
         int      (* flow_binding_ipcp)(struct ipcp_instance_data * user_data,

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -427,8 +427,10 @@ static int connection_destroy_request(struct ipcp_instance_data * data,
         if (remove_cep_id_from_flow(flow, src_cep_id))
                 LOG_ERR("Could not remove cep_id: %d", src_cep_id);
 
-        if (list_empty(&flow->cep_ids_list))
+        if (list_empty(&flow->cep_ids_list)) {
+                list_del(&flow->list);
                 rkfree(flow);
+        }
         spin_unlock(&data->lock);
 
         return 0;
@@ -487,38 +489,32 @@ connection_create_arrived(struct ipcp_instance_data * data,
         flow = find_flow(data, port_id);
         if (!flow) {
                 spin_unlock(&data->lock);
-                flow = rkzalloc(sizeof(*flow), GFP_KERNEL);
-                if (!flow) {
-                        LOG_ERR("Could not create a flow in normal-ipcp");
-                        efcp_connection_destroy(data->efcpc, cep_id);
-                        return cep_id_bad();
-                }
-                flow->port_id = port_id;
-                INIT_LIST_HEAD(&flow->list);
-                INIT_LIST_HEAD(&flow->cep_ids_list);
+                LOG_ERR("Could not create a flow in normal-ipcp");
+                efcp_connection_destroy(data->efcpc, cep_id);
+                return cep_id_bad();
+        }
+        flow->port_id = port_id;
+        INIT_LIST_HEAD(&flow->list);
+        INIT_LIST_HEAD(&flow->cep_ids_list);
 
-                ipcp = kipcm_find_ipcp(default_kipcm, data->id);
-                if (!ipcp) {
-                        LOG_ERR("KIPCM could not retrieve this IPCP");
-                        efcp_connection_destroy(data->efcpc, cep_id);
-                        return cep_id_bad();
-                }
-
-                ASSERT(user_ipcp->ops);
-                ASSERT(user_ipcp->ops->flow_binding_ipcp);
-                if (user_ipcp->ops->flow_binding_ipcp(user_ipcp->data,
-                                                      conn->port_id,
-                                                      ipcp)) {
-                        LOG_ERR("Could not bind flow with user_ipcp");
-                        efcp_connection_destroy(data->efcpc, cep_id);
-                        return cep_id_bad();
-                }
-
-                spin_lock(&data->lock);
-                list_add(&flow->list, &data->flows);
-
+        ipcp = kipcm_find_ipcp(default_kipcm, data->id);
+        if (!ipcp) {
+                LOG_ERR("KIPCM could not retrieve this IPCP");
+                efcp_connection_destroy(data->efcpc, cep_id);
+                return cep_id_bad();
         }
 
+        ASSERT(user_ipcp->ops);
+        ASSERT(user_ipcp->ops->flow_binding_ipcp);
+        if (user_ipcp->ops->flow_binding_ipcp(user_ipcp->data,
+                                              conn->port_id,
+                                              ipcp)) {
+                LOG_ERR("Could not bind flow with user_ipcp");
+                efcp_connection_destroy(data->efcpc, cep_id);
+                return cep_id_bad();
+        }
+
+        list_add(&flow->list, &data->flows);
         list_add(&cep_entry->list, &flow->cep_ids_list);
         flow->active = cep_id;
         flow->state = PORT_STATE_ALLOCATED;

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -1388,6 +1388,7 @@ static struct ipcp_instance_ops eth_vlan_instance_ops = {
         .flow_allocate_request     = eth_vlan_flow_allocate_request,
         .flow_allocate_response    = eth_vlan_flow_allocate_response,
         .flow_deallocate           = eth_vlan_flow_deallocate,
+        .flow_prebind              = NULL,
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = eth_vlan_unbind_user_ipcp,

--- a/linux/net/rina/ipcps/shim-hv.c
+++ b/linux/net/rina/ipcps/shim-hv.c
@@ -1125,6 +1125,7 @@ static struct ipcp_instance_ops shim_hv_ipcp_ops = {
         .flow_allocate_request     = shim_hv_flow_allocate_request,
         .flow_allocate_response    = shim_hv_flow_allocate_response,
         .flow_deallocate           = shim_hv_flow_deallocate,
+        .flow_prebind              = NULL,
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = shim_hv_unbind_user_ipcp,

--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -2407,7 +2407,7 @@ static int tcp_udp_query_rib(struct ipcp_instance_data * data,
                              const string_t *            object_name,
                              uint64_t                    object_instance,
                              uint32_t                    scope,
-                             const string_t *            filter) 
+                             const string_t *            filter)
 {
 	LOG_MISSING;
 	return -1;
@@ -2417,6 +2417,7 @@ static struct ipcp_instance_ops tcp_udp_instance_ops = {
         .flow_allocate_request     = tcp_udp_flow_allocate_request,
         .flow_allocate_response    = tcp_udp_flow_allocate_response,
         .flow_deallocate           = tcp_udp_flow_deallocate,
+        .flow_prebind              = NULL,
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = tcp_udp_unbind_user_ipcp,

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -105,6 +105,42 @@ port_id_t kfa_port_id_reserve(struct kfa *     instance,
 }
 EXPORT_SYMBOL(kfa_port_id_reserve);
 
+/* NOTE: Add instance-locking IFF exporting to API */
+static int kfa_flow_destroy(struct kfa *       instance,
+                            struct ipcp_flow * flow,
+                            port_id_t          id)
+{
+        int                    retval = 0;
+
+        ASSERT(flow);
+
+        LOG_DBG("We are destroying flow %d", id);
+
+        /* FIXME: Should we ASSERT() here ? */
+        if (!flow->sdu_ready)
+                LOG_WARN("Instance %pK SDU-ready FIFO is NULL", instance);
+        else
+                if (rfifo_destroy(flow->sdu_ready,
+                                  (void (*) (void *)) sdu_destroy)) {
+                        LOG_ERR("Flow %d FIFO has not been destroyed", id);
+                        retval = -1;
+                }
+
+        if (kfa_pmap_remove(instance->flows, id)) {
+                LOG_ERR("Could not remove pending flow with port-id %d", id);
+                retval = -1;
+        }
+
+        if (pidm_release(instance->pidm, id)) {
+                LOG_ERR("Could not release pid %d from the map", id);
+                retval = -1;
+        }
+
+        rkfree(flow);
+
+        return retval;
+}
+
 int  kfa_port_id_release(struct kfa * instance,
                          port_id_t    port_id)
 {
@@ -152,42 +188,6 @@ int  kfa_port_id_release(struct kfa * instance,
         return 0;
 }
 EXPORT_SYMBOL(kfa_port_id_release);
-
-/* NOTE: Add instance-locking IFF exporting to API */
-static int kfa_flow_destroy(struct kfa *       instance,
-                            struct ipcp_flow * flow,
-                            port_id_t          id)
-{
-        int                    retval = 0;
-
-        ASSERT(flow);
-
-        LOG_DBG("We are destroying flow %d", id);
-
-        /* FIXME: Should we ASSERT() here ? */
-        if (!flow->sdu_ready)
-                LOG_WARN("Instance %pK SDU-ready FIFO is NULL", instance);
-        else
-                if (rfifo_destroy(flow->sdu_ready,
-                                  (void (*) (void *)) sdu_destroy)) {
-                        LOG_ERR("Flow %d FIFO has not been destroyed", id);
-                        retval = -1;
-                }
-
-        if (kfa_pmap_remove(instance->flows, id)) {
-                LOG_ERR("Could not remove pending flow with port-id %d", id);
-                retval = -1;
-        }
-
-        if (pidm_release(instance->pidm, id)) {
-                LOG_ERR("Could not release pid %d from the map", id);
-                retval = -1;
-        }
-
-        rkfree(flow);
-
-        return retval;
-}
 
 struct flowdel_data {
         struct kfa * kfa;

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -289,6 +289,7 @@ static int kfa_flow_deallocate(struct ipcp_instance_data * data,
         if ((atomic_read(&flow->readers) == 0) &&
             (atomic_read(&flow->writers) == 0) &&
             (atomic_read(&flow->posters) == 0)) {
+                LOG_DBG("Destroying kfa flow now...");
                 if (kfa_flow_destroy(instance, flow, id))
                         LOG_ERR("Could not destroy the flow correctly");
                 spin_unlock_irqrestore(&instance->lock, flags);
@@ -311,7 +312,6 @@ static int kfa_flow_deallocate(struct ipcp_instance_data * data,
 
         return 0;
 }
-EXPORT_SYMBOL(kfa_flow_deallocate);
 
 static bool ok_write(struct ipcp_flow * flow)
 {

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -295,7 +295,6 @@ static int kfa_flow_deallocate(struct ipcp_instance_data * data,
                 return 0;
         }
 
-        spin_unlock_irqrestore(&instance->lock, flags);
 
         wqdata       = rkzalloc(sizeof(*wqdata), GFP_KERNEL);
         wqdata->kfa  = instance;
@@ -303,11 +302,12 @@ static int kfa_flow_deallocate(struct ipcp_instance_data * data,
 
         item = rwq_work_create_ni(kfa_flow_deallocate_worker, (void *) wqdata);
         if (!item) {
-                rkfree(data);
+                rkfree(wqdata);
                 return -1;
         }
 
         rwq_work_post(data->kfa->flowdelq, item);
+        spin_unlock_irqrestore(&instance->lock, flags);
 
         return 0;
 }

--- a/linux/net/rina/kipcm.c
+++ b/linux/net/rina/kipcm.c
@@ -2227,16 +2227,19 @@ int kipcm_deallocate_port(struct kipcm *   kipcm,
                           port_id_t        port_id)
 {
         struct ipcp_instance * ipc_process;
+        int                    ret = 0;
 
         if (!kipcm) {
                 LOG_ERR("Bogus kipcm instance passed, bailing out");
-                return -1;
+                ret = -1;
+                goto exit;
         }
 
         ipc_process = ipcp_imap_find(kipcm->instances, ipc_id);
         if (!ipc_process) {
                 LOG_ERR("IPC process %d not found", ipc_id);
-                return -1;
+                ret = -1;
+                goto exit;
         }
 
         ASSERT(ipc_process->ops);
@@ -2245,12 +2248,13 @@ int kipcm_deallocate_port(struct kipcm *   kipcm,
         if (ipc_process->ops->flow_deallocate(ipc_process->data, port_id)) {
                 LOG_ERR("Failed deallocate flow request "
                         "for port id: %d", port_id);
-                return -1;
+                ret = -1;
+                goto exit;
         }
 
+        exit:
         kfa_port_id_release(kipcm->kfa, port_id);
-
-        return 0;
+        return ret;
 }
 
 int kipcm_notify_flow_alloc_req_result(struct kipcm *   kipcm,

--- a/linux/net/rina/kipcm.c
+++ b/linux/net/rina/kipcm.c
@@ -2200,12 +2200,13 @@ port_id_t kipcm_allocate_port(struct kipcm *   kipcm,
         }
 
         ASSERT(ipc_process->ops);
-        if (ipc_process->ops->flow_prebind) {
-                ipc_process->ops->flow_prebind(ipc_process->data, pid);
-        }
 
         user_ipc_process = ipcp_imap_find_by_name(kipcm->instances,
                                                   process_name);
+
+        if (ipc_process->ops->flow_prebind) {
+                ipc_process->ops->flow_prebind(ipc_process->data, user_ipc_process, pid);
+        }
 
         if (user_ipc_process) {
                 KIPCM_UNLOCK(kipcm);


### PR DESCRIPTION
Related to #595 some other bugs where discovered and fixed by means of a new op in the normal_ipcp api. It has to be merged in pristine-1.2 and ported to pristine-1.3.

Tested and working, @bernatgaston  to test again and ack it.