### PR TITLE
stop copying DIF templates to the <installation folder/etc> when building rinad

### DIFF
--- a/rinad/src/ipcm/dif-template-manager.cc
+++ b/rinad/src/ipcm/dif-template-manager.cc
@@ -324,6 +324,10 @@ void DIFTemplateManager::augment_dif_template(rinad::DIFTemplate * dif_template)
 		}
 	}
 
+	if (dif_template->smConfiguration.policy_set_.name_ == std::string()) {
+		dif_template->smConfiguration = default_template->smConfiguration;
+	}
+
 	if (dif_template->addressPrefixes.size() == 0) {
 		for (std::list<rinad::AddressPrefixConfiguration>::iterator it =
 				default_template->addressPrefixes.begin();


### PR DESCRIPTION
Since it's quite annoying that it overwrites the DIF templates of the user