### PR TITLE
Pristine 1.3 Fix errors when setting encryption key

### DIFF
--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -119,7 +119,6 @@ struct dup_config_entry {
 	string_t * 	encryption_cipher;
 	string_t * 	message_digest;
 	string_t * 	compress_alg;
-	struct buffer * key;
 };
 
 struct dup_config {

--- a/linux/net/rina/ipcp-utils.c
+++ b/linux/net/rina/ipcp-utils.c
@@ -700,9 +700,6 @@ int dup_config_entry_destroy(struct dup_config_entry * entry)
 	if (entry->message_digest)
 		rkfree(entry->message_digest);
 
-	if (entry->key)
-		buffer_destroy(entry->key);
-
 	rkfree(entry);
 
 	return 0;
@@ -761,11 +758,6 @@ int dup_config_entry_cpy(const struct dup_config_entry * src,
                     string_dup(src->message_digest, &dst->message_digest))
                     return -1;
 
-                if (src->key) {
-                	dst->key = buffer_dup(src->key);
-                	if (!dst->key)
-                		return -1;
-                }
                 dst->enable_decryption = src->enable_decryption;
                 dst->enable_encryption = src->enable_encryption;
         }

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1676,7 +1676,6 @@ int rmt_enable_encryption(struct rmt *    instance,
 		}
 	}
 
-	rmt_port->dup_config->key = encrypt_key;
 	if (!rmt_port->dup_config->enable_decryption) {
 		rmt_port->dup_config->enable_decryption = enable_decryption;
 	}

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1621,8 +1621,6 @@ int rmt_enable_encryption(struct rmt *    instance,
 {
 	struct rmt_n1_port * rmt_port;
 	unsigned long        flags;
-	char * key;
-	ssize_t key_length;
 
 	if (!instance) {
 		LOG_ERR("Bogus RMT instance passed");
@@ -1663,13 +1661,10 @@ int rmt_enable_encryption(struct rmt *    instance,
 	spin_lock_irqsave(&rmt_port->lock, flags);
 	if (!rmt_port->dup_config->enable_decryption &&
 			!rmt_port->dup_config->enable_encryption) {
-		key_length = buffer_length(encrypt_key);
-		key = rkmalloc(key_length, GFP_KERNEL);
-		memcpy(key, buffer_data_ro(encrypt_key), key_length);
-
 		/* Need to set key. FIXME: Move this to policy specific code */
 		if (crypto_blkcipher_setkey(rmt_port->blkcipher,
-					    key, key_length)) {
+					    buffer_data_ro(encrypt_key),
+					    buffer_length(encrypt_key))) {
 			LOG_ERR("Could not set encryption key for N-1 port %d", port_id);
 			spin_unlock_irqrestore(&rmt_port->lock, flags);
 			return -1;


### PR DESCRIPTION
Fixed errors when setting the encryption key:

* No need to store the key in the config (it is useless and uses memory for nothing). Moreover, there was a bug since the key is destroyed by the KIPCM before returning from the 'enable_encryption' function, and the RMT was destroying the entry again when destroying the N-1 port.

* No need to copy the key before setting it at the blockcipher, since the blockcipher copies it.