### PR TITLE
rmt: sender_worker: workaround to avoid unlimited spinning

### DIFF
--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -668,7 +668,7 @@ static void send_worker(unsigned long o)
                                                 LOG_ERR("Could not write scheduled PDU in n1 port");
                                         pdus_sent++;
                                 }
-                        } while((pdus_sent < MAX_PDUS_SENT_PER_CYCLE) &&
+                        } while(pdu && (pdus_sent < MAX_PDUS_SENT_PER_CYCLE) &&
                                 (atomic_read(&n1_port->n_sdus) > 0));
                 }
                 rcu_read_unlock();


### PR DESCRIPTION
This is a workaround for https://github.com/IRATI/stack/issues/628, useful to make pristine-1.3 usable again.