### PR TITLE
rinad: ipcp: fix Edge equality operator logic

### DIFF
--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -162,7 +162,7 @@ std::list<unsigned int> Edge::getEndpoints()
 
 bool Edge::operator==(const Edge & other) const
 {
-	if (isVertexIn(other.address1_)) {
+	if (!isVertexIn(other.address1_)) {
 		return false;
 	}
 


### PR DESCRIPTION
This fixes wrong logic in Edge::operator==.