### PR TITLE
check_maintainers: fix python3 and misc bugs

### DIFF
--- a/check_maintainers.py
+++ b/check_maintainers.py
@@ -65,6 +65,8 @@ def get_directory(p):
 	return p.rsplit('/', 1)[0]
 
 def check_extension(f):
+	if f == MAINTAINERS_FILE:
+		return True
 	return os.path.splitext(f)[1] in CHECK_EXTENSIONS
 
 def get_maintainers(maintainers, fn):
@@ -138,7 +140,7 @@ def list_maintainers(maintainers, opt):
 			sys.exit(1)
 
 	for f_ in p.stdout.read().split():
-		f_ = str(f_)
+		f_ = f_.decode('utf-8')
 		ms, n = get_maintainers(maintainers, f_)
 		if not check_extension(f_):
 			continue


### PR DESCRIPTION
Fixed following bugs in check_maintainers.py:

* -l was incorrectly ignoring file names due to non-implicit
  conversion of bytestring to str
* include MAINTAINERS file.