### PR TITLE
Shim eth vlan can notify user IPCPs about flows going up and down

### DIFF
--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -248,7 +248,7 @@ struct ipcp_instance_ops {
                                          port_id_t                   port_id);
         int      (* flow_unbinding_user_ipcp)(struct ipcp_instance_data * user_data,
                                               port_id_t                   port_id);
-	int	(* flow_state_change)(struct ipcp_instance_data *data,
+	int	(* nm1_flow_state_change)(struct ipcp_instance_data *data,
 				      port_id_t port_id, bool up);
 
         int      (* sdu_enqueue)(struct ipcp_instance_data * data,

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -248,6 +248,8 @@ struct ipcp_instance_ops {
                                          port_id_t                   port_id);
         int      (* flow_unbinding_user_ipcp)(struct ipcp_instance_data * user_data,
                                               port_id_t                   port_id);
+	int	(* flow_state_change)(struct ipcp_instance_data *data,
+				      port_id_t port_id, bool up);
 
         int      (* sdu_enqueue)(struct ipcp_instance_data * data,
                                  port_id_t                   id,

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -249,7 +249,7 @@ struct ipcp_instance_ops {
         int      (* flow_unbinding_user_ipcp)(struct ipcp_instance_data * user_data,
                                               port_id_t                   port_id);
 	int	(* nm1_flow_state_change)(struct ipcp_instance_data *data,
-				      port_id_t port_id, bool up);
+					  port_id_t port_id, bool up);
 
         int      (* sdu_enqueue)(struct ipcp_instance_data * data,
                                  port_id_t                   id,

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -409,7 +409,7 @@ static int normal_flow_unbinding_user_ipcp(struct ipcp_instance_data * data,
         return 0;
 }
 
-static int normal_flow_state_change(struct ipcp_instance_data * data,
+static int normal_nm1_flow_state_change(struct ipcp_instance_data * data,
 				    port_id_t			pid,
 				    bool			up)
 {
@@ -1028,7 +1028,7 @@ static struct ipcp_instance_ops normal_instance_ops = {
         .flow_binding_ipcp         = ipcp_flow_binding,
         .flow_unbinding_ipcp       = normal_flow_unbinding_ipcp,
         .flow_unbinding_user_ipcp  = normal_flow_unbinding_user_ipcp,
-	.flow_state_change	   = normal_flow_state_change,
+	.nm1_flow_state_change	   = normal_nm1_flow_state_change,
 
         .application_register      = NULL,
         .application_unregister    = NULL,

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -410,9 +410,11 @@ static int normal_flow_unbinding_user_ipcp(struct ipcp_instance_data * data,
 }
 
 static int normal_nm1_flow_state_change(struct ipcp_instance_data * data,
-				    port_id_t			pid,
-				    bool			up)
+					port_id_t		    pid,
+					bool			    up)
 {
+	LOG_INFO("N-1 flow with pid %d went %s", pid, (up ? "up" : "down"));
+
 	return 0;
 }
 

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -409,6 +409,13 @@ static int normal_flow_unbinding_user_ipcp(struct ipcp_instance_data * data,
         return 0;
 }
 
+static int normal_flow_state_change(struct ipcp_instance_data * data,
+				    port_id_t			pid,
+				    bool			up)
+{
+	return 0;
+}
+
 static int connection_destroy_request(struct ipcp_instance_data * data,
                                       cep_id_t                    src_cep_id)
 {
@@ -1021,6 +1028,7 @@ static struct ipcp_instance_ops normal_instance_ops = {
         .flow_binding_ipcp         = ipcp_flow_binding,
         .flow_unbinding_ipcp       = normal_flow_unbinding_ipcp,
         .flow_unbinding_user_ipcp  = normal_flow_unbinding_user_ipcp,
+	.flow_state_change	   = normal_flow_state_change,
 
         .application_register      = NULL,
         .application_unregister    = NULL,

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -1418,6 +1418,7 @@ static struct ipcp_instance_ops eth_vlan_instance_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = eth_vlan_unbind_user_ipcp,
+	.flow_state_change	   = NULL,
 
         .application_register      = eth_vlan_application_register,
         .application_unregister    = eth_vlan_application_unregister,

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -1468,7 +1468,23 @@ static int eth_vlan_netdev_notify(struct notifier_block *nb,
 
         list_for_each_entry(pos, &eth_vlan_data.instances, list) {
 		if (pos->dev == dev) {
-			LOG_INFO("GOT EVENT %lu FOR netdev %p", event, pos->dev);
+			switch (event) {
+				case NETDEV_UP:
+					LOG_INFO("Device %s goes up",
+						 dev->name);
+					break;
+
+				case NETDEV_DOWN:
+					LOG_INFO("Device %s goes down",
+						 dev->name);
+					break;
+
+				default:
+					LOG_DBG("Ignoring event %lu "
+						"on device %s",
+						event, dev->name);
+					break;
+			}
 		}
 	}
 

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -1418,7 +1418,7 @@ static struct ipcp_instance_ops eth_vlan_instance_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = eth_vlan_unbind_user_ipcp,
-	.flow_state_change	   = NULL,
+	.nm1_flow_state_change	   = NULL,
 
         .application_register      = eth_vlan_application_register,
         .application_unregister    = eth_vlan_application_unregister,

--- a/linux/net/rina/ipcps/shim-hv.c
+++ b/linux/net/rina/ipcps/shim-hv.c
@@ -1139,6 +1139,7 @@ static struct ipcp_instance_ops shim_hv_ipcp_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = shim_hv_unbind_user_ipcp,
+	.flow_state_change	   = NULL,
 
         .application_register      = shim_hv_application_register,
         .application_unregister    = shim_hv_application_unregister,

--- a/linux/net/rina/ipcps/shim-hv.c
+++ b/linux/net/rina/ipcps/shim-hv.c
@@ -1139,7 +1139,7 @@ static struct ipcp_instance_ops shim_hv_ipcp_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = shim_hv_unbind_user_ipcp,
-	.flow_state_change	   = NULL,
+	.nm1_flow_state_change	   = NULL,
 
         .application_register      = shim_hv_application_register,
         .application_unregister    = shim_hv_application_unregister,

--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -2431,6 +2431,7 @@ static struct ipcp_instance_ops tcp_udp_instance_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = tcp_udp_unbind_user_ipcp,
+	.flow_state_change	   = NULL,
 
         .application_register      = tcp_udp_application_register,
         .application_unregister    = tcp_udp_application_unregister,

--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -2431,7 +2431,7 @@ static struct ipcp_instance_ops tcp_udp_instance_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = tcp_udp_unbind_user_ipcp,
-	.flow_state_change	   = NULL,
+	.nm1_flow_state_change	   = NULL,
 
         .application_register      = tcp_udp_application_register,
         .application_unregister    = tcp_udp_application_unregister,


### PR DESCRIPTION
With this patch, a new operation called nm1_flow_state_change has been added to the IPCP kernel ops. The purpose of this operation is to inform an IPCP that an N-1 flow has gone "up" or "down". A stub for this operation has been implemented for the normal IPCP kernel implementation - it just logs the event for now.

The shim-eth-vlan implementation has been upgraded to detect up/down events of the associated network interface and consequently notify the N+1 IPCP that is using the flows provided by the shim.

Waiting to be acked by:
@sandervrijders 
@miqueltarzan  