### PR TITLE
kernel: pff-ps: add pff_port_state_change() op

### DIFF
--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -418,6 +418,10 @@ static int normal_nm1_flow_state_change(struct ipcp_instance_data * data,
 {
 	LOG_INFO("N-1 flow with pid %d went %s", pid, (up ? "up" : "down"));
 
+	if (rmt_pff_port_state_change(data->rmt, pid, up)) {
+		LOG_ERR("rmt_port_state_change() failed");
+	}
+
 	return 0;
 }
 

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -1484,8 +1484,9 @@ static int ntfy_user_ipcp_on_if_state_change(struct ipcp_instance_data * data,
 			continue;
                 }
 
-		flow->user_ipcp->ops->nm1_flow_state_change(data, flow->port_id,
-							    up);
+		flow->user_ipcp->ops->
+                            nm1_flow_state_change(flow->user_ipcp->data,
+                                                  flow->port_id, up);
         }
 
 	return 0;

--- a/linux/net/rina/pff-ps-default.c
+++ b/linux/net/rina/pff-ps-default.c
@@ -593,6 +593,7 @@ pff_ps_default_create(struct rina_component * component)
 
         ps->pff_add = default_add;
         ps->pff_remove = default_remove;
+	ps->pff_port_state_change = NULL;
         ps->pff_is_empty = default_is_empty;
         ps->pff_flush = default_flush;
         ps->pff_nhop = default_nhop;

--- a/linux/net/rina/pff-ps.h
+++ b/linux/net/rina/pff-ps.h
@@ -36,6 +36,9 @@ struct pff_ps {
         int (* pff_remove)(struct pff_ps *        ps,
                            struct mod_pff_entry * entry);
 
+	int (* pff_port_state_change)(struct pff_ps * ps,
+				      port_id_t port_id, bool up);
+
         bool (* pff_is_empty)(struct pff_ps * ps);
         int  (* pff_flush)(struct pff_ps * ps);
 

--- a/linux/net/rina/pff.c
+++ b/linux/net/rina/pff.c
@@ -193,6 +193,31 @@ int pff_remove(struct pff *           instance,
         return 0;
 }
 
+int pff_port_state_change(struct pff *	pff,
+			  port_id_t	port_id,
+			  bool		up)
+{
+        struct pff_ps * ps;
+
+        if (!__pff_is_ok(pff))
+                return -1;
+
+        rcu_read_lock();
+
+        ps = container_of(rcu_dereference(pff->base.ps),
+                          struct pff_ps, base);
+
+        if (ps->pff_port_state_change &&
+			ps->pff_port_state_change(ps, port_id, up)) {
+                rcu_read_unlock();
+                return -1;
+        }
+
+        rcu_read_unlock();
+
+        return 0;
+}
+
 int pff_nhop(struct pff * instance,
              struct pci * pci,
              port_id_t ** ports,

--- a/linux/net/rina/pff.h
+++ b/linux/net/rina/pff.h
@@ -41,6 +41,10 @@ int             pff_add(struct pff *           instance,
 int             pff_remove(struct pff *           instance,
                            struct mod_pff_entry * entry);
 
+int		pff_port_state_change(struct pff *	pff,
+				      port_id_t		port_id,
+				      bool		up);
+
 /* NOTE: ports and entries are in-out parms */
 int             pff_nhop(struct pff * instance,
                          struct pci * pci,

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1632,6 +1632,15 @@ int rmt_pff_remove(struct rmt *           instance,
 }
 EXPORT_SYMBOL(rmt_pff_remove);
 
+int rmt_pff_port_state_change(struct rmt *	rmt,
+			      port_id_t		port_id,
+			      bool		up)
+{
+        return is_rmt_pff_ok(rmt) ?
+	       pff_port_state_change(rmt->pff, port_id, up) : -1;
+}
+EXPORT_SYMBOL(rmt_pff_port_state_change);
+
 int rmt_pff_dump(struct rmt *       instance,
                  struct list_head * entries)
 {

--- a/linux/net/rina/rmt.h
+++ b/linux/net/rina/rmt.h
@@ -94,38 +94,56 @@ struct rmt_queue_set {
 };
 
 struct rmt_kqueue *     rmt_kqueue_create(unsigned int key);
+
 int                     rmt_kqueue_destroy(struct rmt_kqueue * q);
+
 struct rmt_qgroup *     rmt_qgroup_create(port_id_t pid);
+
 int                     rmt_qgroup_destroy(struct rmt_qgroup* g);
+
 struct rmt_kqueue *     rmt_kqueue_find(struct rmt_qgroup * g,
                                         unsigned int        key);
 struct rmt_queue_set *  rmt_queue_set_create(void);
+
 int                     rmt_queue_set_destroy(struct rmt_queue_set * qs);
+
 struct rmt_qgroup *     rmt_qgroup_find(struct rmt_queue_set * qs,
                                         port_id_t              pid);
+
 struct rmt * rmt_create(struct ipcp_instance *  parent,
                         struct kfa *            kfa,
                         struct efcp_container * efcpc);
+
 int          rmt_destroy(struct rmt * instance);
 
 int          rmt_address_set(struct rmt * instance,
                              address_t    address);
+
 int          rmt_dt_cons_set(struct rmt *     instance,
                              struct dt_cons * dt_cons);
+
 int 	     rmt_sdup_config_set(struct rmt *         instance,
                     	         struct sdup_config * sdup_conf);
+
 int          rmt_config_set(struct rmt *        instance,
                             struct rmt_config * rmt_config);
 
 int          rmt_n1port_bind(struct rmt * instance,
                              port_id_t    id,
                              struct ipcp_instance * n1_ipcp);
+
 int          rmt_n1port_unbind(struct rmt * instance,
                                port_id_t    id);
+
 int          rmt_pff_add(struct rmt *           instance,
 			 struct mod_pff_entry * entry);
+
 int          rmt_pff_remove(struct rmt *        instance,
 			 struct mod_pff_entry * entry);
+
+int          rmt_pff_port_state_change(struct rmt *	rmt,
+				       port_id_t	port_id,
+				       bool		up);
 int          rmt_pff_dump(struct rmt *       instance,
                           struct list_head * entries);
 int          rmt_pff_flush(struct rmt * instance);
@@ -133,15 +151,18 @@ int          rmt_pff_flush(struct rmt * instance);
 int          rmt_send(struct rmt * instance,
                       struct pci * pci,
                       struct pdu * pdu);
+
 int          rmt_send_port_id(struct rmt *  instance,
                               port_id_t     id,
                               struct pdu *  pdu);
+
 int          rmt_receive(struct rmt * instance,
                          struct sdu * sdu,
                          port_id_t    from);
 
 int          rmt_enable_port_id(struct rmt * instance,
                                 port_id_t    id);
+
 int          rmt_disable_port_id(struct rmt * instance,
                                  port_id_t    id);
 


### PR DESCRIPTION
The pff_port_state_change() operation has been added to the policy set in order to receive notifications about flow going up or down.