### PR TITLE
Fix rinad IPCP tests in pristine-1.2

### DIFF
--- a/librina/test/test-01.cc
+++ b/librina/test/test-01.cc
@@ -33,7 +33,7 @@ bool checkAllocatedFlows(unsigned int expectedFlows) {
         std::vector<FlowInformation> allocatedFlows = ipcManager->getAllocatedFlows();
         if (allocatedFlows.size() != expectedFlows) {
                 std::cout << "ERROR: Expected " << expectedFlows
-                                << " allocated flows, but only found " + allocatedFlows.size()
+                                << " allocated flows, but only found " << allocatedFlows.size()
                                 << "\n";
                 return false;
         }
@@ -53,7 +53,7 @@ bool checkRegisteredApplications(unsigned int expectedApps) {
         if (registeredApplications.size() != expectedApps) {
                 std::cout << "ERROR: Expected " << expectedApps
                                 << " registered applications, but only found "
-                                                + registeredApplications.size() << "²n";
+                                                << registeredApplications.size() << "²n";
                 return false;
         }
 

--- a/rinad/src/ipcp/plugins/default/test-routing.cc
+++ b/rinad/src/ipcp/plugins/default/test-routing.cc
@@ -434,11 +434,9 @@ public:
 	}
 
     std::vector<rina::PsFactory>::iterator
-                    psFactoryLookup(const std::string& component,
-                                   const std::string& name) {
+                    psFactoryLookup(const rina::PsInfo& ps_info) {
     	std::vector<rina::PsFactory>::iterator response;
-    	(void) component;
-    	(void) name;
+    	(void) ps_info;
     	return response;
     }
 
@@ -447,10 +445,8 @@ public:
     	return 0;
     }
 
-    int psFactoryUnpublish(const std::string& component,
-                                          const std::string& name){
-    	(void) component;
-    	(void) name;
+    int psFactoryUnpublish(const rina::PsInfo& ps_info){
+    	(void) ps_info;
     	return 0;
     }
 

--- a/rinad/src/ipcp/test-encoders.cc
+++ b/rinad/src/ipcp/test-encoders.cc
@@ -538,7 +538,7 @@ bool test_neighbor(rinad::Encoder * encoder) {
 	nei.supporting_difs_.push_back(rina::ApplicationProcessNamingInformation("Castefa.i2CAT", "1"));
 
 	rina::CDAPMessage cdapMessage = rina::CDAPMessage();
-	cdapMessage.obj_class_ = rinad::EncoderConstants::NEIGHBOR_RIB_OBJECT_CLASS;
+	cdapMessage.obj_class_ = rina::NeighborSetRIBObject::NEIGHBOR_RIB_OBJECT_CLASS;
 
 	encoder->encode(&nei, &cdapMessage);
 
@@ -576,7 +576,7 @@ bool test_neighbor_list(rinad::Encoder * encoder) {
 	nei_list.push_back(&nei2);
 
 	rina::CDAPMessage cdapMessage = rina::CDAPMessage();
-	cdapMessage.obj_class_ = rinad::EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_CLASS;
+	cdapMessage.obj_class_ = rina::NeighborSetRIBObject::NEIGHBOR_SET_RIB_OBJECT_CLASS;
 
 	encoder->encode(&nei_list, &cdapMessage);
 
@@ -629,9 +629,9 @@ int main()
 			new rinad::EnrollmentInformationRequestEncoder());
 	encoder.addEncoder(rinad::EncoderConstants::FLOW_RIB_OBJECT_CLASS,
 			new rinad::FlowEncoder());
-	encoder.addEncoder(rinad::EncoderConstants::NEIGHBOR_RIB_OBJECT_CLASS,
+	encoder.addEncoder(rina::NeighborSetRIBObject::NEIGHBOR_RIB_OBJECT_CLASS,
 			new rinad::NeighborEncoder());
-	encoder.addEncoder(rinad::EncoderConstants::NEIGHBOR_SET_RIB_OBJECT_CLASS,
+	encoder.addEncoder(rina::NeighborSetRIBObject::NEIGHBOR_SET_RIB_OBJECT_CLASS,
 			new rinad::NeighborListEncoder());
 	encoder.addEncoder(rinad::EncoderConstants::QOS_CUBE_RIB_OBJECT_CLASS,
 			new rinad::QoSCubeEncoder());


### PR DESCRIPTION
A couple of fixes on rinad's `make check`

**WARNING**: this commit contains _intentionally_ #621, so please ACK and merge #621 first