### PR TITLE
Pristine 1.3 shim eth size

### DIFF
--- a/linux/net/rina/ipcps/Kconfig
+++ b/linux/net/rina/ipcps/Kconfig
@@ -50,6 +50,13 @@ config RINA_SHIM_ETH_VLAN_BURST_LIMIT
        help
          No help for the time being
 
+config RINA_SHIM_ETH_MAX_BUFFER_SIZE
+	int "shim-eth-vlan max SDU size"
+	default 1500
+    depends on RINA_SHIM_ETH_VLAN
+    help
+	  No help for the time being
+
 config RINA_SHIM_ETH_VLAN_REGRESSION_TESTS
 	bool "Perform regression testing upon loading"
 	default n

--- a/linux/net/rina/ipcps/Kconfig
+++ b/linux/net/rina/ipcps/Kconfig
@@ -50,13 +50,6 @@ config RINA_SHIM_ETH_VLAN_BURST_LIMIT
        help
          No help for the time being
 
-config RINA_SHIM_ETH_MAX_BUFFER_SIZE
-	int "shim-eth-vlan max SDU size"
-	default 1500
-    depends on RINA_SHIM_ETH_VLAN
-    help
-	  No help for the time being
-
 config RINA_SHIM_ETH_VLAN_REGRESSION_TESTS
 	bool "Perform regression testing upon loading"
 	default n

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -737,7 +737,7 @@ static int eth_vlan_sdu_write(struct ipcp_instance_data * data,
         }
 
         length = buffer_length(sdu->buffer);
-        if (length > CONFIG_RINA_SHIM_ETH_MAX_BUFFER_SIZE) {
+        if (length > data->dev->mtu) {
         	LOG_ERR("SDU too large (%d), dropping", length);
         	sdu_destroy(sdu);
         	return -1;


### PR DESCRIPTION
Added a check for max SDU size in shim-eth-vlan write (max size configurable via kconfig)

Maintainers:

@sandervrijders 