### PR TITLE
check_maintainers: list maintainers of a patchset

### DIFF
--- a/check_maintainers.py
+++ b/check_maintainers.py
@@ -4,13 +4,13 @@ import os
 import sys
 import getopt
 import re
+import subprocess
 import fnmatch
+from argparse import ArgumentParser, RawTextHelpFormatter
 
 """
 
 @brief Check sanity of MAINTAINERS file
-
-
 @author Marc Sune <marc.sune (at) bisdn.de>
 
 """
@@ -67,10 +67,9 @@ def get_directory(p):
 def check_extension(f):
 	return os.path.splitext(f)[1] in CHECK_EXTENSIONS
 
-def validate_maintainers(maintainers, fn):
-	global errors
-	num_maintainers=0
+def get_maintainers(maintainers, fn):
 	c=list()
+	num_maintainers=0
 	for m, val in maintainers.items():
 		for p in val["f"]:
 			if fnmatch.fnmatch(fn, p):
@@ -79,9 +78,14 @@ def validate_maintainers(maintainers, fn):
 		for p in val["x"]:
 			if fnmatch.fnmatch(fn, p):
 				num_maintainers -=1
+	return c, num_maintainers
+
+def validate_maintainers(maintainers, fn):
+	global errors
+	c, num_maintainers = get_maintainers(maintainers, fn)
 
 	if num_maintainers == 0:
-		errormsg("unclaimed file: '%s'" % (fn))
+		errormsg("unclaimed file '%s'" % (fn))
 		errors +=1
 	elif num_maintainers > 1:
 		msg="duplicated claim for file '%s' by\n" % (fn)
@@ -101,14 +105,85 @@ def scan_paths(maintainers, paths):
 					continue
 
 				validate_maintainers(maintainers, name)
+
+def list_maintainers(maintainers, opt):
+
+	try:
+		int(opt)
+		is_int = True
+	except:
+		is_int = False
+
+	if os.path.isfile(opt):
+		cmd = "git apply --index --numstat "+opt+" | cut -f 3-"
+		try:
+			p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+		except Exception as e:
+			errormsg("Unable to parse patch file '"+opt+"'. Error"+str(e))
+			sys.exit(1)
+	elif is_int:
+		cmd = "git diff HEAD~"+opt+" --name-only"
+		try:
+			p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+		except Exception as e:
+			errormsg("Unable to retrieve files for the last '"+opt+"' commits. Error"+str(e))
+			sys.exit(1)
+
+	else:
+		cmd = "git diff "+opt+" --name-only"
+		try:
+			p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+		except Exception as e:
+			errormsg("Unable to retrieve files for the last '"+opt+"' commits. Error"+str(e))
+			sys.exit(1)
+
+	for f_ in p.stdout.read().split():
+		ms, n = get_maintainers(maintainers, f_)
+		if not check_extension(f_):
+			continue
+		if n == 0:
+			continue
+		print "F: "+f_
+		for m in ms:
+			print "\t"+m
+
 #Main routine
 def main():
+	#Parse arguments
+	parser = ArgumentParser(description=" %s - check maintainers script.\n\n"
+				"Check sanity of the MAINTAINERS file and list maintainers for a patch/series." % (__file__),
+				epilog="Examples:\n"
+				" %s \t\t\t-- check MAINTAINERS file sanity and against the current tree\n"
+				" %s -n 0001-feature.patch\t-- list *only* the maintainers of the files affected by the patch\n"
+				" %s -n -l 20\t\t-- list *only* the maintainers of the files affected by the last 20 patches (git diff HEAD~20)\n"
+				" %s -n -l v0.9.0\t\t-- list *only* the maintainers of the files affected by the last 20 patches (git diff v0.9.0)" % (__file__, __file__,__file__,__file__),
+                                add_help=True,
+				formatter_class=RawTextHelpFormatter)
+
+	parser.add_argument("-n", "--no-maintainers-check",
+			dest="no_check", action="store_true", default=False,
+			help="Do not check the MAINTAINERS file against the tree")
+
+	parser.add_argument("-l", "--list-maintainers",
+			dest="patchset", default=False,
+			help="List maintainers for a patch/series of patches.\n"
+				"PATCHSET can be: a patch file, or the number of commits \nfrom HEAD or commit SHA")
+	args = parser.parse_args()
+
 	try:
 		f = open(MAINTAINERS_FILE)
 	except:
 		errormsg("Unable to open maintainers file '"+MAINTAINERS_FILE+"'")
+
+	#Parse maintainers file
 	maintainers = parse_maintainers(f)
-	scan_paths(maintainers, PATHS_TO_CHECK)
+	#Check it
+	if not args.no_check:
+		scan_paths(maintainers, PATHS_TO_CHECK)
+	#List maintainers
+	if args.patchset:
+		list_maintainers(maintainers, args.patchset)
+
 	if errors > 0:
 		print("Number of errors: %s" % errors)
 	sys.exit(errors)


### PR DESCRIPTION
This patch adds the functionality to check_maintainers.py to list
the maintainers of the files that a commit or a series of commits
affect.

It supports:

* Checking a (single) patch file
* Checking last N commits in the current branch
* Checking against the current HEAD with a ref (e.g. a git tag)

Other improvements:

* Adding help option '-h'
* Minor cosmetics to the code