### PR TITLE
kernel: pff: add component delivery workflow SDK support

### DIFF
--- a/linux/net/rina/dtcp.c
+++ b/linux/net/rina/dtcp.c
@@ -1282,7 +1282,9 @@ int dtcp_set_policy_set_param(struct dtcp * dtcp,
                         LOG_ERR("Unknown DTP parameter policy '%s'", name);
                 }
                 rcu_read_unlock();
+
         } else {
+                /* The request addresses the DTP policy-set. */
                 ret = base_set_policy_set_param(&dtcp->base, path, name, value);
         }
 

--- a/linux/net/rina/pff.c
+++ b/linux/net/rina/pff.c
@@ -251,21 +251,22 @@ int pff_dump(struct pff *       instance,
         return 0;
 }
 
-/* NOTE: Skeleton code, PFF currently has no subcomponents*/
 int pff_select_policy_set(struct pff *     pff,
                           const string_t * path,
                           const string_t * name)
 {
-        int ret;
+	int ret;
 
-        if (path && strcmp(path, "")) {
-                LOG_ERR("This component has no selectable subcomponents");
-                return -1;
-        }
+	BUG_ON(!path);
 
-        ret = base_select_policy_set(&pff->base, &policy_sets, name);
+	if (strcmp(path, "")) {
+		LOG_ERR("This component has no selectable subcomponents");
+		return -1;
+	}
 
-        return ret;
+	ret = base_select_policy_set(&pff->base, &policy_sets, name);
+
+	return ret;
 }
 EXPORT_SYMBOL(pff_select_policy_set);
 

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -420,12 +420,26 @@ int rmt_select_policy_set(struct rmt * rmt,
                           const string_t * path,
                           const string_t * name)
 {
-        if (path && strcmp(path, "")) {
-                LOG_ERR("This component has no selectable subcomponents");
-                return -1;
-        }
+	size_t cmplen;
+	size_t offset;
 
-        return base_select_policy_set(&rmt->base, &policy_sets, name);
+	BUG_ON(!path);
+
+	parse_component_id(path, &cmplen, &offset);
+
+	if (strcmp(path, "") == 0) {
+		/* The request addresses this policy-set. */
+		return base_select_policy_set(&rmt->base, &policy_sets, name);
+
+	} else if (strncmp(path, "pff", cmplen) == 0) {
+		/* The request addresses the PFF subcomponent. */
+		return pff_select_policy_set(rmt->pff, path + offset, name);
+	}
+
+	LOG_ERR("This component has no subcomponent "
+			"named '%s'", path);
+
+	return -1;
 }
 EXPORT_SYMBOL(rmt_select_policy_set);
 
@@ -434,13 +448,17 @@ int rmt_set_policy_set_param(struct rmt * rmt,
                              const char * name,
                              const char * value)
 {
-        struct rmt_ps *ps;
-        int ret = -1;
+	size_t cmplen;
+	size_t offset;
+	struct rmt_ps *ps;
+	int ret = -1;
 
         if (!rmt || !path || !name || !value) {
                 LOG_ERRF("NULL arguments %p %p %p %p", rmt, path, name, value);
                 return -1;
         }
+
+        parse_component_id(path, &cmplen, &offset);
 
         LOG_DBG("set-policy-set-param '%s' '%s' '%s'", path, name, value);
 
@@ -454,7 +472,13 @@ int rmt_set_policy_set_param(struct rmt * rmt,
                         LOG_ERR("Unknown RMT parameter policy '%s'", name);
                 }
                 rcu_read_unlock();
+
+	} else if (strncmp(path, "pff", cmplen) == 0) {
+		/* The request addresses the PFF subcomponent. */
+		return pff_set_policy_set_param(rmt->pff, path + offset, name, value);
+
         } else {
+		/* The request addresses the RMT policy-set. */
                 ret = base_set_policy_set_param(&rmt->base, path, name, value);
         }
 


### PR DESCRIPTION
With this patch rmt_select_policy_set() and rmt_set_policy_set_param()
calls pff_select_policy_set() and pff_set_policy_set_param(),
when needed.

@sandervrijders @miqueltarzan @lbergesio : waiting for your ACKs.