### PR TITLE
kernel: shim-hv: fix compilation warning

### DIFF
--- a/linux/net/rina/ipcps/shim-hv.c
+++ b/linux/net/rina/ipcps/shim-hv.c
@@ -1109,6 +1109,7 @@ shim_hv_ipcp_name(struct ipcp_instance_data *priv)
         return &priv->name;
 }
 
+static const struct name *
 shim_hv_dif_name(struct ipcp_instance_data *priv)
 {
         ASSERT(priv);


### PR DESCRIPTION
Add missing return type declaration.