### PR TITLE
QOS_CUBES obviated in RNL. fix #574

### DIFF
--- a/linux/net/rina/rnl-utils.c
+++ b/linux/net/rina/rnl-utils.c
@@ -1391,10 +1391,6 @@ static int parse_efcp_config(struct nlattr *      efcp_config_attr,
                         goto parse_fail;
         }
 
-        if (attrs[EFCPC_ATTR_QOS_CUBES]) {
-                LOG_MISSING;
-        }
-
         if (attrs[EFCPC_ATTR_UNKNOWN_FLOW_POLICY]) {
                 if (parse_policy(attrs[EFCPC_ATTR_UNKNOWN_FLOW_POLICY],
                                  efcp_config->unknown_flow))


### PR DESCRIPTION
This PR fixes #574. EFCP QoS cubes are not needed in the kernel at the moment. The NL message contains them because of user space dependencies. Until a needed of parsing and using this information appears they can be simply obviated and so remove the LOG_MISSING statement.

I am the maintainer of this file, so it is an ack from me. Since it is a very trivial change I guess it can be merged by any admin directly.

root@irati-vm-leo-1:/home/irati# python check_maintainers.py -n -l 1
F: linux/net/rina/rnl-utils.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
