### PR TITLE
Connection struct made internal to EFCP. Connection policies replaced by DTP and DTCP config structs.

### DIFF
--- a/librina/include/librina/configuration.h
+++ b/librina/include/librina/configuration.h
@@ -395,13 +395,11 @@ public:
         PolicyConfig rtt_estimator_policy_;
 };
 
-/// This class defines the policies paramenters for an EFCP connection
-class ConnectionPolicies {
+/// This class defines the policies paramenters for the DTP Component
+class DTPConfig {
 public:
-        ConnectionPolicies();
+        DTPConfig();
 #ifndef SWIG
-        const DTCPConfig& get_dtcp_configuration() const;
-        void set_dtcp_configuration(const DTCPConfig& dtcp_configuration);
         bool is_dtcp_present() const;
         void set_dtcp_present(bool dtcp_present);
         const PolicyConfig& get_initial_seq_num_policy() const;
@@ -492,8 +490,10 @@ public:
 	unsigned int get_id() const;
 	const std::string& get_name() const;
 	void set_name(const std::string& name);
-	const ConnectionPolicies& get_efcp_policies() const;
-	void set_efcp_policies(const ConnectionPolicies& efcp_policies);
+	const DTPConfig& get_dtp_config() const;
+	void set_dtp_config(const DTPConfig& dtp_config);
+	const DTCPConfig& get_dtcp_config() const;
+	void set_dtcp_config(const DTCPConfig& dtcp_config);
 	unsigned int get_average_bandwidth() const;
 	void set_average_bandwidth(unsigned int average_bandwidth);
 	unsigned int get_average_sdu_bandwidth() const;
@@ -523,8 +523,11 @@ public:
 	/// The id of the QoS cube
 	unsigned int id_;
 
-	/// The EFCP policies associated to this QoS Cube
-	ConnectionPolicies efcp_policies_;
+	/// The DTP policies associated to this QoS Cube
+        DTPConfig dtp_config_;
+
+	/// The DTCP policies associated to this QoS Cube
+        DTCPConfig dtcp_config_;
 
 	/// Average bandwidth in bytes/s. A value of 0 means don't care.
 	unsigned int average_bandwidth_;

--- a/librina/include/librina/configuration.h
+++ b/librina/include/librina/configuration.h
@@ -432,9 +432,6 @@ public:
         /// Indicates if DTCP is required
         bool dtcp_present_;
 
-        /// The configuration of the DTCP instance
-        DTCPConfig dtcp_configuration_;
-
         /// Policy Set for DTP.
         PolicyConfig dtp_policy_set_;
 

--- a/librina/include/librina/ipc-process.h
+++ b/librina/include/librina/ipc-process.h
@@ -9,12 +9,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
@@ -765,9 +765,14 @@ public:
         int destCepId;
 
         /**
-         * The EFCP connection policies
+         * The DTP connection policies
          */
-        ConnectionPolicies policies;
+        DTPConfig dtpConfig;
+
+        /**
+         * The DTCP connection policies
+         */
+        DTCPConfig dtcpConfig;
 
         /**
          * The id of the IPC Process using the flow supported by this
@@ -791,8 +796,10 @@ public:
         void setFlowUserIpcProcessId(unsigned short flowUserIpcProcessId);
         int getSourceCepId() const;
         void setSourceCepId(int sourceCepId);
-        const ConnectionPolicies& getPolicies() const;
-        void setPolicies(const ConnectionPolicies& policies);
+        const DTPConfig& getDTPConfig() const;
+        void setDTPConfig(const DTPConfig& dtpConfig);
+        const DTCPConfig& getDTCPConfig() const;
+        void setDTCPConfig(const DTCPConfig& dtcpConfig);
 #endif
         const std::string toString();
 };

--- a/librina/src/configuration.cc
+++ b/librina/src/configuration.cc
@@ -761,9 +761,6 @@ const std::string DTPConfig::toString() {
         ss<<"; Partial delivery: "<<partial_delivery_;
         ss<<"; In order delivery: "<<in_order_delivery_;
         ss<<"; Max allowed SDU gap: "<<max_sdu_gap_<<std::endl;
-        if (dtcp_present_) {
-                ss<<"DTCP Configuration: "<<dtcp_configuration_.toString();
-        }
         return ss.str();
 }
 

--- a/librina/src/configuration.cc
+++ b/librina/src/configuration.cc
@@ -643,8 +643,8 @@ const std::string DTCPConfig::toString() {
         return ss.str();
 }
 
-// CLASS CONNECTION POLICIES
-ConnectionPolicies::ConnectionPolicies(){
+// CLASS DTP CONFIG
+DTPConfig::DTPConfig(){
 	dtcp_present_ = false;
 	seq_num_rollover_threshold_ = 0;
 	initial_a_timer_ = 0;
@@ -654,106 +654,98 @@ ConnectionPolicies::ConnectionPolicies(){
 	max_sdu_gap_ = 0;
 }
 
-const PolicyConfig& ConnectionPolicies::get_dtp_policy_set() const {
+const PolicyConfig& DTPConfig::get_dtp_policy_set() const {
         return dtp_policy_set_;
 }
 
-void ConnectionPolicies::set_dtp_policy_set(
+void DTPConfig::set_dtp_policy_set(
                 const PolicyConfig& dtp_policy_set) {
 	dtp_policy_set_ = dtp_policy_set;
 }
 
-const PolicyConfig& ConnectionPolicies::get_rcvr_timer_inactivity_policy() const {
+const PolicyConfig& DTPConfig::get_rcvr_timer_inactivity_policy() const {
 	return rcvr_timer_inactivity_policy_;
 }
 
-void ConnectionPolicies::set_rcvr_timer_inactivity_policy(
+void DTPConfig::set_rcvr_timer_inactivity_policy(
                 const PolicyConfig& rcvr_timer_inactivity_policy) {
 	rcvr_timer_inactivity_policy_ = rcvr_timer_inactivity_policy;
 }
 
-const PolicyConfig& ConnectionPolicies::get_sender_timer_inactivity_policy() const {
+const PolicyConfig& DTPConfig::get_sender_timer_inactivity_policy() const {
 	return sender_timer_inactivity_policy_;
 }
 
-void ConnectionPolicies::set_sender_timer_inactivity_policy(
+void DTPConfig::set_sender_timer_inactivity_policy(
                 const PolicyConfig& sender_timer_inactivity_policy) {
 	sender_timer_inactivity_policy_ = sender_timer_inactivity_policy;
 }
 
-const DTCPConfig& ConnectionPolicies::get_dtcp_configuration() const {
-	return dtcp_configuration_;
-}
-
-void ConnectionPolicies::set_dtcp_configuration(const DTCPConfig& dtcp_configuration) {
-	dtcp_configuration_ = dtcp_configuration;
-}
-
-bool ConnectionPolicies::is_dtcp_present() const {
+bool DTPConfig::is_dtcp_present() const {
 	return dtcp_present_;
 }
 
-void ConnectionPolicies::set_dtcp_present(bool dtcp_present) {
+void DTPConfig::set_dtcp_present(bool dtcp_present) {
 	dtcp_present_ = dtcp_present;
 }
 
-const PolicyConfig& ConnectionPolicies::get_initial_seq_num_policy() const {
+const PolicyConfig& DTPConfig::get_initial_seq_num_policy() const {
 	return initial_seq_num_policy_;
 }
 
-void ConnectionPolicies::set_initial_seq_num_policy(const PolicyConfig& initial_seq_num_policy) {
+void DTPConfig::set_initial_seq_num_policy(const PolicyConfig& initial_seq_num_policy) {
 	initial_seq_num_policy_ = initial_seq_num_policy;
 }
 
-unsigned int ConnectionPolicies::get_seq_num_rollover_threshold() const {
+unsigned int DTPConfig::get_seq_num_rollover_threshold() const {
 	return seq_num_rollover_threshold_;
 }
 
-void ConnectionPolicies::set_seq_num_rollover_threshold(unsigned int seq_num_rollover_threshold) {
+void DTPConfig::set_seq_num_rollover_threshold(unsigned int seq_num_rollover_threshold) {
 	seq_num_rollover_threshold_ = seq_num_rollover_threshold;
 }
 
-unsigned int ConnectionPolicies::get_initial_a_timer() const {
+unsigned int DTPConfig::get_initial_a_timer() const {
 	return initial_a_timer_;
 }
 
-void ConnectionPolicies::set_initial_a_timer(unsigned int initial_a_timer) {
+void DTPConfig::set_initial_a_timer(unsigned int initial_a_timer) {
 	initial_a_timer_ = initial_a_timer;
 }
 
-bool ConnectionPolicies::is_in_order_delivery() const {
+bool DTPConfig::is_in_order_delivery() const {
 	return in_order_delivery_;
 }
 
-void ConnectionPolicies::set_in_order_delivery(bool in_order_delivery) {
+void DTPConfig::set_in_order_delivery(bool in_order_delivery) {
 	in_order_delivery_ = in_order_delivery;
 }
 
-int ConnectionPolicies::get_max_sdu_gap() const {
+int DTPConfig::get_max_sdu_gap() const {
 	return max_sdu_gap_;
 }
 
-void ConnectionPolicies::set_max_sdu_gap(int max_sdu_gap) {
+void DTPConfig::set_max_sdu_gap(int max_sdu_gap) {
 	max_sdu_gap_ = max_sdu_gap;
 }
 
-bool ConnectionPolicies::is_partial_delivery() const {
+bool DTPConfig::is_partial_delivery() const {
 	return partial_delivery_;
 }
 
-void ConnectionPolicies::set_partial_delivery(bool partial_delivery) {
+void DTPConfig::set_partial_delivery(bool partial_delivery) {
 	partial_delivery_ = partial_delivery;
 }
 
-bool ConnectionPolicies::is_incomplete_delivery() const {
+bool DTPConfig::is_incomplete_delivery() const {
 	return incomplete_delivery_;
 }
 
-void ConnectionPolicies::set_incomplete_delivery(bool incomplete_delivery) {
+void DTPConfig::set_incomplete_delivery(bool incomplete_delivery) {
 	incomplete_delivery_ = incomplete_delivery;
 }
 
-const std::string ConnectionPolicies::toString() {
+const std::string DTPConfig::toString() {
         std::stringstream ss;
         ss<<"DTP Policy Set (name/version): "<<dtp_policy_set_.get_name();
         ss<<"/"<<dtp_policy_set_.get_version();
@@ -829,12 +821,20 @@ void QoSCube::set_name(const std::string& name) {
 	name_ = name;
 }
 
-const ConnectionPolicies& QoSCube::get_efcp_policies() const {
-	return efcp_policies_;
+const DTPConfig& QoSCube::get_dtp_config() const {
+	return dtp_config_;
 }
 
-void QoSCube::set_efcp_policies(const ConnectionPolicies& efcp_policies) {
-	efcp_policies_ = efcp_policies;
+void QoSCube::set_dtp_config(const DTPConfig& dtp_config) {
+	dtp_config_ = dtp_config;
+}
+
+const DTCPConfig& QoSCube::get_dtcp_config() const {
+	return dtcp_config_;
+}
+
+void QoSCube::set_dtcp_config(const DTCPConfig& dtcp_config) {
+	dtcp_config_ = dtcp_config;
 }
 
 unsigned int QoSCube::get_average_bandwidth() const {
@@ -929,7 +929,8 @@ const std::string QoSCube::toString() {
         ss<<"; Average SDU bandwidth (bytes/s): "<<average_sdu_bandwidth_<<std::endl;
         ss<<"Peak bandwidth duration (ms): "<<peak_bandwidth_duration_;
         ss<<"; Peak SDU bandwidth duration (ms): "<<peak_sdu_bandwidth_duration_<<std::endl;
-        ss<<"EFCP policies: "<<efcp_policies_.toString();
+        ss<<"DTP Configuration: "<<dtp_config_.toString();
+        ss<<"DTCP Configuration: "<<dtcp_config_.toString();
         return ss.str();
 }
 

--- a/librina/src/ipc-process.cc
+++ b/librina/src/ipc-process.cc
@@ -820,12 +820,20 @@ void Connection::setSourceCepId(int sourceCepId) {
         this->sourceCepId = sourceCepId;
 }
 
-const ConnectionPolicies& Connection::getPolicies() const {
-        return policies;
+const DTPConfig& Connection::getDTPConfig() const {
+        return dtpConfig;
 }
 
-void Connection::setPolicies(const ConnectionPolicies& policies) {
-        this->policies = policies;
+void Connection::setDTPConfig(const DTPConfig& dtpConfig) {
+        this->dtpConfig = dtpConfig;
+}
+
+const DTCPConfig& Connection::getDTCPConfig() const {
+        return dtcpConfig;
+}
+
+void Connection::setDTCPConfig(const DTCPConfig& dtcpConfig) {
+        this->dtcpConfig = dtcpConfig;
 }
 
 const std::string Connection::toString() {
@@ -836,7 +844,8 @@ const std::string Connection::toString() {
         ss<<"; Dest cep-id: "<<destCepId<<std::endl;
         ss<<"Por-id: "<<portId<<"; QoS-id: "<<qosId;
         ss<<"; Flow user IPC Process id: "<<flowUserIpcProcessId<<std::endl;
-        ss<<"Policies: "<<policies.toString();
+        ss<<"DTP Configuration: "<<dtpConfig.toString();
+        ss<<"DTCP Configuration: "<<dtcpConfig.toString();
         return ss.str();
 }
 

--- a/librina/src/netlink-parsers.cc
+++ b/librina/src/netlink-parsers.cc
@@ -1030,9 +1030,12 @@ QoSCube * parseQoSCubeObject(nlattr *nested) {
 	attr_policy[QOS_CUBE_ATTR_UND_BER].type = NLA_U32;
 	attr_policy[QOS_CUBE_ATTR_UND_BER].minlen = 4;
 	attr_policy[QOS_CUBE_ATTR_UND_BER].maxlen = 4;
-	attr_policy[QOS_CUBE_ATTR_EFCP_POLICIES].type = NLA_NESTED;
-	attr_policy[QOS_CUBE_ATTR_EFCP_POLICIES].minlen = 0;
-	attr_policy[QOS_CUBE_ATTR_EFCP_POLICIES].maxlen = 0;
+	attr_policy[QOS_CUBE_ATTR_DTP_CONFIG].type = NLA_NESTED;
+	attr_policy[QOS_CUBE_ATTR_DTP_CONFIG].minlen = 0;
+	attr_policy[QOS_CUBE_ATTR_DTP_CONFIG].maxlen = 0;
+	attr_policy[QOS_CUBE_ATTR_DTCP_CONFIG].type = NLA_NESTED;
+	attr_policy[QOS_CUBE_ATTR_DTCP_CONFIG].minlen = 0;
+	attr_policy[QOS_CUBE_ATTR_DTCP_CONFIG].maxlen = 0;
 	struct nlattr *attrs[QOS_CUBE_ATTR_MAX + 1];
 
 	int err = nla_parse_nested(attrs, QOS_CUBE_ATTR_MAX, nested, attr_policy);
@@ -1045,7 +1048,8 @@ QoSCube * parseQoSCubeObject(nlattr *nested) {
 
 	QoSCube * result = new QoSCube(nla_get_string(attrs[QOS_CUBE_ATTR_NAME]),
 			nla_get_u32(attrs[QOS_CUBE_ATTR_ID]));
-	ConnectionPolicies * efcpPolicies;
+	DTPConfig  * dtpConfig;
+	DTCPConfig  * dtcpConfig;
 
 	if (attrs[QOS_CUBE_ATTR_AVG_BAND]) {
 		result->set_average_bandwidth(nla_get_u32(attrs[QOS_CUBE_ATTR_AVG_BAND]));
@@ -1090,24 +1094,35 @@ QoSCube * parseQoSCubeObject(nlattr *nested) {
 				nla_get_u32(attrs[QOS_CUBE_ATTR_PEAK_SDU_BAND_DUR]));
 	}
 
-	if (attrs[QOS_CUBE_ATTR_EFCP_POLICIES]) {
-	        efcpPolicies = parseConnectionPoliciesObject(
-	                        attrs[QOS_CUBE_ATTR_EFCP_POLICIES]);
-	        if (efcpPolicies == 0) {
+	if (attrs[QOS_CUBE_ATTR_DTP_CONFIG]) {
+	        dtpConfig = parseDTPConfigObject(
+	                        attrs[QOS_CUBE_ATTR_DTP_CONFIG]);
+	        if (dtpConfig == 0) {
 	                delete result;
 	                return 0;
 	        } else {
-	                result->set_efcp_policies(*efcpPolicies);
-	                delete efcpPolicies;
+	                result->set_dtp_config(*dtpConfig);
+	                delete dtpConfig;
 	        }
 	}
 
+	if (attrs[QOS_CUBE_ATTR_DTCP_CONFIG]) {
+	        dtcpConfig = parseDTCPConfigObject(
+	                        attrs[QOS_CUBE_ATTR_DTCP_CONFIG]);
+	        if (dtcpConfig == 0) {
+	                delete result;
+	                return 0;
+	        } else {
+	                result->set_dtcp_config(*dtcpConfig);
+	                delete dtcpConfig;
+	        }
+	}
 	return result;
 }
 
 int putQoSCubeObject(nl_msg* netlinkMessage,
 		QoSCube* object){
-        struct nlattr *efcpPolicies;
+        struct nlattr *dtpConfig, *dtcpConfig;
 
 	NLA_PUT_STRING(netlinkMessage, QOS_CUBE_ATTR_NAME,
 			object->name_.c_str());
@@ -1160,15 +1175,25 @@ int putQoSCubeObject(nl_msg* netlinkMessage,
 				object.getUndetectedBitErrorRate());
 	}*/
 
-	if (!(efcpPolicies = nla_nest_start(netlinkMessage, QOS_CUBE_ATTR_EFCP_POLICIES))){
+	if (!(dtpConfig = nla_nest_start(netlinkMessage, QOS_CUBE_ATTR_DTP_CONFIG))){
 	        goto nla_put_failure;
 	}
 
-	if (putConnectionPoliciesObject(netlinkMessage, object->efcp_policies_) < 0) {
+	if (putDTPConfigObject(netlinkMessage, object->dtp_config_) < 0) {
 	        goto nla_put_failure;
 	}
 
-	nla_nest_end(netlinkMessage, efcpPolicies);
+	nla_nest_end(netlinkMessage, dtpConfig);
+
+	if (!(dtcpConfig = nla_nest_start(netlinkMessage, QOS_CUBE_ATTR_DTCP_CONFIG))){
+	        goto nla_put_failure;
+	}
+
+	if (putDTCPConfigObject(netlinkMessage, object->dtcp_config_) < 0) {
+	        goto nla_put_failure;
+	}
+
+	nla_nest_end(netlinkMessage, dtcpConfig);
 
 	return 0;
 
@@ -3006,25 +3031,14 @@ parseDTCPConfigObject(nlattr *nested) {
         return result;
 }
 
-int putConnectionPoliciesObject(nl_msg* netlinkMessage,
-		const ConnectionPolicies& object) {
+int putDTPConfigObject(nl_msg* netlinkMessage,
+		const DTPConfig& object) {
 
-        struct nlattr *dtcpConfig, *initSeqNumPolicy, *rtimerInacPolicy,
+        struct nlattr *initSeqNumPolicy, *rtimerInacPolicy,
                 *stimerInacPolicy, *dtpPolicySet;
 
         if (object.is_dtcp_present()){
                 NLA_PUT_FLAG(netlinkMessage, CPA_ATTR_DTCP_PRESENT);
-                if (!(dtcpConfig = nla_nest_start(netlinkMessage,
-                                CPA_ATTR_DTCP_CONFIG))) {
-                        goto nla_put_failure;
-                }
-
-                if (putDTCPConfigObject(netlinkMessage,
-                                object.get_dtcp_configuration())< 0) {
-                        goto nla_put_failure;
-                }
-
-                nla_nest_end(netlinkMessage, dtcpConfig);
         }
 
         if (!(initSeqNumPolicy = nla_nest_start(netlinkMessage,
@@ -3101,15 +3115,12 @@ int putConnectionPoliciesObject(nl_msg* netlinkMessage,
 	return -1;
 }
 
-ConnectionPolicies *
-parseConnectionPoliciesObject(nlattr *nested) {
+DTPConfig *
+parseDTPConfigObject(nlattr *nested) {
 	struct nla_policy attr_policy[CPA_ATTR_MAX + 1];
 	attr_policy[CPA_ATTR_DTCP_PRESENT].type = NLA_FLAG;
 	attr_policy[CPA_ATTR_DTCP_PRESENT].minlen = 0;
 	attr_policy[CPA_ATTR_DTCP_PRESENT].maxlen = 0;
-	attr_policy[CPA_ATTR_DTCP_CONFIG].type = NLA_NESTED;
-	attr_policy[CPA_ATTR_DTCP_CONFIG].minlen = 0;
-	attr_policy[CPA_ATTR_DTCP_CONFIG].maxlen = 0;
         attr_policy[CPA_ATTR_DTP_POLICY_SET].type = NLA_NESTED;
         attr_policy[CPA_ATTR_DTP_POLICY_SET].minlen = 0;
         attr_policy[CPA_ATTR_DTP_POLICY_SET].maxlen = 0;
@@ -3149,9 +3160,8 @@ parseConnectionPoliciesObject(nlattr *nested) {
 		return 0;
 	}
 
-	ConnectionPolicies * result =
-			new ConnectionPolicies();
-	DTCPConfig * dtcpConfig;
+	DTPConfig * result =
+			new DTPConfig();
 	PolicyConfig * initSeqNumPolicy;
         PolicyConfig * sTimerInacPolicy;
         PolicyConfig * rTimerInacPolicy;
@@ -3159,21 +3169,6 @@ parseConnectionPoliciesObject(nlattr *nested) {
 
 	if (attrs[CPA_ATTR_DTCP_PRESENT]) {
 	        result->set_dtcp_present(true);
-
-	        if (attrs[CPA_ATTR_DTCP_CONFIG]){
-	                dtcpConfig = parseDTCPConfigObject(attrs[CPA_ATTR_DTCP_CONFIG]);
-	                if (dtcpConfig == 0) {
-	                        delete result;
-	                        return 0;
-	                } else {
-	                        result->set_dtcp_configuration(*dtcpConfig);
-	                        delete dtcpConfig;
-	                }
-	        } else {
-	                delete result;
-	                LOG_ERR("DTCP Config should have been present but it is not");
-	                return 0;
-	        }
 	} else {
 	        result->set_dtcp_present(false);
 	}
@@ -3264,7 +3259,7 @@ parseConnectionPoliciesObject(nlattr *nested) {
 
 int putConnectionObject(nl_msg* netlinkMessage,
                 const Connection& object) {
-        struct nlattr *policies;
+        struct nlattr *dtpConfig, *dtcpConfig;
 
         NLA_PUT_U32(netlinkMessage, CONN_ATTR_PORT_ID, object.getPortId());
         NLA_PUT_U32(netlinkMessage, CONN_ATTR_SOURCE_ADDRESS,
@@ -3277,16 +3272,27 @@ int putConnectionObject(nl_msg* netlinkMessage,
         NLA_PUT_U32(netlinkMessage, CONN_ATTR_DEST_CEP_ID,
                         object.getDestCepId());
 
-        if (!(policies = nla_nest_start(netlinkMessage, CONN_ATTR_POLICIES))) {
+        if (!(dtpConfig = nla_nest_start(netlinkMessage, CONN_ATTR_DTP_CONFIG))) {
                 goto nla_put_failure;
         }
 
-        if (putConnectionPoliciesObject(netlinkMessage,
-                        object.getPolicies())< 0) {
+        if (putDTPConfigObject(netlinkMessage,
+                        object.getDTPConfig())< 0) {
                 goto nla_put_failure;
         }
 
-        nla_nest_end(netlinkMessage, policies);
+        nla_nest_end(netlinkMessage, dtpConfig);
+
+        if (!(dtcpConfig = nla_nest_start(netlinkMessage, CONN_ATTR_DTCP_CONFIG))) {
+                goto nla_put_failure;
+        }
+
+        if (putDTCPConfigObject(netlinkMessage,
+                        object.getDTCPConfig())< 0) {
+                goto nla_put_failure;
+        }
+
+        nla_nest_end(netlinkMessage, dtcpConfig);
 
         NLA_PUT_U16(netlinkMessage, CONN_ATTR_FLOW_USER_IPCP_ID,
                         object.getFlowUserIpcProcessId());
@@ -3318,9 +3324,12 @@ Connection * parseConnectionObject(nlattr *nested) {
         attr_policy[CONN_ATTR_DEST_CEP_ID].type = NLA_U32;
         attr_policy[CONN_ATTR_DEST_CEP_ID].minlen = 4;
         attr_policy[CONN_ATTR_DEST_CEP_ID].maxlen = 4;
-        attr_policy[CONN_ATTR_POLICIES].type = NLA_NESTED;
-        attr_policy[CONN_ATTR_POLICIES].minlen = 0;
-        attr_policy[CONN_ATTR_POLICIES].maxlen = 0;
+        attr_policy[CONN_ATTR_DTP_CONFIG].type = NLA_NESTED;
+        attr_policy[CONN_ATTR_DTP_CONFIG].minlen = 0;
+        attr_policy[CONN_ATTR_DTP_CONFIG].maxlen = 0;
+        attr_policy[CONN_ATTR_DTCP_CONFIG].type = NLA_NESTED;
+        attr_policy[CONN_ATTR_DTCP_CONFIG].minlen = 0;
+        attr_policy[CONN_ATTR_DTCP_CONFIG].maxlen = 0;
         attr_policy[CONN_ATTR_FLOW_USER_IPCP_ID].type = NLA_U16;
         attr_policy[CONN_ATTR_FLOW_USER_IPCP_ID].minlen = 2;
         attr_policy[CONN_ATTR_FLOW_USER_IPCP_ID].maxlen = 2;
@@ -3334,7 +3343,8 @@ Connection * parseConnectionObject(nlattr *nested) {
         }
 
         Connection * result = new Connection();
-        ConnectionPolicies * connectionPolicies;
+        DTPConfig * dtpConfig;
+        DTCPConfig * dtcpConfig;
 
         if (attrs[CONN_ATTR_PORT_ID]) {
                 result->setPortId(nla_get_u32(attrs[CONN_ATTR_PORT_ID]));
@@ -3364,15 +3374,27 @@ Connection * parseConnectionObject(nlattr *nested) {
                                 nla_get_u32(attrs[CONN_ATTR_DEST_CEP_ID]));
         }
 
-        if (attrs[CONN_ATTR_POLICIES]){
-                connectionPolicies = parseConnectionPoliciesObject(
-                                attrs[CONN_ATTR_POLICIES]);
-                if (connectionPolicies == 0) {
+        if (attrs[CONN_ATTR_DTP_CONFIG]){
+                dtpConfig = parseDTPConfigObject(
+                                attrs[CONN_ATTR_DTP_CONFIG]);
+                if (dtpConfig == 0) {
                         delete result;
                         return 0;
                 } else {
-                        result->setPolicies(*connectionPolicies);
-                        delete connectionPolicies;
+                        result->setDTPConfig(*dtpConfig);
+                        delete dtpConfig;
+                }
+        }
+
+        if (attrs[CONN_ATTR_DTCP_CONFIG]){
+                dtcpConfig = parseDTCPConfigObject(
+                                attrs[CONN_ATTR_DTCP_CONFIG]);
+                if (dtcpConfig == 0) {
+                        delete result;
+                        return 0;
+                } else {
+                        result->setDTCPConfig(*dtcpConfig);
+                        delete dtcpConfig;
                 }
         }
 
@@ -4984,7 +5006,7 @@ int putIpcmDIFQueryRIBResponseMessageObject(nl_msg* netlinkMessage,
 
 int putIpcpConnectionCreateRequestMessageObject(nl_msg* netlinkMessage,
                 const IpcpConnectionCreateRequestMessage& object) {
-        struct nlattr *policies;
+        struct nlattr *dtpConfig, *dtcpConfig;
 
         NLA_PUT_U32(netlinkMessage, ICCRM_ATTR_PORT_ID,
                         object.getConnection().getPortId());
@@ -4995,17 +5017,29 @@ int putIpcpConnectionCreateRequestMessageObject(nl_msg* netlinkMessage,
         NLA_PUT_U32(netlinkMessage, ICCRM_ATTR_QOS_ID,
                         object.getConnection().getQosId());
 
-        if (!(policies = nla_nest_start(
-                        netlinkMessage, ICCRM_ATTR_POLICIES))){
+        if (!(dtpConfig = nla_nest_start(
+                        netlinkMessage, ICCRM_ATTR_DTP_CONFIG))){
                 goto nla_put_failure;
         }
 
-        if (putConnectionPoliciesObject(netlinkMessage,
-                        object.getConnection().getPolicies()) < 0) {
+        if (putDTPConfigObject(netlinkMessage,
+                        object.getConnection().getDTPConfig()) < 0) {
                 goto nla_put_failure;
         }
 
-        nla_nest_end(netlinkMessage, policies);
+        nla_nest_end(netlinkMessage, dtpConfig);
+
+        if (!(dtcpConfig = nla_nest_start(
+                        netlinkMessage, ICCRM_ATTR_DTCP_CONFIG))){
+                goto nla_put_failure;
+        }
+
+        if (putDTCPConfigObject(netlinkMessage,
+                        object.getConnection().getDTCPConfig()) < 0) {
+                goto nla_put_failure;
+        }
+
+        nla_nest_end(netlinkMessage, dtcpConfig);
 
         return 0;
 
@@ -5056,7 +5090,7 @@ int putIpcpConnectionUpdateResultMessageObject(nl_msg* netlinkMessage,
 
 int putIpcpConnectionCreateArrivedMessageObject(nl_msg* netlinkMessage,
                 const IpcpConnectionCreateArrivedMessage& object) {
-        struct nlattr *policies;
+        struct nlattr *dtpConfig, *dtcpConfig;
 
         NLA_PUT_U32(netlinkMessage, ICCAM_ATTR_PORT_ID,
                         object.getConnection().getPortId());
@@ -5071,17 +5105,29 @@ int putIpcpConnectionCreateArrivedMessageObject(nl_msg* netlinkMessage,
         NLA_PUT_U16(netlinkMessage, ICCAM_ATTR_FLOW_USER_IPCP_ID,
                         object.getConnection().getFlowUserIpcProcessId());
 
-        if (!(policies = nla_nest_start(
-                        netlinkMessage, ICCAM_ATTR_POLICIES))){
+        if (!(dtpConfig = nla_nest_start(
+                        netlinkMessage, ICCAM_ATTR_DTP_CONFIG))){
                 goto nla_put_failure;
         }
 
-        if (putConnectionPoliciesObject(netlinkMessage,
-                        object.getConnection().getPolicies()) < 0) {
+        if (putDTPConfigObject(netlinkMessage,
+                        object.getConnection().getDTPConfig()) < 0) {
                 goto nla_put_failure;
         }
 
-        nla_nest_end(netlinkMessage, policies);
+        nla_nest_end(netlinkMessage, dtpConfig);
+
+        if (!(dtcpConfig = nla_nest_start(
+                        netlinkMessage, ICCAM_ATTR_DTCP_CONFIG))){
+                goto nla_put_failure;
+        }
+
+        if (putDTCPConfigObject(netlinkMessage,
+                        object.getConnection().getDTCPConfig()) < 0) {
+                goto nla_put_failure;
+        }
+
+        nla_nest_end(netlinkMessage, dtcpConfig);
 
         return 0;
 
@@ -8393,9 +8439,12 @@ IpcpConnectionCreateRequestMessage * parseIpcpConnectionCreateRequestMessage(
         attr_policy[ICCRM_ATTR_QOS_ID].type = NLA_U32;
         attr_policy[ICCRM_ATTR_QOS_ID].minlen = 4;
         attr_policy[ICCRM_ATTR_QOS_ID].maxlen = 4;
-        attr_policy[ICCRM_ATTR_POLICIES].type = NLA_NESTED;
-        attr_policy[ICCRM_ATTR_POLICIES].minlen = 0;
-        attr_policy[ICCRM_ATTR_POLICIES].maxlen = 0;
+        attr_policy[ICCRM_ATTR_DTP_CONFIG].type = NLA_NESTED;
+        attr_policy[ICCRM_ATTR_DTP_CONFIG].minlen = 0;
+        attr_policy[ICCRM_ATTR_DTP_CONFIG].maxlen = 0;
+        attr_policy[ICCRM_ATTR_DTCP_CONFIG].type = NLA_NESTED;
+        attr_policy[ICCRM_ATTR_DTCP_CONFIG].minlen = 0;
+        attr_policy[ICCRM_ATTR_DTCP_CONFIG].maxlen = 0;
         struct nlattr *attrs[ICCRM_ATTR_MAX + 1];
 
         int err = genlmsg_parse(hdr, sizeof(struct rinaHeader), attrs,
@@ -8408,7 +8457,8 @@ IpcpConnectionCreateRequestMessage * parseIpcpConnectionCreateRequestMessage(
 
         IpcpConnectionCreateRequestMessage * result;
         Connection * connection = new Connection();
-        ConnectionPolicies * policies;
+        DTPConfig * dtpConfig;
+        DTCPConfig * dtcpConfig;
 
         if (attrs[ICCRM_ATTR_PORT_ID]) {
                 connection->setPortId(nla_get_u32(attrs[ICCRM_ATTR_PORT_ID]));
@@ -8428,15 +8478,27 @@ IpcpConnectionCreateRequestMessage * parseIpcpConnectionCreateRequestMessage(
                 connection->setQosId(nla_get_u32(attrs[ICCRM_ATTR_QOS_ID]));
         }
 
-	if (attrs[ICCRM_ATTR_POLICIES]) {
-	        policies = parseConnectionPoliciesObject(
-	                        attrs[ICCRM_ATTR_POLICIES]);
-		if (policies == 0) {
+	if (attrs[ICCRM_ATTR_DTP_CONFIG]) {
+	        dtpConfig = parseDTPConfigObject(
+	                        attrs[ICCRM_ATTR_DTP_CONFIG]);
+		if (dtpConfig == 0) {
 			delete connection;
 			return 0;
 		} else {
-			connection->setPolicies(*policies);
-			delete policies;
+			connection->setDTPConfig(*dtpConfig);
+			delete dtpConfig;
+		}
+	}
+
+	if (attrs[ICCRM_ATTR_DTCP_CONFIG]) {
+	        dtcpConfig = parseDTCPConfigObject(
+	                        attrs[ICCRM_ATTR_DTCP_CONFIG]);
+		if (dtcpConfig == 0) {
+			delete connection;
+			return 0;
+		} else {
+			connection->setDTCPConfig(*dtcpConfig);
+			delete dtcpConfig;
 		}
 	}
 
@@ -8584,9 +8646,12 @@ IpcpConnectionCreateArrivedMessage * parseIpcpConnectionCreateArrivedMessage(
         attr_policy[ICCAM_ATTR_FLOW_USER_IPCP_ID].type = NLA_U16;
         attr_policy[ICCAM_ATTR_FLOW_USER_IPCP_ID].minlen = 2;
         attr_policy[ICCAM_ATTR_FLOW_USER_IPCP_ID].maxlen = 2;
-        attr_policy[ICCAM_ATTR_POLICIES].type = NLA_NESTED;
-        attr_policy[ICCAM_ATTR_POLICIES].minlen = 0;
-        attr_policy[ICCAM_ATTR_POLICIES].maxlen = 0;
+        attr_policy[ICCAM_ATTR_DTP_CONFIG].type = NLA_NESTED;
+        attr_policy[ICCAM_ATTR_DTP_CONFIG].minlen = 0;
+        attr_policy[ICCAM_ATTR_DTP_CONFIG].maxlen = 0;
+        attr_policy[ICCAM_ATTR_DTCP_CONFIG].type = NLA_NESTED;
+        attr_policy[ICCAM_ATTR_DTCP_CONFIG].minlen = 0;
+        attr_policy[ICCAM_ATTR_DTCP_CONFIG].maxlen = 0;
         struct nlattr *attrs[ICCAM_ATTR_MAX + 1];
 
         int err = genlmsg_parse(hdr, sizeof(struct rinaHeader), attrs,
@@ -8599,7 +8664,8 @@ IpcpConnectionCreateArrivedMessage * parseIpcpConnectionCreateArrivedMessage(
 
         IpcpConnectionCreateArrivedMessage * result;
         Connection * connection = new Connection();
-        ConnectionPolicies * policies;
+        DTPConfig * dtpConfig;
+        DTCPConfig * dtcpConfig;
 
         if (attrs[ICCAM_ATTR_PORT_ID]) {
                 connection->setPortId(nla_get_u32(attrs[ICCAM_ATTR_PORT_ID]));
@@ -8629,15 +8695,27 @@ IpcpConnectionCreateArrivedMessage * parseIpcpConnectionCreateArrivedMessage(
                                 nla_get_u16(attrs[ICCAM_ATTR_FLOW_USER_IPCP_ID]));
         }
 
-        if (attrs[ICCAM_ATTR_POLICIES]) {
-                policies = parseConnectionPoliciesObject(
-                                attrs[ICCAM_ATTR_POLICIES]);
-                if (policies == 0) {
+        if (attrs[ICCAM_ATTR_DTP_CONFIG]) {
+                dtpConfig = parseDTPConfigObject(
+                                attrs[ICCAM_ATTR_DTP_CONFIG]);
+                if (dtpConfig == 0) {
                         delete connection;
                         return 0;
                 } else {
-                        connection->setPolicies(*policies);
-                        delete policies;
+                        connection->setDTPConfig(*dtpConfig);
+                        delete dtpConfig;
+                }
+        }
+
+        if (attrs[ICCAM_ATTR_DTCP_CONFIG]) {
+                dtcpConfig = parseDTCPConfigObject(
+                                attrs[ICCAM_ATTR_DTCP_CONFIG]);
+                if (dtcpConfig == 0) {
+                        delete connection;
+                        return 0;
+                } else {
+                        connection->setDTCPConfig(*dtcpConfig);
+                        delete dtcpConfig;
                 }
         }
 

--- a/librina/src/netlink-parsers.h
+++ b/librina/src/netlink-parsers.h
@@ -338,7 +338,8 @@ enum QoSCubesAttributes {
 	QOS_CUBE_ATTR_MAX_GAP,
 	QOS_CUBE_ATTR_DELAY,
 	QOS_CUBE_ATTR_JITTER,
-	QOS_CUBE_ATTR_EFCP_POLICIES,
+	QOS_CUBE_ATTR_DTP_CONFIG,
+	QOS_CUBE_ATTR_DTCP_CONFIG,
 	__QOS_CUBE_ATTR_MAX,
 };
 
@@ -1150,10 +1151,8 @@ DTCPConfig *
 parseDTCPConfigObject(nlattr *nested);
 
 /* ConnectionPolicies class */
-enum ConnectionPoliciesAttributes {
+enum DTPConfigAttributes {
 	CPA_ATTR_DTCP_PRESENT = 1,
-	CPA_ATTR_DTCP_CONFIG,
-        CPA_ATTR_DTP_POLICY_SET,
 	CPA_ATTR_RCVR_TIMER_INAC_POLICY,
 	CPA_ATTR_SNDR_TIMER_INAC_POLICY,
 	CPA_ATTR_INIT_SEQ_NUM_POLICY,
@@ -1163,16 +1162,17 @@ enum ConnectionPoliciesAttributes {
 	CPA_ATTR_INCOMPLETE_DELIVERY,
 	CPA_ATTR_IN_ORDER_DELIVERY,
 	CPA_ATTR_MAX_SDU_GAP,
+        CPA_ATTR_DTP_POLICY_SET,
 	__CPA_ATTR_MAX,
 };
 
 #define CPA_ATTR_MAX (__CPA_ATTR_MAX -1)
 
-int putConnectionPoliciesObject(nl_msg * netlinkMessage,
-                const ConnectionPolicies& object);
+int putDTPConfigObject(nl_msg * netlinkMessage,
+                const DTPConfig& object);
 
-ConnectionPolicies *
-parseConnectionPoliciesObject(nlattr *nested);
+DTPConfig *
+parseDTPConfigObject(nlattr *nested);
 
 /* Connection class */
 enum ConnectionAttributes {
@@ -1182,7 +1182,8 @@ enum ConnectionAttributes {
         CONN_ATTR_QOS_ID,
         CONN_ATTR_SOURCE_CEP_ID,
         CONN_ATTR_DEST_CEP_ID,
-        CONN_ATTR_POLICIES,
+        CONN_ATTR_DTP_CONFIG,
+        CONN_ATTR_DTCP_CONFIG,
         CONN_ATTR_FLOW_USER_IPCP_ID,
         __CONN_ATTR_MAX,
 };
@@ -1199,7 +1200,8 @@ enum IpcpConnectionCreateRequestMessageAttributes {
         ICCRM_ATTR_SOURCE_ADDR,
         ICCRM_ATTR_DEST_ADDR,
         ICCRM_ATTR_QOS_ID,
-        ICCRM_ATTR_POLICIES,
+        ICCRM_ATTR_DTP_CONFIG,
+        ICCRM_ATTR_DTCP_CONFIG,
         __ICCRM_ATTR_MAX,
 };
 
@@ -1266,7 +1268,8 @@ enum IpcpConnectionCreateArrivedMessageAttributes {
         ICCAM_ATTR_DEST_CEP_ID,
         ICCAM_ATTR_QOS_ID,
         ICCAM_ATTR_FLOW_USER_IPCP_ID,
-        ICCAM_ATTR_POLICIES,
+        ICCAM_ATTR_DTP_CONFIG,
+        ICCAM_ATTR_DTCP_CONFIG,
         __ICCAM_ATTR_MAX,
 };
 

--- a/linux/net/rina/Makefile
+++ b/linux/net/rina/Makefile
@@ -15,7 +15,7 @@ obj-$(CONFIG_RINA) +=				\
 	serdes.o pdu-ser.o du-protection.o	\
 	ipcp-utils.o				\
 	connection.o common.o policies.o	\
-	dtcp-utils.o                            \
+	dtp-conf-utils.o dtcp-conf-utils.o      \
 
 obj-y +=					\
 	syscalls.o

--- a/linux/net/rina/connection.c
+++ b/linux/net/rina/connection.c
@@ -160,7 +160,7 @@ EXPORT_SYMBOL(connection_dst_addr_set);
 int connection_src_cep_id_set(struct connection * conn,
                               cep_id_t            cep_id)
 {
-        if (!conn || !(is_cep_id_ok(cep_id))) return -1;
+        if (!conn) return -1;
         conn->source_cep_id = cep_id;
         return 0;
 }
@@ -169,7 +169,7 @@ EXPORT_SYMBOL(connection_src_cep_id_set);
 int connection_dst_cep_id_set(struct connection * conn,
                               cep_id_t            cep_id)
 {
-        if (!conn || !(is_cep_id_ok(cep_id))) return -1;
+        if (!conn) return -1;
         conn->destination_cep_id = cep_id;
         return 0;
 }

--- a/linux/net/rina/connection.c
+++ b/linux/net/rina/connection.c
@@ -3,6 +3,7 @@
  *
  *    Francesco Salvestrini <f.salvestrini@nextworks.it>
  *    Sander Vrijders <sander.vrijders@intec.ugent.be>
+ *    Leonardo Bergesio <leonardo.bergesio@i2cat.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +32,36 @@
 #include "connection.h"
 #include "dtcp-utils.h"
 #include "policies.h"
+
+/* FIXME: Move RNL structure to RNL placeholder files */
+/* FIXME: More params to be added */
+struct conn_policies {
+        /* FIXME: Anyone using this variable? To be removed */
+        bool                 dtcp_present;
+        struct dtp_config *  dtp_cfg;
+        struct dtcp_config * dtcp_cfg;
+
+        /* DTP Policy set configuration */
+        struct policy * dtp_ps;
+};
+
+/* NOTE: Do not use this struct directly, IT MUST BE HIDDEN */
+/* FIXME: Add setters/getters to struct connection*/
+struct connection {
+        port_id_t              port_id;
+
+        address_t              source_address;
+        address_t              destination_address;
+
+        cep_id_t               source_cep_id;
+        cep_id_t               destination_cep_id;
+
+        qos_id_t               qos_id;
+
+        /* FIXME: Are we sure about the next fixme? */
+        /* FIXME: Add the list of policies associated with this connection */
+        struct conn_policies * policies_params;
+};
 
 struct connection * connection_create(void)
 {

--- a/linux/net/rina/connection.h
+++ b/linux/net/rina/connection.h
@@ -3,6 +3,7 @@
  *
  *    Francesco Salvestrini <f.salvestrini@nextworks.it>
  *    Sander Vrijders <sander.vrijders@intec.ugent.be>
+ *    Leonardo Bergesio <leonardo.bergesio@i2cat.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,49 +30,8 @@
 
 struct dtcp_config;
 
-/* FIXME: Move RNL structure to RNL placeholder files */
-/* FIXME: More params to be added */
-struct conn_policies {
-        /* FIXME: Anyone using this variable? To be removed */
-        bool                 dtcp_present;
-        struct dtcp_config * dtcp_cfg;
-
-        /* DTP Policy set configuration */
-        struct policy * dtp_ps;
-
-        /* FIXME The following three "policies" are unused, useless
-         * and duplicated - they already exist as function pointers
-         * (dtp-ps.h). They have to be removed here, and therefore
-         * from netlink (kernespace+userspace) and from librina. */
-        struct policy *      initial_sequence_number;
-        struct policy *      receiver_inactivity_timer;
-        struct policy *      sender_inactivity_timer;
-        /* Sequence number rollover threshold */
-        int                  seq_num_ro_th;
-        timeout_t            initial_a_timer;
-        bool                 partial_delivery;
-        bool                 incomplete_delivery;
-        bool                 in_order_delivery;
-        seq_num_t            max_sdu_gap;
-};
-
-/* NOTE: Do not use this struct directly, IT MUST BE HIDDEN */
-/* FIXME: Add setters/getters to struct connection*/
-struct connection {
-        port_id_t              port_id;
-
-        address_t              source_address;
-        address_t              destination_address;
-
-        cep_id_t               source_cep_id;
-        cep_id_t               destination_cep_id;
-
-        qos_id_t               qos_id;
-
-        /* FIXME: Are we sure about the next fixme? */
-        /* FIXME: Add the list of policies associated with this connection */
-        struct conn_policies * policies_params;
-};
+struct conn_policies;
+struct connection;
 
 struct conn_policies * conn_policies_create(void);
 struct connection *    connection_create(void);

--- a/linux/net/rina/connection.h
+++ b/linux/net/rina/connection.h
@@ -28,16 +28,29 @@
 #include "common.h"
 #include "qos.h"
 
-struct dtcp_config;
-
-struct conn_policies;
 struct connection;
 
-struct conn_policies * conn_policies_create(void);
-struct connection *    connection_create(void);
-struct connection *    connection_dup_from_user(const
+struct connection *  connection_create(void);
+struct connection *  connection_dup_from_user(const
                                                 struct connection __user * c);
-int                    conn_policies_destroy(struct conn_policies * cp_params);
-int                    connection_destroy(struct connection * conn);
+int                  connection_destroy(struct connection * conn);
+port_id_t            connection_port_id(const struct connection * conn);
+address_t            connection_src_addr(const struct connection * conn);
+address_t            connection_dst_addr(const struct connection * conn);
+cep_id_t             connection_src_cep_id(const struct connection * conn);
+cep_id_t             connection_dst_cep_id(const struct connection * conn);
+qos_id_t             connection_qos_id(const struct connection * conn);
+int                  connection_port_id_set(struct connection * conn,
+                                            port_id_t           port_id);
+int                  connection_src_addr_set(struct connection * conn,
+                                             address_t           addr);
+int                  connection_dst_addr_set(struct connection * conn,
+                                             address_t           addr);
+int                  connection_src_cep_id_set(struct connection * conn,
+                                               cep_id_t            cep_id);
+int                  connection_dst_cep_id_set(struct connection * conn,
+                                               cep_id_t            cep_id);
+int                  connection_qos_id_set(struct connection * conn,
+                                           qos_id_t            qos_id);
 
 #endif

--- a/linux/net/rina/dt-utils.c
+++ b/linux/net/rina/dt-utils.c
@@ -32,7 +32,7 @@
 /* FIXME: Maybe dtcp_cfg should be moved somewhere else and then delete this */
 #include "dtcp.h"
 #include "dtcp-ps.h"
-#include "dtcp-utils.h"
+#include "dtcp-conf-utils.h"
 #include "dt.h"
 #include "dtp.h"
 #include "rmt.h"

--- a/linux/net/rina/dtcp-conf-utils.c
+++ b/linux/net/rina/dtcp-conf-utils.c
@@ -1,5 +1,5 @@
 /*
- * DTCP Utils (Data Transfer Control Protocol)
+ * DTCP CONFIG Utils (Data Transfer Control Protocol)
  *
  *    Leonardo Bergesio     <leonardo.bergesio@i2cat.net>
  *    Francesco Salvestrini <f.salvestrini@nextworks.it>
@@ -21,7 +21,7 @@
 
 #include <linux/kernel.h>
 
-#define RINA_PREFIX "dtcp-utils"
+#define RINA_PREFIX "dtcp-conf-utils"
 
 #include "logs.h"
 #include "utils.h"

--- a/linux/net/rina/dtcp-conf-utils.c
+++ b/linux/net/rina/dtcp-conf-utils.c
@@ -26,7 +26,7 @@
 #include "logs.h"
 #include "utils.h"
 #include "debug.h"
-#include "dtcp-utils.h"
+#include "dtcp-conf-utils.h"
 #include "policies.h"
 
 /* FIXME: These externs have to disappear from here */

--- a/linux/net/rina/dtcp-conf-utils.h
+++ b/linux/net/rina/dtcp-conf-utils.h
@@ -19,8 +19,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef RINA_DTCP_UTILS_H
-#define RINA_DTCP_UTILS_H
+#ifndef RINA_DTCP_CONF_UTILS_H
+#define RINA_DTCP_CONF_UTILS_H
 
 #include "common.h"
 

--- a/linux/net/rina/dtcp-ps-common.c
+++ b/linux/net/rina/dtcp-ps-common.c
@@ -33,7 +33,6 @@
 #include "dtcp-ps.h"
 #include "dtp.h"
 #include "dtcp.h"
-#include "dtcp-utils.h"
 #include "dt-utils.h"
 #include "debug.h"
 
@@ -42,7 +41,6 @@ common_sv_update(struct dtcp_ps * ps, seq_num_t seq)
 {
         struct dtcp * dtcp = ps->dm;
         int                  retval = 0;
-        struct dtcp_config * dtcp_cfg;
 
         bool                 flow_ctrl;
         bool                 win_based;
@@ -53,10 +51,6 @@ common_sv_update(struct dtcp_ps * ps, seq_num_t seq)
                 LOG_ERR("No instance passed, cannot run policy");
                 return -1;
         }
-
-        dtcp_cfg = dtcp_config_get(dtcp);
-        if (!dtcp_cfg)
-                return -1;
 
         flow_ctrl  = ps->flow_ctrl;
         win_based  = ps->flowctrl.window_based;

--- a/linux/net/rina/dtcp.c
+++ b/linux/net/rina/dtcp.c
@@ -29,12 +29,12 @@
 #include "debug.h"
 #include "dtcp.h"
 #include "rmt.h"
-#include "connection.h"
 #include "dtp.h"
 #include "dt-utils.h"
-#include "dtcp-utils.h"
+#include "dtcp-conf-utils.h"
 #include "ps-factory.h"
 #include "dtcp-ps.h"
+#include "policies.h"
 
 static struct policy_set_list policy_sets = {
         .head = LIST_HEAD_INIT(policy_sets.head)
@@ -153,7 +153,7 @@ struct dtcp {
          */
         struct dtcp_sv *       sv; /* The state-vector */
         struct rina_component  base;
-        struct connection *    conn;
+        struct dtcp_config *   cfg;
         struct rmt *           rmt;
 
         atomic_t               cpdus_in_transit;
@@ -169,11 +169,7 @@ struct dtcp_config * dtcp_config_get(struct dtcp * dtcp)
 {
         if (!dtcp)
                 return NULL;
-        if (!dtcp->conn)
-                return NULL;
-        if (!dtcp->conn->policies_params)
-                return NULL;
-        return dtcp->conn->policies_params->dtcp_cfg;
+        return dtcp->cfg;
 }
 EXPORT_SYMBOL(dtcp_config_get);
 
@@ -193,8 +189,8 @@ int dtcp_pdu_send(struct dtcp * dtcp, struct pdu * pdu)
 
         return common_efcp_pdu_send(efcp,
         			    dtcp->rmt,
-        			    dtcp->conn->destination_address,
-        			    dtcp->conn->qos_id,
+        			    efcp_dst_addr(efcp),
+        			    efcp_qos_id(efcp),
         			    pdu);
 }
 EXPORT_SYMBOL(dtcp_pdu_send);
@@ -454,9 +450,15 @@ static void last_snd_data_ack_set(struct dtcp * dtcp, seq_num_t seq_num)
 static int push_pdus_rmt(struct dtcp * dtcp)
 {
         struct cwq *  q;
+        struct efcp * efcp;
 
         ASSERT(dtcp);
 
+        efcp = dt_efcp(dtcp->parent);
+        if (!efcp) {
+                LOG_ERR("Passed instance has no EFCP, bailing out");
+                return -1;
+        }
         q = dt_cwq(dtcp->parent);
         if (!q) {
                 LOG_ERR("No Closed Window Queue");
@@ -466,8 +468,8 @@ static int push_pdus_rmt(struct dtcp * dtcp)
         cwq_deliver(q,
                     dtcp->parent,
                     dtcp->rmt,
-                    dtcp->conn->destination_address,
-                    dtcp->conn->qos_id);
+                    efcp_dst_addr(efcp),
+                    efcp_qos_id(efcp));
 
         return 0;
 }
@@ -478,9 +480,16 @@ struct pdu * pdu_ctrl_create_ni(struct dtcp * dtcp, pdu_type_t type)
         struct pci *    pci;
         struct buffer * buffer;
         seq_num_t       seq;
+        struct efcp *   efcp;
 
         if (!pdu_type_is_control(type))
                 return NULL;
+
+        efcp = dt_efcp(dtcp->parent);
+        if (!efcp) {
+                LOG_ERR("Passed instance has no EFCP, bailing out");
+                return NULL;
+        }
 
         buffer = buffer_create_ni(1);
         if (!buffer)
@@ -500,12 +509,12 @@ struct pdu * pdu_ctrl_create_ni(struct dtcp * dtcp, pdu_type_t type)
 
         seq = next_snd_ctl_seq(dtcp);
         if (pci_format(pci,
-                       dtcp->conn->source_cep_id,
-                       dtcp->conn->destination_cep_id,
-                       dtcp->conn->source_address,
-                       dtcp->conn->destination_address,
+                       efcp_src_cep_id(efcp),
+                       efcp_dst_cep_id(efcp),
+                       efcp_src_addr(efcp),
+                       efcp_dst_addr(efcp),
                        seq,
-                       dtcp->conn->qos_id,
+                       efcp_qos_id(efcp),
                        type)) {
                 pdu_destroy(pdu);
                 pci_destroy(pci);
@@ -1145,7 +1154,7 @@ int dtcp_select_policy_set(struct dtcp * dtcp,
                            const string_t * path,
                            const string_t * name)
 {
-        struct dtcp_config * cfg = dtcp->conn->policies_params->dtcp_cfg;
+        struct dtcp_config * cfg = dtcp->cfg;
         struct dtcp_ps *ps;
         int ret;
 
@@ -1290,10 +1299,9 @@ int dtcp_set_policy_set_param(struct dtcp * dtcp,
 }
 EXPORT_SYMBOL(dtcp_set_policy_set_param);
 
-struct dtcp * dtcp_create(struct dt *         dt,
-                          struct connection * conn,
-                          const string_t *    dtcp_ps_name,
-                          struct rmt *        rmt)
+struct dtcp * dtcp_create(struct dt *          dt,
+                          struct dtcp_config * dtcp_cfg,
+                          struct rmt *         rmt)
 {
         struct dtcp * tmp;
         string_t *    ps_name;
@@ -1302,8 +1310,8 @@ struct dtcp * dtcp_create(struct dt *         dt,
                 LOG_ERR("No DT passed, bailing out");
                 return NULL;
         }
-        if (!conn) {
-                LOG_ERR("No connection, bailing out");
+        if (!dtcp_cfg) {
+                LOG_ERR("No DTCP conf, bailing out");
                 return NULL;
         }
         if (!rmt) {
@@ -1326,13 +1334,13 @@ struct dtcp * dtcp_create(struct dt *         dt,
                 return NULL;
         }
 
-        tmp->conn = conn;
+        tmp->cfg  = dtcp_cfg;
         tmp->rmt  = rmt;
         atomic_set(&tmp->cpdus_in_transit, 0);
 
         rina_component_init(&tmp->base);
 
-        ps_name = (string_t *) dtcp_ps_name;
+        ps_name = (string_t *) policy_name(dtcp_ps(dtcp_cfg));
         if (!ps_name || !strcmp(ps_name, ""))
                 ps_name = RINA_PS_DEFAULT_NAME;
 
@@ -1366,6 +1374,7 @@ int dtcp_destroy(struct dtcp * instance)
         }
 
         if (instance->sv)       rkfree(instance->sv);
+        if (instance->cfg)      dtcp_config_destroy(instance->cfg);
         rina_component_fini(&instance->base);
         rkfree(instance);
 

--- a/linux/net/rina/dtcp.h
+++ b/linux/net/rina/dtcp.h
@@ -32,10 +32,9 @@ struct dtcp_rctrl_config;
 struct connection;
 struct rmt;
 
-struct dtcp *        dtcp_create(struct dt *         dt,
-                                 struct connection * conn,
-                                 const string_t *    dtcp_ps_name,
-                                 struct rmt *        rmt);
+struct dtcp *        dtcp_create(struct dt *          dt,
+                                 struct dtcp_config * dtcp_cfg,
+                                 struct rmt *         rmt);
 
 int                  dtcp_destroy(struct dtcp * instance);
 

--- a/linux/net/rina/dtp-conf-utils.c
+++ b/linux/net/rina/dtp-conf-utils.c
@@ -1,0 +1,169 @@
+/*
+ * DTP CONFIG UTILS (Data Transfer Protocol)
+ *
+ *    Leonardo Bergesio <leonardo.bergesio@i2cat.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#define RINA_PREFIX "dtp-conf-utils"
+
+#include "logs.h"
+#include "utils.h"
+#include "debug.h"
+#include "dtcp-utils.h"
+#include "policies.h"
+
+struct dtp_config {
+        /* FIXME The following three "policies" are unused, useless
+         * and duplicated - they already exist as function pointers
+         * (dtp-ps.h). They have to be removed here, and therefore
+         * from netlink (kernespace+userspace) and from librina. */
+        struct policy *      initial_sequence_number;
+        struct policy *      receiver_inactivity_timer;
+        struct policy *      sender_inactivity_timer;
+        /* Sequence number rollover threshold */
+        int                  seq_num_ro_th;
+        timeout_t            initial_a_timer;
+        bool                 partial_delivery;
+        bool                 incomplete_delivery;
+        bool                 in_order_delivery;
+        seq_num_t            max_sdu_gap;
+};
+
+struct policy * dtp_initial_sequence_number(struct dtp_config * cfg)
+{
+        if (!cfg) return NULL;
+        return cfg->initial_sequence_number;
+}
+EXPORT_SYMBOL(dtp_initial_sequence_number);
+
+int dtp_initial_sequence_number_set(struct dtp_config * cfg,
+                                    struct policy *     p)
+{
+        if (!cfg || p) return -1;
+        cfg->initial_sequence_number = p;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_initial_sequence_number_set);
+
+struct policy * dtp_receiver_inactivity_timer(struct dtp_config * cfg)
+{
+        if (!cfg) return NULL;
+        return cfg->receiver_inactivity_timer;
+}
+EXPORT_SYMBOL(dtp_receiver_inactivity_timer);
+
+int dtp_receiver_inactivity_timer_set(struct dtp_config * cfg,
+                                      struct policy *     p)
+{
+        if (!cfg || p) return -1;
+        cfg->receiver_inactivity_timer = p;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_receiver_inactivity_timer_set);
+
+struct policy * dtp_sender_inactivity_timer(struct dtp_config * cfg)
+{
+        if (!cfg) return NULL;
+        return cfg->sender_inactivity_timer;
+}
+EXPORT_SYMBOL(dtp_receiver_inactivity_timer);
+
+int dtp_sender_inactivity_timer_set(struct dtp_config * cfg,
+                                struct policy *     p)
+{
+        if (!cfg || p) return -1;
+        cfg->sender_inactivity_timer = p;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_receiver_inactivity_timer_set);
+
+
+int dtp_seq_num_ro_th(struct dtp_config * cfg)
+{
+        if (!cfg) return -1;
+        return cfg->seq_num_ro_th;
+}
+EXPORT_SYMBOL(dtp_seq_num_ro_th);
+
+int dtp_seq_num_ro_th_set(struct dtp_config * cfg, int seq_num_ro_th)
+{
+        if (!cfg) return -1;
+        cfg->seq_num_ro_th = seq_num_ro_th;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_seq_num_ro_th_set);
+
+timeout_t dtp_initial_a_timer(struct dtp_config * cfg)
+{
+        if (!cfg) return -1;
+        return cfg->initial_a_timer;
+}
+EXPORT_SYMBOL(dtp_initial_a_timer);
+
+int dtp_initial_a_timer_set(struct dtp_config * cfg,
+                             timeout_t initial_a_timer)
+{
+        if (!cfg) return -1;
+        cfg->initial_a_timer = initial_a_timer;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_initial_a_timer_set);
+
+bool dtp_partial_del(struct dtp_config * cfg)
+{
+        if (!cfg) return -1;
+        return cfg->partial_delivery;
+}
+EXPORT_SYMBOL(dtp_partial_del);
+
+int dtp_partial_del_set(struct dtp_config * cfg, bool partial_del)
+{
+        if (!cfg) return -1;
+        cfg->partial_delivery = partial_del;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_partial_del_set);
+
+bool dtp_incomplete_del(struct dtp_config * cfg)
+{
+        if (!cfg) return -1;
+        return cfg->incomplete_delivery;
+}
+EXPORT_SYMBOL(dtp_incomplete_del);
+
+int dtp_incomplete_del_set(struct dtp_config * cfg, bool incomplete_del)
+{
+        if (!cfg) return -1;
+        cfg->incomplete_delivery = incomplete_del;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_incomplete_del_set);
+
+seq_num_t dtp_max_sdu_gap(struct dtp_config * cfg)
+{
+        if (!cfg) return -1;
+        return cfg->max_sdu_gap;
+}
+EXPORT_SYMBOL(dtp_max_sdu_gap);
+
+int dtp_max_sdu_gap_set(struct dtp_config * cfg, seq_num_t max_sdu_gap)
+{
+        if (!cfg) return -1;
+        cfg->max_sdu_gap = max_sdu_gap;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_max_sdu_gap_set);

--- a/linux/net/rina/dtp-conf-utils.c
+++ b/linux/net/rina/dtp-conf-utils.c
@@ -21,9 +21,9 @@
 #define RINA_PREFIX "dtp-conf-utils"
 
 #include "logs.h"
+#include "dtp-conf-utils.h"
 #include "utils.h"
 #include "debug.h"
-#include "dtcp-utils.h"
 #include "policies.h"
 
 struct dtp_config {
@@ -34,6 +34,7 @@ struct dtp_config {
         struct policy *      initial_sequence_number;
         struct policy *      receiver_inactivity_timer;
         struct policy *      sender_inactivity_timer;
+        bool                 dtcp_present;
         /* Sequence number rollover threshold */
         int                  seq_num_ro_th;
         timeout_t            initial_a_timer;
@@ -41,129 +42,239 @@ struct dtp_config {
         bool                 incomplete_delivery;
         bool                 in_order_delivery;
         seq_num_t            max_sdu_gap;
+
+        struct policy *      dtp_ps;
 };
 
-struct policy * dtp_initial_sequence_number(struct dtp_config * cfg)
+int dtp_config_destroy(struct dtp_config * cfg)
+{
+        if (!cfg)
+                return -1;
+        if (cfg->initial_sequence_number)
+                policy_destroy(cfg->initial_sequence_number);
+        if (cfg->receiver_inactivity_timer)
+                policy_destroy(cfg->receiver_inactivity_timer);
+        if (cfg->sender_inactivity_timer)
+                policy_destroy(cfg->sender_inactivity_timer);
+        if (cfg->dtp_ps)
+                policy_destroy(cfg->dtp_ps);
+
+        rkfree(cfg);
+
+        return 0;
+}
+EXPORT_SYMBOL(dtp_config_destroy);
+
+static struct dtp_config * dtp_config_create_gfp(gfp_t flags)
+{
+        struct dtp_config * tmp;
+
+        tmp = rkzalloc(sizeof(*tmp), flags);
+        if (!tmp)
+                return NULL;
+
+        tmp->dtp_ps = policy_create();
+        if (!tmp->dtp_ps)
+                goto clean;
+
+        tmp->initial_sequence_number = policy_create();
+        if (!tmp->initial_sequence_number) {
+                LOG_ERR("Could not create initial_sequence_number");
+                goto clean;
+        }
+
+        tmp->receiver_inactivity_timer = policy_create();
+        if (!tmp->receiver_inactivity_timer) {
+                LOG_ERR("Could not create receiver_inactivity_timer policy");
+                goto clean;
+        }
+
+        tmp->sender_inactivity_timer = policy_create();
+        if (!tmp->sender_inactivity_timer) {
+                LOG_ERR("Could not create sender_inactivity_timer policy");
+                goto clean;
+        }
+
+        return tmp;
+
+clean:
+        dtp_config_destroy(tmp);
+        return NULL;
+}
+
+struct dtp_config * dtp_config_create(void)
+{ return dtp_config_create_gfp(GFP_KERNEL); }
+EXPORT_SYMBOL(dtp_config_create);
+
+struct dtp_config * dtp_config_create_ni(void)
+{ return dtp_config_create_gfp(GFP_ATOMIC); }
+EXPORT_SYMBOL(dtp_config_create_ni);
+
+struct policy * dtp_conf_initial_sequence_number(struct dtp_config * cfg)
 {
         if (!cfg) return NULL;
         return cfg->initial_sequence_number;
 }
-EXPORT_SYMBOL(dtp_initial_sequence_number);
+EXPORT_SYMBOL(dtp_conf_initial_sequence_number);
 
-int dtp_initial_sequence_number_set(struct dtp_config * cfg,
+int dtp_conf_initial_sequence_number_set(struct dtp_config * cfg,
                                     struct policy *     p)
 {
         if (!cfg || p) return -1;
         cfg->initial_sequence_number = p;
         return 0;
 }
-EXPORT_SYMBOL(dtp_initial_sequence_number_set);
+EXPORT_SYMBOL(dtp_conf_initial_sequence_number_set);
 
-struct policy * dtp_receiver_inactivity_timer(struct dtp_config * cfg)
+struct policy * dtp_conf_receiver_inactivity_timer(struct dtp_config * cfg)
 {
         if (!cfg) return NULL;
         return cfg->receiver_inactivity_timer;
 }
-EXPORT_SYMBOL(dtp_receiver_inactivity_timer);
+EXPORT_SYMBOL(dtp_conf_receiver_inactivity_timer);
 
-int dtp_receiver_inactivity_timer_set(struct dtp_config * cfg,
+int dtp_conf_receiver_inactivity_timer_set(struct dtp_config * cfg,
                                       struct policy *     p)
 {
         if (!cfg || p) return -1;
         cfg->receiver_inactivity_timer = p;
         return 0;
 }
-EXPORT_SYMBOL(dtp_receiver_inactivity_timer_set);
+EXPORT_SYMBOL(dtp_conf_receiver_inactivity_timer_set);
 
-struct policy * dtp_sender_inactivity_timer(struct dtp_config * cfg)
+struct policy * dtp_conf_sender_inactivity_timer(struct dtp_config * cfg)
 {
         if (!cfg) return NULL;
         return cfg->sender_inactivity_timer;
 }
-EXPORT_SYMBOL(dtp_receiver_inactivity_timer);
+EXPORT_SYMBOL(dtp_conf_sender_inactivity_timer);
 
-int dtp_sender_inactivity_timer_set(struct dtp_config * cfg,
+int dtp_conf_sender_inactivity_timer_set(struct dtp_config * cfg,
                                 struct policy *     p)
 {
         if (!cfg || p) return -1;
         cfg->sender_inactivity_timer = p;
         return 0;
 }
-EXPORT_SYMBOL(dtp_receiver_inactivity_timer_set);
+EXPORT_SYMBOL(dtp_conf_sender_inactivity_timer_set);
 
+bool dtp_conf_dtcp_present(struct dtp_config * cfg)
+{
+        if (!cfg) return false;
+        return cfg->dtcp_present;
+}
+EXPORT_SYMBOL(dtp_conf_dtcp_present);
 
-int dtp_seq_num_ro_th(struct dtp_config * cfg)
+int dtp_conf_dtcp_present_set(struct dtp_config * cfg, bool present)
+{
+        if (!cfg) return -1;
+        return cfg->dtcp_present = present;
+}
+EXPORT_SYMBOL(dtp_conf_dtcp_present_set);
+
+int dtp_conf_seq_num_ro_th(struct dtp_config * cfg)
 {
         if (!cfg) return -1;
         return cfg->seq_num_ro_th;
 }
-EXPORT_SYMBOL(dtp_seq_num_ro_th);
+EXPORT_SYMBOL(dtp_conf_seq_num_ro_th);
 
-int dtp_seq_num_ro_th_set(struct dtp_config * cfg, int seq_num_ro_th)
+int dtp_conf_seq_num_ro_th_set(struct dtp_config * cfg, int seq_num_ro_th)
 {
         if (!cfg) return -1;
         cfg->seq_num_ro_th = seq_num_ro_th;
         return 0;
 }
-EXPORT_SYMBOL(dtp_seq_num_ro_th_set);
+EXPORT_SYMBOL(dtp_conf_seq_num_ro_th_set);
 
-timeout_t dtp_initial_a_timer(struct dtp_config * cfg)
+timeout_t dtp_conf_initial_a_timer(struct dtp_config * cfg)
 {
         if (!cfg) return -1;
         return cfg->initial_a_timer;
 }
-EXPORT_SYMBOL(dtp_initial_a_timer);
+EXPORT_SYMBOL(dtp_conf_initial_a_timer);
 
-int dtp_initial_a_timer_set(struct dtp_config * cfg,
+int dtp_conf_initial_a_timer_set(struct dtp_config * cfg,
                              timeout_t initial_a_timer)
 {
         if (!cfg) return -1;
         cfg->initial_a_timer = initial_a_timer;
         return 0;
 }
-EXPORT_SYMBOL(dtp_initial_a_timer_set);
+EXPORT_SYMBOL(dtp_conf_initial_a_timer_set);
 
-bool dtp_partial_del(struct dtp_config * cfg)
+bool dtp_conf_partial_del(struct dtp_config * cfg)
 {
-        if (!cfg) return -1;
+        if (!cfg) return false;
         return cfg->partial_delivery;
 }
-EXPORT_SYMBOL(dtp_partial_del);
+EXPORT_SYMBOL(dtp_conf_partial_del);
 
-int dtp_partial_del_set(struct dtp_config * cfg, bool partial_del)
+int dtp_conf_partial_del_set(struct dtp_config * cfg, bool partial_del)
 {
         if (!cfg) return -1;
         cfg->partial_delivery = partial_del;
         return 0;
 }
-EXPORT_SYMBOL(dtp_partial_del_set);
+EXPORT_SYMBOL(dtp_conf_partial_del_set);
 
-bool dtp_incomplete_del(struct dtp_config * cfg)
+bool dtp_conf_incomplete_del(struct dtp_config * cfg)
 {
-        if (!cfg) return -1;
+        if (!cfg) return false;
         return cfg->incomplete_delivery;
 }
-EXPORT_SYMBOL(dtp_incomplete_del);
+EXPORT_SYMBOL(dtp_conf_incomplete_del);
 
-int dtp_incomplete_del_set(struct dtp_config * cfg, bool incomplete_del)
+int dtp_conf_incomplete_del_set(struct dtp_config * cfg, bool incomplete_del)
 {
         if (!cfg) return -1;
         cfg->incomplete_delivery = incomplete_del;
         return 0;
 }
-EXPORT_SYMBOL(dtp_incomplete_del_set);
+EXPORT_SYMBOL(dtp_conf_incomplete_del_set);
 
-seq_num_t dtp_max_sdu_gap(struct dtp_config * cfg)
+bool dtp_conf_in_order_del(struct dtp_config * cfg)
+{
+        if (!cfg) return false;
+        return cfg->in_order_delivery;
+}
+EXPORT_SYMBOL(dtp_conf_in_order_del);
+
+int dtp_conf_in_order_del_set(struct dtp_config * cfg, bool in_order_del)
+{
+        if (!cfg) return -1;
+        cfg->in_order_delivery = in_order_del;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_conf_in_order_del_set);
+
+seq_num_t dtp_conf_max_sdu_gap(struct dtp_config * cfg)
 {
         if (!cfg) return -1;
         return cfg->max_sdu_gap;
 }
-EXPORT_SYMBOL(dtp_max_sdu_gap);
+EXPORT_SYMBOL(dtp_conf_max_sdu_gap);
 
-int dtp_max_sdu_gap_set(struct dtp_config * cfg, seq_num_t max_sdu_gap)
+int dtp_conf_max_sdu_gap_set(struct dtp_config * cfg, seq_num_t max_sdu_gap)
 {
         if (!cfg) return -1;
         cfg->max_sdu_gap = max_sdu_gap;
         return 0;
 }
-EXPORT_SYMBOL(dtp_max_sdu_gap_set);
+EXPORT_SYMBOL(dtp_conf_max_sdu_gap_set);
+
+struct policy * dtp_conf_ps_get(struct dtp_config * cfg)
+{
+        if (!cfg) return NULL;
+        return cfg->dtp_ps;
+}
+EXPORT_SYMBOL(dtp_conf_ps_get);
+
+int dtp_conf_ps_set(struct dtp_config * cfg,
+               struct policy *     ps)
+{
+        if (!cfg || ps) return -1;
+        cfg->dtp_ps = ps;
+        return 0;
+}
+EXPORT_SYMBOL(dtp_conf_ps_set);

--- a/linux/net/rina/dtp-conf-utils.h
+++ b/linux/net/rina/dtp-conf-utils.h
@@ -1,0 +1,45 @@
+/*
+ * DTP CONFIG UTILS (Data Transfer Protocol);
+ *
+ *    Leonardo Bergesio <leonardo.bergesio@i2cat.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option); any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef RINA_DTP_CONF_UTILS_H
+#define RINA_DTP_CONF_UTILS_H
+
+struct dtp_config;
+
+struct policy * dtp_initial_sequence_number(struct dtp_config * cfg);
+int             dtp_initial_sequence_number_set(struct dtp_config * cfg,
+struct policy * dtp_receiver_inactivity_timer(struct dtp_config * cfg);
+int             dtp_receiver_inactivity_timer_set(struct dtp_config * cfg,
+                                                  struct policy *     p);
+struct policy * dtp_sender_inactivity_timer(struct dtp_config * cfg);
+
+int             dtp_sender_inactivity_timer_set(struct dtp_config * cfg,
+                                                struct policy *     p);
+int             dtp_seq_num_ro_th(struct dtp_config * cfg);
+int             dtp_seq_num_ro_th_set(struct dtp_config * cfg, int seq_num_ro_th);
+timeout_t       dtp_initial_a_timer(struct dtp_config * cfg);
+int             dtp_initial_a_timer_set(struct dtp_config * cfg,
+                             timeout_t initial_a_timer);
+bool            dtp_partial_del(struct dtp_config * cfg);
+int             dtp_partial_del_set(struct dtp_config * cfg, bool partial_del);
+bool            dtp_incomplete_del(struct dtp_config * cfg);
+int             dtp_incomplete_del_set(struct dtp_config * cfg, bool incomplete_del);
+seq_num_t       dtp_max_sdu_gap(struct dtp_config * cfg);
+int             dtp_max_sdu_gap_set(struct dtp_config * cfg, seq_num_t max_sdu_gap);

--- a/linux/net/rina/dtp-conf-utils.h
+++ b/linux/net/rina/dtp-conf-utils.h
@@ -21,25 +21,40 @@
 #ifndef RINA_DTP_CONF_UTILS_H
 #define RINA_DTP_CONF_UTILS_H
 
+#include "common.h"
+
 struct dtp_config;
 
-struct policy * dtp_initial_sequence_number(struct dtp_config * cfg);
-int             dtp_initial_sequence_number_set(struct dtp_config * cfg,
-struct policy * dtp_receiver_inactivity_timer(struct dtp_config * cfg);
-int             dtp_receiver_inactivity_timer_set(struct dtp_config * cfg,
-                                                  struct policy *     p);
-struct policy * dtp_sender_inactivity_timer(struct dtp_config * cfg);
+struct dtp_config * dtp_config_create(void);
+struct dtp_config * dtp_config_create_ni(void);
+int                 dtp_config_destroy(struct dtp_config * cfg);
 
-int             dtp_sender_inactivity_timer_set(struct dtp_config * cfg,
-                                                struct policy *     p);
-int             dtp_seq_num_ro_th(struct dtp_config * cfg);
-int             dtp_seq_num_ro_th_set(struct dtp_config * cfg, int seq_num_ro_th);
-timeout_t       dtp_initial_a_timer(struct dtp_config * cfg);
-int             dtp_initial_a_timer_set(struct dtp_config * cfg,
-                             timeout_t initial_a_timer);
-bool            dtp_partial_del(struct dtp_config * cfg);
-int             dtp_partial_del_set(struct dtp_config * cfg, bool partial_del);
-bool            dtp_incomplete_del(struct dtp_config * cfg);
-int             dtp_incomplete_del_set(struct dtp_config * cfg, bool incomplete_del);
-seq_num_t       dtp_max_sdu_gap(struct dtp_config * cfg);
-int             dtp_max_sdu_gap_set(struct dtp_config * cfg, seq_num_t max_sdu_gap);
+struct policy * dtp_conf_initial_sequence_number(struct dtp_config * cfg);
+int             dtp_conf_initial_sequence_number_set(struct dtp_config * cfg,
+                                                     struct policy *     p);
+struct policy * dtp_conf_receiver_inactivity_timer(struct dtp_config * cfg);
+int             dtp_conf_receiver_inactivity_timer_set(struct dtp_config * cfg,
+                                                       struct policy *     p);
+struct policy * dtp_conf_sender_inactivity_timer(struct dtp_config * cfg);
+int             dtp_conf_sender_inactivity_timer_set(struct dtp_config * cfg,
+                                                     struct policy *     p);
+bool            dtp_conf_dtcp_present(struct dtp_config * cfg);
+int             dtp_conf_dtcp_present_set(struct dtp_config * cfg, bool present);
+int             dtp_conf_seq_num_ro_th(struct dtp_config * cfg);
+int             dtp_conf_seq_num_ro_th_set(struct dtp_config * cfg, int seq_num_ro_th);
+timeout_t       dtp_conf_initial_a_timer(struct dtp_config * cfg);
+int             dtp_conf_initial_a_timer_set(struct dtp_config * cfg,
+                                            timeout_t initial_a_timer);
+bool            dtp_conf_partial_del(struct dtp_config * cfg);
+int             dtp_conf_partial_del_set(struct dtp_config * cfg, bool partial_del);
+bool            dtp_conf_incomplete_del(struct dtp_config * cfg);
+int             dtp_conf_incomplete_del_set(struct dtp_config * cfg, bool incomplete_del);
+bool            dtp_conf_in_order_del(struct dtp_config * cfg);
+int             dtp_conf_in_order_del_set(struct dtp_config * cfg, bool in_order_del);
+seq_num_t       dtp_conf_max_sdu_gap(struct dtp_config * cfg);
+int             dtp_conf_max_sdu_gap_set(struct dtp_config * cfg, seq_num_t max_sdu_gap);
+struct policy * dtp_conf_ps_get(struct dtp_config * cfg);
+int             dtp_conf_ps_set(struct dtp_config * cfg,
+                           struct policy *     ps);
+
+#endif

--- a/linux/net/rina/dtp-ps-common.c
+++ b/linux/net/rina/dtp-ps-common.c
@@ -35,7 +35,7 @@
 #include "dtp.h"
 #include "dtcp.h"
 #include "dtcp-ps.h"
-#include "dtcp-utils.h"
+#include "dtcp-conf-utils.h"
 #include "dt-utils.h"
 #include "debug.h"
 
@@ -90,8 +90,6 @@ common_closed_window(struct dtp_ps * ps, struct pdu * pdu)
         struct dtp * dtp = ps->dm;
         struct cwq * cwq;
         struct dt *  dt;
-        struct dtp_sv * sv;
-        struct connection * connection;
         uint_t       max_len;
 
         if (!dtp) {
@@ -119,15 +117,7 @@ common_closed_window(struct dtp_ps * ps, struct pdu * pdu)
 
         ASSERT(dtp);
 
-        sv = dtp_dtp_sv(dtp);
-        ASSERT(sv);
-        connection = dtp_sv_connection(sv);
-        ASSERT(connection);
-        ASSERT(connection->policies_params);
-
-        max_len = dtcp_max_closed_winq_length(connection->
-                                              policies_params->
-                                              dtcp_cfg);
+        max_len = dtcp_max_closed_winq_length(dtcp_config_get(dt_dtcp(dt)));
         if (cwq_size(cwq) < max_len - 1) {
                 if (cwq_push(cwq, pdu)) {
                         LOG_ERR("Failed to push into cwq");

--- a/linux/net/rina/dtp.c
+++ b/linux/net/rina/dtp.c
@@ -1135,12 +1135,12 @@ int dtp_write(struct dtp * instance,
 
         csn = nxt_seq_get(sv);
         if (pci_format(pci,
-                       sv->connection->source_cep_id,
-                       sv->connection->destination_cep_id,
-                       sv->connection->source_address,
-                       sv->connection->destination_address,
+                       efcp_src_cep_id(dtp->efcp),
+                       efcp_dst_cep_id(dtp->efcp),
+                       efcp_src_addr(dtp->efcp),
+                       efcp_dst_addr(dtp->efcp),
                        csn,
-                       sv->connection->qos_id,
+                       efcp_qos_id(dtp->efcp),
                        PDU_TYPE_DT)) {
                 pci_destroy(pci);
                 sdu_destroy(sdu);

--- a/linux/net/rina/dtp.c
+++ b/linux/net/rina/dtp.c
@@ -33,9 +33,11 @@
 #include "dt-utils.h"
 #include "dtcp.h"
 #include "dtcp-ps.h"
-#include "dtcp-utils.h"
+#include "dtp-conf-utils.h"
+#include "dtcp-conf-utils.h"
 #include "ps-factory.h"
 #include "dtp-ps.h"
+#include "policies.h"
 
 static struct policy_set_list policy_sets = {
         .head = LIST_HEAD_INIT(policy_sets.head)
@@ -44,9 +46,6 @@ static struct policy_set_list policy_sets = {
 /* This is the DT-SV part maintained by DTP */
 struct dtp_sv {
         spinlock_t          lock;
-
-        /* Configuration values */
-        struct connection * connection; /* FIXME: Are we really sure ??? */
 
         uint_t              seq_number_rollover_threshold;
         uint_t              dropped_pdus;
@@ -70,8 +69,8 @@ struct dtp {
         struct dtp_sv *           sv; /* The state-vector */
 
         struct rina_component     base;
+        struct dtp_config *       cfg;
         struct rmt *              rmt;
-        struct efcp *             efcp;
         struct squeue *           seqq;
         struct {
                 struct rtimer * sender_inactivity;
@@ -81,7 +80,6 @@ struct dtp {
 };
 
 static struct dtp_sv default_sv = {
-        .connection                    = NULL,
         .seq_nr_to_send                = 0,
         .max_seq_nr_sent               = 0,
         .seq_number_rollover_threshold = 0,
@@ -111,12 +109,6 @@ struct dtp_sv * dtp_dtp_sv(struct dtp * dtp)
         return dtp->sv;
 }
 EXPORT_SYMBOL(dtp_dtp_sv);
-
-struct connection * dtp_sv_connection(struct dtp_sv * sv)
-{
-        return sv->connection;
-}
-EXPORT_SYMBOL(dtp_sv_connection);
 
 int nxt_seq_reset(struct dtp_sv * sv, seq_num_t sn)
 {
@@ -484,6 +476,7 @@ static int pdu_post(struct dtp * instance,
 {
         struct sdu *    sdu;
         struct buffer * buffer;
+        struct efcp *   efcp;
 
         ASSERT(instance->sv);
 
@@ -497,10 +490,11 @@ static int pdu_post(struct dtp * instance,
         pdu_buffer_disown(pdu);
         pdu_destroy(pdu);
 
-        ASSERT(instance->sv->connection);
+        efcp = dt_efcp(instance->parent);
+        ASSERT(efcp);
 
-        if (efcp_enqueue(instance->efcp,
-                         instance->sv->connection->port_id,
+        if (efcp_enqueue(efcp,
+                         efcp_port_id(efcp),
                          sdu)) {
                 LOG_ERR("Could not enqueue SDU to EFCP");
                 return -1;
@@ -607,9 +601,6 @@ seq_num_t process_A_expiration(struct dtp * dtp, struct dtcp * dtcp)
         ASSERT(seqq);
 
         a = dt_sv_a(dt);
-
-        ASSERT(sv->connection);
-        ASSERT(sv->connection->policies_params);
 
         rcu_read_lock();
         ps = container_of(rcu_dereference(dtp->base.ps), struct dtp_ps, base);
@@ -820,7 +811,7 @@ int dtp_select_policy_set(struct dtp * dtp,
                           const string_t * path,
                           const string_t * name)
 {
-        struct conn_policies *params = dtp->sv->connection->policies_params;
+        struct dtp_config * cfg = dtp->cfg;
         struct dtp_ps * ps;
         int ret;
 
@@ -839,13 +830,13 @@ int dtp_select_policy_set(struct dtp * dtp,
          * and not from the struct connection. */
         mutex_lock(&dtp->base.ps_lock);
         ps = container_of(dtp->base.ps, struct dtp_ps, base);
-        ps->dtcp_present        = params->dtcp_present;
-        ps->seq_num_ro_th       = params->seq_num_ro_th;
-        ps->initial_a_timer     = params->initial_a_timer;
-        ps->partial_delivery    = params->partial_delivery;
-        ps->incomplete_delivery = params->incomplete_delivery;
-        ps->in_order_delivery   = params->in_order_delivery;
-        ps->max_sdu_gap         = params->max_sdu_gap;
+        ps->dtcp_present        = dtp_conf_dtcp_present(cfg);
+        ps->seq_num_ro_th       = dtp_conf_seq_num_ro_th(cfg);
+        ps->initial_a_timer     = dtp_conf_initial_a_timer(cfg);
+        ps->partial_delivery    = dtp_conf_partial_del(cfg);
+        ps->incomplete_delivery = dtp_conf_incomplete_del(cfg);
+        ps->in_order_delivery   = dtp_conf_in_order_del(cfg);
+        ps->max_sdu_gap         = dtp_conf_max_sdu_gap(cfg);
         mutex_unlock(&dtp->base.ps_lock);
 
         return 0;
@@ -918,9 +909,7 @@ EXPORT_SYMBOL(dtp_set_policy_set_param);
 
 struct dtp * dtp_create(struct dt *         dt,
                         struct rmt *        rmt,
-                        struct efcp *       efcp,
-                        const string_t *    dtp_ps_name,
-                        struct connection * connection)
+                        struct dtp_config * dtp_cfg)
 {
         struct dtp * tmp;
         string_t *   ps_name;
@@ -930,6 +919,11 @@ struct dtp * dtp_create(struct dt *         dt,
                 return NULL;
         }
         dt_sv_drf_flag_set(dt, true);
+
+        if (!dtp_cfg) {
+                LOG_ERR("No DTP conf passed, bailing out");
+                return NULL;
+        }
 
         if (!rmt) {
                 LOG_ERR("No RMT passed, bailing out");
@@ -956,11 +950,10 @@ struct dtp * dtp_create(struct dt *         dt,
 
         spin_lock_init(&tmp->sv->lock);
 
-        tmp->sv->connection = connection;
+        tmp->cfg   = dtp_cfg;
 
-        tmp->rmt            = rmt;
-        tmp->efcp           = efcp;
-        tmp->seqq           = squeue_create(tmp);
+        tmp->rmt  = rmt;
+        tmp->seqq = squeue_create(tmp);
         if (!tmp->seqq) {
                 LOG_ERR("Could not create Sequencing queue");
                 dtp_destroy(tmp);
@@ -981,7 +974,7 @@ struct dtp * dtp_create(struct dt *         dt,
 
         rina_component_init(&tmp->base);
 
-        ps_name = (string_t *) dtp_ps_name;
+        ps_name = (string_t *) policy_name(dtp_conf_ps_get(dtp_cfg));
         if (!ps_name || !strcmp(ps_name, ""))
                 ps_name = RINA_PS_DEFAULT_NAME;
 
@@ -1021,6 +1014,7 @@ int dtp_destroy(struct dtp * instance)
 
         if (instance->seqq) squeue_destroy(instance->seqq);
         if (instance->sv)   rkfree(instance->sv);
+        if (instance->cfg) dtp_config_destroy(instance->cfg);
         rina_component_fini(&instance->base);
 
         rkfree(instance);
@@ -1067,6 +1061,7 @@ int dtp_write(struct dtp * instance,
         struct pdu *            cpdu;
         struct dtp_ps *         ps;
         seq_num_t               sn, csn;
+        struct efcp *           efcp;
 
         if (!sdu_is_ok(sdu))
                 return -1;
@@ -1084,16 +1079,17 @@ int dtp_write(struct dtp * instance,
                 return -1;
         }
 
-        /* State Vector must not be NULL */
-        sv = instance->sv;
-        if (!sv) {
-                LOG_ERR("Bogus DTP-SV passed, bailing out");
+        efcp = dt_efcp(dt);
+        if (!efcp) {
+                LOG_ERR("Bogus EFCP passed, bailing out");
                 sdu_destroy(sdu);
                 return -1;
         }
 
-        if (!sv->connection) {
-                LOG_ERR("Bogus SV connection passed, bailing out");
+        /* State Vector must not be NULL */
+        sv = instance->sv;
+        if (!sv) {
+                LOG_ERR("Bogus DTP-SV passed, bailing out");
                 sdu_destroy(sdu);
                 return -1;
         }
@@ -1135,12 +1131,12 @@ int dtp_write(struct dtp * instance,
 
         csn = nxt_seq_get(sv);
         if (pci_format(pci,
-                       efcp_src_cep_id(dtp->efcp),
-                       efcp_dst_cep_id(dtp->efcp),
-                       efcp_src_addr(dtp->efcp),
-                       efcp_dst_addr(dtp->efcp),
+                       efcp_src_cep_id(efcp),
+                       efcp_dst_cep_id(efcp),
+                       efcp_src_addr(efcp),
+                       efcp_dst_addr(efcp),
                        csn,
-                       efcp_qos_id(dtp->efcp),
+                       efcp_qos_id(efcp),
                        PDU_TYPE_DT)) {
                 pci_destroy(pci);
                 sdu_destroy(sdu);
@@ -1304,9 +1300,8 @@ int dtp_receive(struct dtp * instance,
         }
 
         if (!instance                  ||
-            !instance->efcp            ||
-            !instance->sv              ||
-            !instance->sv->connection) {
+            !instance->parent          ||
+            !instance->sv) {
                 LOG_ERR("Bogus instance passed, bailing out");
                 pdu_destroy(pdu);
                 return -1;

--- a/linux/net/rina/dtp.h
+++ b/linux/net/rina/dtp.h
@@ -32,9 +32,7 @@
 
 struct dtp * dtp_create(struct dt *         dt,
                         struct rmt *        rmt,
-                        struct efcp *       efcp,
-                        const string_t *    dtp_ps_name,
-                        struct connection * connection);
+                        struct dtp_config * dtp_cfg);
 int          dtp_destroy(struct dtp * instance);
 
 int          dtp_sv_init(struct dtp * dtp,

--- a/linux/net/rina/efcp.c
+++ b/linux/net/rina/efcp.c
@@ -699,7 +699,7 @@ cep_id_t efcp_connection_create(struct efcp_container * container,
 
         connection = connection_create();
         if (!connection)
-                return -1;
+                return cep_id_bad();
 
         ASSERT(dtp_cfg);
 
@@ -707,8 +707,8 @@ cep_id_t efcp_connection_create(struct efcp_container * container,
         connection_src_addr_set(connection, src_addr);
         connection_port_id_set(connection, port_id);
         connection_qos_id_set(connection, qos_id);
-        connection_src_cep_id_set(connection, cep_id_bad()); /* init value */
-        connection_dst_cep_id_set(connection, cep_id_bad()); /* init velue */
+        connection_src_cep_id_set(connection, src_cep_id);
+        connection_dst_cep_id_set(connection, dst_cep_id);
 
         tmp = efcp_create();
         if (!tmp) {

--- a/linux/net/rina/efcp.c
+++ b/linux/net/rina/efcp.c
@@ -859,7 +859,7 @@ cep_id_t efcp_connection_create(struct efcp_container * container,
 
         spin_lock_irqsave(&container->lock, flags);
         if (efcp_imap_add(container->instances,
-                          connection_src_cep_id(connection),
+                          cep_id,
                           tmp)) {
                 spin_unlock_irqrestore(&container->lock, flags);
                 LOG_ERR("Cannot add a new instance into container %pK",

--- a/linux/net/rina/efcp.h
+++ b/linux/net/rina/efcp.h
@@ -53,7 +53,8 @@ cep_id_t                efcp_connection_create(struct efcp_container * container
                                                qos_id_t                qos_id,
                                                cep_id_t                src_cep_id,
                                                cep_id_t                dst_cep_id,
-                                               struct conn_policies *  cp_params);
+                                               struct dtp_config *     dtp_cfg,
+                                               struct dtcp_config *    dtcp_cfg);
 int                     efcp_connection_destroy(struct efcp_container * cont,
                                                 cep_id_t                id);
 int                     efcp_connection_update(struct efcp_container * cont,
@@ -84,6 +85,7 @@ cep_id_t                efcp_dst_cep_id(struct efcp * efcp);
 address_t               efcp_src_addr(struct efcp * efcp);
 address_t               efcp_dst_addr(struct efcp * efcp);
 qos_id_t                efcp_qos_id(struct efcp * efcp);
+port_id_t               efcp_port_id(struct efcp * efcp);
 
 int efcp_container_select_policy_set(struct efcp_container * container,
                                      const string_t * path,

--- a/linux/net/rina/efcp.h
+++ b/linux/net/rina/efcp.h
@@ -45,9 +45,15 @@ int                     efcp_container_receive(struct efcp_container * c,
                                                struct pdu *            pdu);
 
 /* FIXME: Rename efcp_connection_*() as efcp_*() */
-cep_id_t                efcp_connection_create(struct efcp_container * cont,
+cep_id_t                efcp_connection_create(struct efcp_container * container,
                                                struct ipcp_instance *  user_ipcp,
-                                               struct connection     * conn);
+                                               address_t               src_addr,
+                                               address_t               dst_addr,
+                                               port_id_t               port_id,
+                                               qos_id_t                qos_id,
+                                               cep_id_t                src_cep_id,
+                                               cep_id_t                dst_cep_id,
+                                               struct conn_policies *  cp_params);
 int                     efcp_connection_destroy(struct efcp_container * cont,
                                                 cep_id_t                id);
 int                     efcp_connection_update(struct efcp_container * cont,
@@ -72,6 +78,12 @@ int                     efcp_enqueue(struct efcp * efcp,
                                      struct sdu *  sdu);
 int                     efcp_enable_write(struct efcp * efcp);
 int                     efcp_disable_write(struct efcp * efcp);
+
+cep_id_t                efcp_src_cep_id(struct efcp * efcp);
+cep_id_t                efcp_dst_cep_id(struct efcp * efcp);
+address_t               efcp_src_addr(struct efcp * efcp);
+address_t               efcp_dst_addr(struct efcp * efcp);
+qos_id_t                efcp_qos_id(struct efcp * efcp);
 
 int efcp_container_select_policy_set(struct efcp_container * container,
                                      const string_t * path,

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -27,6 +27,9 @@
 #include "du.h"
 #include "connection.h"
 
+struct dtp_config;
+struct dtcp_config;
+
 struct ipcp_instance;
 
 enum ipcp_config_type {
@@ -215,7 +218,8 @@ struct ipcp_instance_ops {
                                        address_t                   source,
                                        address_t                   dest,
                                        qos_id_t                    qos_id,
-                                       struct conn_policies *      cp_params);
+                                       struct dtp_config *         dtp_config,
+                                       struct dtcp_config *        dtcp_config);
 
         int      (* connection_update)(struct ipcp_instance_data * data,
                                        struct ipcp_instance *      user_ipcp,
@@ -234,7 +238,8 @@ struct ipcp_instance_ops {
                                       address_t                   dest,
                                       qos_id_t                    qos_id,
                                       cep_id_t                    dst_cep_id,
-                                      struct conn_policies *      cp_params);
+                                      struct dtp_config *         dtp_config,
+                                      struct dtcp_config *        dtcp_config);
 
         int      (* flow_prebind)(struct ipcp_instance_data * data,
                                   struct ipcp_instance *      user_ipcp,

--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -25,7 +25,6 @@
 #include <linux/kobject.h>
 
 #include "du.h"
-#include "connection.h"
 
 struct dtp_config;
 struct dtcp_config;

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -228,7 +228,8 @@ cep_id_t connection_create_request(struct ipcp_instance_data * data,
                                    address_t                   source,
                                    address_t                   dest,
                                    qos_id_t                    qos_id,
-                                   struct conn_policies *      cp_params)
+                                   struct dtp_config *         dtp_cfg,
+                                   struct dtcp_config *        dtcp_cfg)
 {
         cep_id_t               cep_id;
         struct normal_flow *   flow;
@@ -236,7 +237,8 @@ cep_id_t connection_create_request(struct ipcp_instance_data * data,
 
         cep_id = efcp_connection_create(data->efcpc, NULL, source, dest,
                                         port_id, qos_id,
-                                        cep_id_bad(), cep_id_bad(), cp_params);
+                                        cep_id_bad(), cep_id_bad(),
+                                        dtp_cfg, dtcp_cfg);
         if (!is_cep_id_ok(cep_id)) {
                 LOG_ERR("Failed EFCP connection creation");
                 return cep_id_bad();
@@ -442,7 +444,8 @@ connection_create_arrived(struct ipcp_instance_data * data,
                           address_t                   dest,
                           qos_id_t                    qos_id,
                           cep_id_t                    dst_cep_id,
-                          struct conn_policies *      cp_params)
+                          struct dtp_config *         dtp_cfg,
+                          struct dtcp_config *        dtcp_cfg)
 {
         cep_id_t               cep_id;
         struct normal_flow *   flow;
@@ -454,7 +457,8 @@ connection_create_arrived(struct ipcp_instance_data * data,
 
         cep_id = efcp_connection_create(data->efcpc, user_ipcp, source, dest,
                                         port_id, qos_id,
-                                        cep_id_bad(), dst_cep_id, cp_params);
+                                        cep_id_bad(), dst_cep_id,
+                                        dtp_cfg, dtcp_cfg);
         if (!is_cep_id_ok(cep_id)) {
                 LOG_ERR("Failed EFCP connection creation");
                 return cep_id_bad();

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -40,7 +40,6 @@
 #include "efcp.h"
 #include "rmt.h"
 #include "efcp-utils.h"
-#include "connection.h"
 
 /*  FIXME: To be removed ABSOLUTELY */
 extern struct kipcm * default_kipcm;

--- a/linux/net/rina/kipcm.c
+++ b/linux/net/rina/kipcm.c
@@ -760,16 +760,18 @@ static int notify_ipcp_conn_create_req(void *             data,
         if (!ipcp)
                 goto fail;
 
-        /* IPCP takes ownership of the cp_params */
+        /* IPCP takes ownership of the dtp and dtcp cfg params */
         src_cep = ipcp->ops->connection_create(ipcp->data,
                                                attrs->port_id,
                                                attrs->src_addr,
                                                attrs->dst_addr,
                                                attrs->qos_id,
-                                               attrs->cp_params);
+                                               attrs->dtp_cfg,
+                                               attrs->dtcp_cfg);
 
         /* The ownership has been passed to connection_create. */
-        attrs->cp_params = NULL;
+        attrs->dtp_cfg = NULL;
+        attrs->dtcp_cfg = NULL;
 
         if (!is_cep_id_ok(src_cep)) {
                 LOG_ERR("IPC process could not create connection");
@@ -882,10 +884,12 @@ static int notify_ipcp_conn_create_arrived(void *             data,
                                                        attrs->dst_addr,
                                                        attrs->qos_id,
                                                        attrs->dst_cep,
-                                                       attrs->cp_params);
+                                                       attrs->dtp_cfg,
+                                                       attrs->dtcp_cfg);
 
         /* The ownership has been passed to connection_create_arrived. */
-        attrs->cp_params = NULL;
+        attrs->dtp_cfg = NULL;
+        attrs->dtcp_cfg = NULL;
 
         if (!is_cep_id_ok(src_cep)) {
                 LOG_ERR("IPC process could not create connection");

--- a/linux/net/rina/rnl-utils.c
+++ b/linux/net/rina/rnl-utils.c
@@ -33,7 +33,8 @@
 #include "utils.h"
 #include "rnl.h"
 #include "rnl-utils.h"
-#include "dtcp-utils.h"
+#include "dtp-conf-utils.h"
+#include "dtcp-conf-utils.h"
 #include "policies.h"
 
 /*

--- a/linux/net/rina/rnl-utils.c
+++ b/linux/net/rina/rnl-utils.c
@@ -212,8 +212,15 @@ rnl_ipcp_conn_create_req_msg_attrs_create(void)
         if  (!tmp)
                 return NULL;
 
-        tmp->cp_params = conn_policies_create();
-        if (!tmp->cp_params) {
+        tmp->dtp_cfg = dtp_config_create();
+        if (!tmp->dtp_cfg) {
+                rkfree(tmp);
+                return NULL;
+        }
+
+        tmp->dtcp_cfg = dtcp_config_create();
+        if (!tmp->dtcp_cfg) {
+                dtp_config_destroy(tmp->dtp_cfg);
                 rkfree(tmp);
                 return NULL;
         }
@@ -230,8 +237,15 @@ rnl_ipcp_conn_create_arrived_msg_attrs_create(void)
         if  (!tmp)
                 return NULL;
 
-        tmp->cp_params = conn_policies_create();
-        if (!tmp->cp_params) {
+        tmp->dtp_cfg = dtp_config_create();
+        if (!tmp->dtp_cfg) {
+                rkfree(tmp);
+                return NULL;
+        }
+
+        tmp->dtcp_cfg = dtcp_config_create();
+        if (!tmp->dtcp_cfg) {
+                dtp_config_destroy(tmp->dtp_cfg);
                 rkfree(tmp);
                 return NULL;
         }
@@ -549,10 +563,16 @@ rnl_ipcp_conn_create_req_msg_attrs_destroy(struct rnl_ipcp_conn_create_req_msg_a
         if (!attrs)
                 return -1;
 
-        if (attrs->cp_params) {
-                conn_policies_destroy(attrs->cp_params);
+        if (attrs->dtp_cfg) {
+                dtp_config_destroy(attrs->dtp_cfg);
                 /* FIXME: The following workaround must be removed */
-                attrs->cp_params = NULL;
+                attrs->dtp_cfg = NULL;
+        }
+
+        if (attrs->dtcp_cfg) {
+                dtcp_config_destroy(attrs->dtcp_cfg);
+                /* FIXME: The following workaround must be removed */
+                attrs->dtcp_cfg = NULL;
         }
 
         rkfree(attrs);
@@ -564,11 +584,16 @@ rnl_ipcp_conn_create_arrived_msg_attrs_destroy(struct rnl_ipcp_conn_create_arriv
 {
         if (!attrs)
                 return -1;
-
-        if (attrs->cp_params) {
-                conn_policies_destroy(attrs->cp_params);
+        if (attrs->dtp_cfg) {
+                dtp_config_destroy(attrs->dtp_cfg);
                 /* FIXME: The following workaround must be removed */
-                attrs->cp_params = NULL;
+                attrs->dtp_cfg = NULL;
+        }
+
+        if (attrs->dtcp_cfg) {
+                dtcp_config_destroy(attrs->dtcp_cfg);
+                /* FIXME: The following workaround must be removed */
+                attrs->dtcp_cfg = NULL;
         }
 
         rkfree(attrs);
@@ -2134,95 +2159,93 @@ static int parse_dtcp_config(struct nlattr * attr, struct dtcp_config * cfg)
         return 0;
 }
 
-static int parse_conn_policies_params(struct nlattr *        cpp_attr,
-                                      struct conn_policies * cpp_struct)
+static int parse_dtp_config(struct nlattr *     attr,
+                            struct dtp_config * cfg)
 {
-        struct nla_policy attr_policy[CPP_ATTR_MAX + 1];
-        struct nlattr * attrs[CPP_ATTR_MAX + 1];
+        struct nla_policy attr_policy[DTPCA_ATTR_MAX + 1];
+        struct nlattr * attrs[DTPCA_ATTR_MAX + 1];
 
-        attr_policy[CPP_ATTR_DTCP_PRESENT].type           = NLA_FLAG;
-        attr_policy[CPP_ATTR_DTCP_PRESENT].len            = 0;
-        attr_policy[CPP_ATTR_DTCP_CONFIG].type            = NLA_NESTED;
-        attr_policy[CPP_ATTR_DTCP_CONFIG].len             = 0;
-        attr_policy[CPP_ATTR_DTP_POLICY_SET].type         = NLA_NESTED;
-        attr_policy[CPP_ATTR_DTP_POLICY_SET].len          = 0;
-        attr_policy[CPP_ATTR_RCVR_TIMER_INAC_POLICY].type = NLA_NESTED;
-        attr_policy[CPP_ATTR_RCVR_TIMER_INAC_POLICY].len  = 0;
-        attr_policy[CPP_ATTR_SNDR_TIMER_INAC_POLICY].type = NLA_NESTED;
-        attr_policy[CPP_ATTR_SNDR_TIMER_INAC_POLICY].len  = 0;
-        attr_policy[CPP_ATTR_INIT_SEQ_NUM_POLICY].type    = NLA_NESTED;
-        attr_policy[CPP_ATTR_INIT_SEQ_NUM_POLICY].len     = 0;
-        attr_policy[CPP_ATTR_SEQ_NUM_ROLLOVER].type       = NLA_U32;
-        attr_policy[CPP_ATTR_SEQ_NUM_ROLLOVER].len        = 4;
-        attr_policy[CPP_ATTR_INIT_A_TIMER].type           = NLA_U32;
-        attr_policy[CPP_ATTR_INIT_A_TIMER].len            = 4;
-        attr_policy[CPP_ATTR_PARTIAL_DELIVERY].type       = NLA_FLAG;
-        attr_policy[CPP_ATTR_PARTIAL_DELIVERY].len        = 0;
-        attr_policy[CPP_ATTR_INCOMPLETE_DELIVERY].type    = NLA_FLAG;
-        attr_policy[CPP_ATTR_INCOMPLETE_DELIVERY].len     = 0;
-        attr_policy[CPP_ATTR_IN_ORDER_DELIVERY].type      = NLA_FLAG;
-        attr_policy[CPP_ATTR_IN_ORDER_DELIVERY].len       = 0;
-        attr_policy[CPP_ATTR_MAX_SDU_GAP].type            = NLA_U32;
-        attr_policy[CPP_ATTR_MAX_SDU_GAP].len             = 4;
+        attr_policy[DTPCA_ATTR_DTCP_PRESENT].type           = NLA_FLAG;
+        attr_policy[DTPCA_ATTR_DTCP_PRESENT].len            = 0;
+        attr_policy[DTPCA_ATTR_RCVR_TIMER_INAC_POLICY].type = NLA_NESTED;
+        attr_policy[DTPCA_ATTR_RCVR_TIMER_INAC_POLICY].len  = 0;
+        attr_policy[DTPCA_ATTR_SNDR_TIMER_INAC_POLICY].type = NLA_NESTED;
+        attr_policy[DTPCA_ATTR_SNDR_TIMER_INAC_POLICY].len  = 0;
+        attr_policy[DTPCA_ATTR_INIT_SEQ_NUM_POLICY].type    = NLA_NESTED;
+        attr_policy[DTPCA_ATTR_INIT_SEQ_NUM_POLICY].len     = 0;
+        attr_policy[DTPCA_ATTR_SEQ_NUM_ROLLOVER].type       = NLA_U32;
+        attr_policy[DTPCA_ATTR_SEQ_NUM_ROLLOVER].len        = 4;
+        attr_policy[DTPCA_ATTR_INIT_A_TIMER].type           = NLA_U32;
+        attr_policy[DTPCA_ATTR_INIT_A_TIMER].len            = 4;
+        attr_policy[DTPCA_ATTR_PARTIAL_DELIVERY].type       = NLA_FLAG;
+        attr_policy[DTPCA_ATTR_PARTIAL_DELIVERY].len        = 0;
+        attr_policy[DTPCA_ATTR_INCOMPLETE_DELIVERY].type    = NLA_FLAG;
+        attr_policy[DTPCA_ATTR_INCOMPLETE_DELIVERY].len     = 0;
+        attr_policy[DTPCA_ATTR_IN_ORDER_DELIVERY].type      = NLA_FLAG;
+        attr_policy[DTPCA_ATTR_IN_ORDER_DELIVERY].len       = 0;
+        attr_policy[DTPCA_ATTR_MAX_SDU_GAP].type            = NLA_U32;
+        attr_policy[DTPCA_ATTR_MAX_SDU_GAP].len             = 4;
+        attr_policy[DTPCA_ATTR_DTP_POLICY_SET].type         = NLA_NESTED;
+        attr_policy[DTPCA_ATTR_DTP_POLICY_SET].len          = 0;
 
         if (nla_parse_nested(attrs,
-                             CPP_ATTR_MAX,
-                             cpp_attr, attr_policy) < 0)
+                             DTPCA_ATTR_MAX,
+                             attr, attr_policy) < 0)
                 return -1;
 
-        cpp_struct->dtcp_present = nla_get_flag(attrs[CPP_ATTR_DTCP_PRESENT]);
+        if (attrs[DTPCA_ATTR_DTCP_PRESENT])
+                dtp_conf_dtcp_present_set(cfg,
+                        nla_get_flag(attrs[DTPCA_ATTR_DTCP_PRESENT]));
 
-        if (attrs[CPP_ATTR_DTCP_CONFIG])
-                if (parse_dtcp_config(attrs[CPP_ATTR_DTCP_CONFIG],
-                                      cpp_struct->dtcp_cfg)) {
-                        LOG_ERR("Could not parse dtcp config");
-                        return -1;
-                }
 
-        if (attrs[CPP_ATTR_DTP_POLICY_SET]) {
-                if (parse_policy(attrs[CPP_ATTR_DTP_POLICY_SET],
-                                 cpp_struct->dtp_ps))
-                        return -1;
-        }
-
-        if (attrs[CPP_ATTR_RCVR_TIMER_INAC_POLICY])
-                if (parse_policy(attrs[CPP_ATTR_RCVR_TIMER_INAC_POLICY],
-                                 cpp_struct->receiver_inactivity_timer))
+        if (attrs[DTPCA_ATTR_RCVR_TIMER_INAC_POLICY])
+                if (parse_policy(attrs[DTPCA_ATTR_RCVR_TIMER_INAC_POLICY],
+                                 dtp_conf_receiver_inactivity_timer(cfg)))
                         return -1;
 
-        if (attrs[CPP_ATTR_SNDR_TIMER_INAC_POLICY])
-                if (parse_policy(attrs[CPP_ATTR_SNDR_TIMER_INAC_POLICY],
-                                 cpp_struct->sender_inactivity_timer))
+        if (attrs[DTPCA_ATTR_SNDR_TIMER_INAC_POLICY])
+                if (parse_policy(attrs[DTPCA_ATTR_SNDR_TIMER_INAC_POLICY],
+                                 dtp_conf_sender_inactivity_timer(cfg)))
                         return -1;
 
-        if (attrs[CPP_ATTR_INIT_SEQ_NUM_POLICY]) {
-                if (parse_policy(attrs[CPP_ATTR_INIT_SEQ_NUM_POLICY],
-                                 cpp_struct->initial_sequence_number)) {
+        if (attrs[DTPCA_ATTR_INIT_SEQ_NUM_POLICY]) {
+                if (parse_policy(attrs[DTPCA_ATTR_INIT_SEQ_NUM_POLICY],
+                                 dtp_conf_initial_sequence_number(cfg))) {
                         LOG_ERR("Could not parse initial_sequence_number "
                                 "policy");
                         return -1;
                 }
         }
 
-        if (attrs[CPP_ATTR_SEQ_NUM_ROLLOVER])
-                cpp_struct->seq_num_ro_th =
-                        nla_get_u32(attrs[CPP_ATTR_SEQ_NUM_ROLLOVER]);
+        if (attrs[DTPCA_ATTR_SEQ_NUM_ROLLOVER])
+                dtp_conf_seq_num_ro_th_set(cfg,
+                        nla_get_u32(attrs[DTPCA_ATTR_SEQ_NUM_ROLLOVER]));
 
-        if (attrs[CPP_ATTR_INIT_A_TIMER])
-                cpp_struct->initial_a_timer =
-                        nla_get_u32(attrs[CPP_ATTR_INIT_A_TIMER]);
+        if (attrs[DTPCA_ATTR_INIT_A_TIMER])
+                dtp_conf_initial_a_timer_set(cfg,
+                        nla_get_u32(attrs[DTPCA_ATTR_INIT_A_TIMER]));
 
-        cpp_struct->partial_delivery    =
-                nla_get_flag(attrs[CPP_ATTR_PARTIAL_DELIVERY]);
-        cpp_struct->incomplete_delivery =
-                nla_get_flag(attrs[CPP_ATTR_INCOMPLETE_DELIVERY]);
-        cpp_struct->in_order_delivery   =
-                nla_get_flag(attrs[CPP_ATTR_IN_ORDER_DELIVERY]);
+        if (attrs[DTPCA_ATTR_PARTIAL_DELIVERY])
+                dtp_conf_partial_del_set(cfg,
+                        nla_get_flag(attrs[DTPCA_ATTR_PARTIAL_DELIVERY]));
 
-        if (attrs[CPP_ATTR_MAX_SDU_GAP])
-                cpp_struct->max_sdu_gap =
-                        nla_get_u32(attrs[CPP_ATTR_MAX_SDU_GAP]);
+        if (attrs[DTPCA_ATTR_INCOMPLETE_DELIVERY])
+                dtp_conf_incomplete_del_set(cfg,
+                        nla_get_flag(attrs[DTPCA_ATTR_INCOMPLETE_DELIVERY]));
 
+        if (attrs[DTPCA_ATTR_IN_ORDER_DELIVERY])
+                dtp_conf_in_order_del_set(cfg,
+                        nla_get_flag(attrs[DTPCA_ATTR_IN_ORDER_DELIVERY]));
+
+        if (attrs[DTPCA_ATTR_MAX_SDU_GAP])
+                dtp_conf_max_sdu_gap_set(cfg,
+                        nla_get_u32(attrs[DTPCA_ATTR_MAX_SDU_GAP]));
+
+        if (attrs[DTPCA_ATTR_DTP_POLICY_SET]) {
+                if (parse_policy(attrs[DTPCA_ATTR_DTP_POLICY_SET],
+                                 dtp_conf_ps_get(cfg)))
+                        return -1;
+        }
         return 0;
 }
 
@@ -2383,10 +2406,19 @@ static int rnl_parse_ipcm_conn_create_req_msg(struct genl_info * info,
         if (info->attrs[ICCRQ_ATTR_QOS_ID])
                 msg_attrs->qos_id   =
                         nla_get_u32(info->attrs[ICCRQ_ATTR_QOS_ID]);
-        if (info->attrs[ICCRQ_ATTR_POLICIES_PARAMS]) {
-                if (parse_conn_policies_params(info->attrs
-                                               [ICCRQ_ATTR_POLICIES_PARAMS],
-                                               msg_attrs->cp_params)) {
+        if (info->attrs[ICCRQ_ATTR_DTP_CONFIG]) {
+                if (parse_dtp_config(info->attrs
+                                     [ICCRQ_ATTR_DTP_CONFIG],
+                                     msg_attrs->dtp_cfg)) {
+                        LOG_ERR(BUILD_STRERROR_BY_MTYPE("RINA_C_IPCM_CONNECTION"
+                                                        "_CREATE_REQUEST"));
+                        return -1;
+                }
+        }
+        if (info->attrs[ICCRQ_ATTR_DTCP_CONFIG]) {
+                if (parse_dtcp_config(info->attrs
+                                     [ICCRQ_ATTR_DTCP_CONFIG],
+                                     msg_attrs->dtcp_cfg)) {
                         LOG_ERR(BUILD_STRERROR_BY_MTYPE("RINA_C_IPCM_CONNECTION"
                                                         "_CREATE_REQUEST"));
                         return -1;
@@ -2418,12 +2450,21 @@ rnl_parse_ipcm_conn_create_arrived_msg(struct genl_info * info,
         if (info->attrs[ICCA_ATTR_FLOW_USER_IPCP_ID])
                 msg_attrs->flow_user_ipc_process_id =
                         nla_get_u16(info->attrs[ICCA_ATTR_FLOW_USER_IPCP_ID]);
-        if (info->attrs[ICCA_ATTR_POLICIES_PARAMS]) {
-                if (parse_conn_policies_params(info->attrs
-                                               [ICCA_ATTR_POLICIES_PARAMS],
-                                               msg_attrs->cp_params)) {
-                        LOG_ERR(BUILD_STRERROR_BY_MTYPE("RINA_C_IPCM_CONNECT"
-                                                        "ION_CREATE_ARRIVED"));
+        if (info->attrs[ICCA_ATTR_DTP_CONFIG]) {
+                if (parse_dtp_config(info->attrs
+                                     [ICCA_ATTR_DTP_CONFIG],
+                                     msg_attrs->dtp_cfg)) {
+                        LOG_ERR(BUILD_STRERROR_BY_MTYPE("RINA_C_IPCM_CONNECTION"
+                                                        "_CREATE_ARRIVED"));
+                        return -1;
+                }
+        }
+        if (info->attrs[ICCA_ATTR_DTCP_CONFIG]) {
+                if (parse_dtcp_config(info->attrs
+                                     [ICCA_ATTR_DTCP_CONFIG],
+                                     msg_attrs->dtcp_cfg)) {
+                        LOG_ERR(BUILD_STRERROR_BY_MTYPE("RINA_C_IPCM_CONNECTION"
+                                                        "_CREATE_ARRIVED"));
                         return -1;
                 }
         }

--- a/linux/net/rina/rnl-utils.h
+++ b/linux/net/rina/rnl-utils.h
@@ -156,7 +156,23 @@ enum dtcp_config_params_attrs_list {
 };
 #define DCA_ATTR_MAX (__DCA_ATTR_MAX - 1)
 
-enum conn_policies_params_attrs_list {
+enum dtp_config_params_attrs_list {
+        DTPCA_ATTR_DTCP_PRESENT = 1,
+        DTPCA_ATTR_RCVR_TIMER_INAC_POLICY,
+        DTPCA_ATTR_SNDR_TIMER_INAC_POLICY,
+        DTPCA_ATTR_INIT_SEQ_NUM_POLICY,
+        DTPCA_ATTR_SEQ_NUM_ROLLOVER,
+        DTPCA_ATTR_INIT_A_TIMER,
+        DTPCA_ATTR_PARTIAL_DELIVERY,
+        DTPCA_ATTR_INCOMPLETE_DELIVERY,
+        DTPCA_ATTR_IN_ORDER_DELIVERY,
+        DTPCA_ATTR_MAX_SDU_GAP,
+        DTPCA_ATTR_DTP_POLICY_SET,
+        __DTPCA_ATTR_MAX,
+};
+#define DTPCA_ATTR_MAX (__DTPCA_ATTR_MAX - 1)
+
+/*enum conn_policies_params_attrs_list {
         CPP_ATTR_DTCP_PRESENT = 1,
         CPP_ATTR_DTCP_CONFIG,
         CPP_ATTR_DTP_POLICY_SET,
@@ -171,7 +187,7 @@ enum conn_policies_params_attrs_list {
         CPP_ATTR_MAX_SDU_GAP,
         __CPP_ATTR_MAX,
 };
-#define CPP_ATTR_MAX (__CPP_ATTR_MAX - 1)
+*/
 
 /* FIXME: in user space these are called without _NAME */
 enum ipcm_alloc_flow_req_attrs_list {
@@ -249,7 +265,8 @@ enum ipcm_conn_create_req_attrs_list {
         ICCRQ_ATTR_SOURCE_ADDR,
         ICCRQ_ATTR_DEST_ADDR,
         ICCRQ_ATTR_QOS_ID,
-        ICCRQ_ATTR_POLICIES_PARAMS,
+        ICCRQ_ATTR_DTP_CONFIG,
+        ICCRQ_ATTR_DTCP_CONFIG,
         __ICCRQ_ATTR_MAX,
 };
 #define ICCRQ_ATTR_MAX (__ICCRQ_ATTR_MAX - 1)
@@ -268,7 +285,8 @@ enum ipcm_conn_create_arrived_attrs_list {
         ICCA_ATTR_DEST_CEP_ID,
         ICCA_ATTR_QOS_ID,
         ICCA_ATTR_FLOW_USER_IPCP_ID,
-        ICCA_ATTR_POLICIES_PARAMS,
+        ICCA_ATTR_DTP_CONFIG,
+        ICCA_ATTR_DTCP_CONFIG,
         __ICCA_ATTR_MAX,
 };
 #define ICCA_ATTR_MAX (__ICCA_ATTR_MAX - 1)
@@ -729,11 +747,12 @@ struct rnl_ipcm_flow_dealloc_noti_msg_attrs {
 
 /*  FIXME: policies should not be int */
 struct rnl_ipcp_conn_create_req_msg_attrs {
-        port_id_t              port_id;
-        address_t              src_addr;
-        address_t              dst_addr;
-        qos_id_t               qos_id;
-        struct conn_policies * cp_params;
+        port_id_t            port_id;
+        address_t            src_addr;
+        address_t            dst_addr;
+        qos_id_t             qos_id;
+        struct dtp_config *  dtp_cfg;
+        struct dtcp_config * dtcp_cfg;
 };
 
 struct rnl_ipcp_conn_create_resp_msg_attrs {
@@ -742,13 +761,14 @@ struct rnl_ipcp_conn_create_resp_msg_attrs {
 };
 
 struct rnl_ipcp_conn_create_arrived_msg_attrs {
-        port_id_t             port_id;
-        address_t             src_addr;
-        address_t             dst_addr;
-        cep_id_t              dst_cep;
-        qos_id_t              qos_id;
-        ipc_process_id_t      flow_user_ipc_process_id;
-        struct conn_policies * cp_params;
+        port_id_t            port_id;
+        address_t            src_addr;
+        address_t            dst_addr;
+        cep_id_t             dst_cep;
+        qos_id_t             qos_id;
+        ipc_process_id_t     flow_user_ipc_process_id;
+        struct dtp_config *  dtp_cfg;
+        struct dtcp_config * dtcp_cfg;
 };
 
 struct rnl_ipcp_conn_create_result_msg_attrs {

--- a/linux/net/rina/rnl.c
+++ b/linux/net/rina/rnl.c
@@ -202,11 +202,12 @@ static struct nla_policy ifdn_policy[IFDN_ATTR_MAX + 1] = {
 };
 
 static struct nla_policy iccrq_policy[ICCRQ_ATTR_MAX + 1] = {
-        [ICCRQ_ATTR_PORT_ID]         = NLA_INIT_U32,
-        [ICCRQ_ATTR_SOURCE_ADDR]     = NLA_INIT_U32,
-        [ICCRQ_ATTR_DEST_ADDR]       = NLA_INIT_U32,
-        [ICCRQ_ATTR_QOS_ID]          = NLA_INIT_U32,
-        [ICCRQ_ATTR_POLICIES_PARAMS] = NLA_INIT_NESTED,
+        [ICCRQ_ATTR_PORT_ID]     = NLA_INIT_U32,
+        [ICCRQ_ATTR_SOURCE_ADDR] = NLA_INIT_U32,
+        [ICCRQ_ATTR_DEST_ADDR]   = NLA_INIT_U32,
+        [ICCRQ_ATTR_QOS_ID]      = NLA_INIT_U32,
+        [ICCRQ_ATTR_DTP_CONFIG]  = NLA_INIT_NESTED,
+        [ICCRQ_ATTR_DTCP_CONFIG] = NLA_INIT_NESTED,
 };
 
 static struct nla_policy icca_policy[ICCA_ATTR_MAX + 1] = {
@@ -216,7 +217,8 @@ static struct nla_policy icca_policy[ICCA_ATTR_MAX + 1] = {
         [ICCA_ATTR_DEST_CEP_ID]       = NLA_INIT_U32,
         [ICCA_ATTR_QOS_ID]            = NLA_INIT_U32,
         [ICCA_ATTR_FLOW_USER_IPCP_ID] = NLA_INIT_U16,
-        [ICCA_ATTR_POLICIES_PARAMS]   = NLA_INIT_NESTED,
+        [ICCA_ATTR_DTP_CONFIG]        = NLA_INIT_NESTED,
+        [ICCA_ATTR_DTCP_CONFIG]       = NLA_INIT_NESTED,
 };
 
 static struct nla_policy icurq_policy[ICURQ_ATTR_MAX + 1] = {

--- a/rinad/src/common/encoder.h
+++ b/rinad/src/common/encoder.h
@@ -181,8 +181,8 @@ public:
 	static rina::DTCPFlowControlConfig* get_DTCPFlowControlConfig(const rina::messages::dtcpFlowControlConfig_t &gpf_conf);
 	static rina::messages::dtcpConfig_t* get_dtcpConfig_t(const rina::DTCPConfig &conf);
 	static rina::DTCPConfig* get_DTCPConfig(const rina::messages::dtcpConfig_t &gpf_conf);
-	static rina::messages::connectionPolicies_t* get_connectionPolicies_t(const rina::ConnectionPolicies &polc);
-	static rina::ConnectionPolicies* get_ConnectionPolicies(const rina::messages::connectionPolicies_t &gpf_polc);
+	static rina::messages::dtpConfig_t* get_dtpConfig_t(const rina::DTPConfig &conf);
+	static rina::DTPConfig* get_DTPConfig(const rina::messages::dtpConfig_t &gpf_conf);
 	static rina::Connection* get_Connection(const rina::messages::connectionId_t &gpf_conn);
 
 private:

--- a/rinad/src/common/encoders/ConnectionPoliciesMessage.proto
+++ b/rinad/src/common/encoders/ConnectionPoliciesMessage.proto
@@ -56,9 +56,8 @@ message dtcpConfig_t {  //configuration of DTCP for a connection
     optional policyDescriptor_t dtcppolicyset = 7;                 //it indicates the name of the policy set fot the dtcp
 }
 
-message connectionPolicies_t { //configuration of the policies and parameters of an EFCP connection
+message dtpConfig_t { //configuration of the policies and parameters of a DTP element
 	optional bool dtcpPresent = 1;                                 //indicates if this connection is using DTCP
-	optional dtcpConfig_t dtcpConfiguration = 2;                   //the DTCP Configuration for this connection
 	optional policyDescriptor_t rcvrtimerinactivitypolicy = 3;     //If no PDUs arrive in this time period, the receiver should expect a DRF in the next Transfer PDU
         optional policyDescriptor_t sendertimerinactiviypolicy = 4;    //This timer is used to detect long periods of no traffic, indicating that a DRF should be sent
 	optional policyDescriptor_t initialseqnumpolicy = 5;           //allows some discretion in selecting the initial sequence number, when DRF is going to be sent

--- a/rinad/src/common/encoders/FlowMessage.proto
+++ b/rinad/src/common/encoders/FlowMessage.proto
@@ -21,9 +21,10 @@ message Flow{  //Contains the information to setup a new flow
 	optional uint32 currentConnectionIdIndex = 8;							//Identifies the index of the current active connection in the flow
 	optional uint32 state = 9; 												//
 	optional qosSpecification_t qosParameters = 10; 			//the QoS parameters specified by the application process that requested this flow
-	optional connectionPolicies_t connectionPolicies = 11;                  //the configuration for the policies and parameters of this EFCP connection
-	optional bytes accessControl = 12; 										// ?
-	optional uint32 maxCreateFlowRetries = 13; 								//Maximum number of retries to create the flow before giving up
-	optional uint32 createFlowRetries = 14; 								//The current number of retries
-	optional uint32 hopCount = 15; 									        //While the search rules that generate the forwarding table should allow for a natural termination condition, it seems wise to have the means to enforce termination
+	optional dtpConfig_t dtpConfig = 12;                  //the configuration for the policies and parameters of this connection's DTP
+	optional dtcpConfig_t dtcpConfig = 13;                  //the configuration for the policies and parameters of this connection's DTCP
+	optional bytes accessControl = 14; 										// ?
+	optional uint32 maxCreateFlowRetries = 15; 								//Maximum number of retries to create the flow before giving up
+	optional uint32 createFlowRetries = 16; 								//The current number of retries
+	optional uint32 hopCount = 17; 									        //While the search rules that generate the forwarding table should allow for a natural termination condition, it seems wise to have the means to enforce termination
 }

--- a/rinad/src/common/encoders/QoSCubeMessage.proto
+++ b/rinad/src/common/encoders/QoSCubeMessage.proto
@@ -4,7 +4,7 @@ import "ConnectionPoliciesMessage.proto";
 
 message qosCube_t{									//a QoS cube specification
 	required uint32 qosId = 1;						//Identifies the QoS cube
-    optional string name = 2;                       // A human-readable name for the QoS cube
+        optional string name = 2;                       // A human-readable name for the QoS cube
 	optional uint64 averageBandwidth = 3;			//in bytes/s, a value of 0 indicates 'don't care'
 	optional uint64 averageSDUBandwidth = 4;		//in bytes/s, a value of 0 indicates 'don't care'
 	optional uint32 peakBandwidthDuration = 5;		//in ms, a value of 0 indicates 'don't care'
@@ -15,5 +15,6 @@ message qosCube_t{									//a QoS cube specification
 	optional uint32 maxAllowableGapSdu = 10;        //indicates the maximum gap allowed in SDUs, a gap of N SDUs is considered the same as all SDUs delivered. A value of -1 indicates 'Any'
 	optional uint32 delay = 11; 					//in milliseconds, indicates the maximum delay allowed in this flow. A value of 0 indicates don't care
 	optional uint32 jitter = 12;					//in milliseconds, indicates indicates the maximum jitter allowed in this flow. A value of 0 indicates don't care
-	optional connectionPolicies_t efcpPolicies = 13;                  //the common configuration policies and parameters for the EFCP connections belonging to this QoS cube
+        optional dtpConfig_t dtpConfiguration = 13;                   //the DTP Configuration for this connectio
+        optional dtcpConfig_t dtcpConfiguration = 14;                   //the DTCP Configuration for this connectio
 }

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -238,81 +238,81 @@ void parse_rtx_flow_ctrl(const Json::Value  root,
 void parse_efcp_policies(const Json::Value  root,
                          rina::QoSCube    & cube)
 {
-        Json::Value con_pol = root["efcpPolicies"];
-        if (con_pol != 0) {
-                rina::ConnectionPolicies cp;
+        Json::Value efcp_conf = root["efcpPolicies"];
+        if (efcp_conf != 0) {
+                rina::DTPConfig dtpc;
 
-                cp.dtcp_present_ = con_pol.get("dtcpPresent",
-                                               cp.dtcp_present_).asBool();
+                dtpc.dtcp_present_ = efcp_conf.get("dtcpPresent",
+                                               dtpc.dtcp_present_).asBool();
 
-                parse_policy(con_pol,
+                parse_policy(efcp_conf,
                              "dtpPolicySet",
-                             cp.dtp_policy_set_);
+                             dtpc.dtp_policy_set_);
 
                 // DTCPConfig
-                Json::Value dtcp_conf = con_pol["dtcpConfiguration"];
+                Json::Value dtcp_conf = efcp_conf["dtcpConfiguration"];
                 if (dtcp_conf != 0) {
-                        rina::DTCPConfig dc;
+                        rina::DTCPConfig dtpcc;
 
-                        dc.flow_control_ =
+                        dtpcc.flow_control_ =
                                 dtcp_conf.get("flowControl",
-                                              dc.flow_control_).asBool();
+                                              dtpcc.flow_control_).asBool();
                         // flow_control_config_
-                        parse_flow_ctrl(dtcp_conf, dc);
+                        parse_flow_ctrl(dtcp_conf, dtpcc);
 
-                        dc.rtx_control_ =
+                        dtpcc.rtx_control_ =
                                 dtcp_conf.get("rtxControl",
-                                              dc.rtx_control_).asBool();
+                                              dtpcc.rtx_control_).asBool();
 
                         // rtx_control_config_
-                        parse_rtx_flow_ctrl(dtcp_conf, dc);
+                        parse_rtx_flow_ctrl(dtcp_conf, dtpcc);
 
                         parse_policy(dtcp_conf,
                                      "dtcpPolicySet",
-                                     dc.dtcp_policy_set_);
+                                     dtpcc.dtcp_policy_set_);
 
                         parse_policy(dtcp_conf,
                                      "lostControlPduPolicy",
-                                     dc.lost_control_pdu_policy_);
+                                     dtpcc.lost_control_pdu_policy_);
 
                         parse_policy(dtcp_conf,
                                      "rttEstimatorPolicy",
-                                     dc.rtt_estimator_policy_);
+                                     dtpcc.rtt_estimator_policy_);
 
-                        cp.dtcp_configuration_ = dc;
+                        cube.dtcp_config_ = dtpcc;
                 }
 
-                parse_policy(dtcp_conf,
+                parse_policy(efcp_conf,
                              "rcvrTimerInactivityPolicy",
-                             cp.rcvr_timer_inactivity_policy_);
+                             dtpc.rcvr_timer_inactivity_policy_);
 
-                parse_policy(dtcp_conf,
+                parse_policy(efcp_conf,
                              "senderTimerInactivityPolicy",
-                             cp.sender_timer_inactivity_policy_);
+                             dtpc.sender_timer_inactivity_policy_);
 
-                parse_policy(con_pol,
+                parse_policy(efcp_conf,
                              "initialSeqNumPolicy",
-                             cp.initial_seq_num_policy_);
+                             dtpc.initial_seq_num_policy_);
 
-                cp.seq_num_rollover_threshold_ =
-                        con_pol.get("seqNumRolloverThreshold",
-                                    cp.seq_num_rollover_threshold_).asUInt();
-                cp.initial_a_timer_ =
-                        con_pol.get("initialATimer",
-                                    cp.initial_a_timer_).asUInt();
-                cp.partial_delivery_ =
-                        con_pol.get("partialDelivery",
-                                    cp.partial_delivery_).asBool();
-                cp.incomplete_delivery_ =
-                        con_pol.get("incompleteDelivery",
-                                    cp.incomplete_delivery_).asBool();
-                cp.in_order_delivery_ =
-                        con_pol.get("inOrderDelivery",
-                                    cp.in_order_delivery_).asBool();
-                cp.max_sdu_gap_ =
-                        con_pol.get("maxSduGap", cp.max_sdu_gap_).asInt();
+                dtpc.seq_num_rollover_threshold_ =
+                        efcp_conf.get("seqNumRolloverThreshold",
+                                    dtpc.seq_num_rollover_threshold_).asUInt();
+                dtpc.initial_a_timer_ =
+                        efcp_conf.get("initialATimer",
+                                    dtpc.initial_a_timer_).asUInt();
+                dtpc.partial_delivery_ =
+                        efcp_conf.get("partialDelivery",
+                                    dtpc.partial_delivery_).asBool();
+                dtpc.incomplete_delivery_ =
+                        efcp_conf.get("incompleteDelivery",
+                                    dtpc.incomplete_delivery_).asBool();
+                dtpc.in_order_delivery_ =
+                        efcp_conf.get("inOrderDelivery",
+                                    dtpc.in_order_delivery_).asBool();
+                dtpc.max_sdu_gap_ =
+                        efcp_conf.get("maxSduGap", dtpc.max_sdu_gap_).asInt();
 
-                cube.efcp_policies_ = cp;
+                cube.dtp_config_ = dtpc;
         }
 }
 

--- a/rinad/src/ipcp/flow-allocator.cc
+++ b/rinad/src/ipcp/flow-allocator.cc
@@ -126,8 +126,10 @@ std::string QoSCubeRIBObject::get_displayable_value()
 		<< cube->peak_bandwidth_duration_;
 	ss << "; Peak SDU bandwidth duration (ms): "
 		<< cube->peak_sdu_bandwidth_duration_ << std::endl;
-	rina::ConnectionPolicies con = cube->efcp_policies_;
-	ss << "EFCP policies: " << con.toString();
+	rina::DTPConfig dtp_conf = cube->dtp_config_;
+	ss << "DTP Configuration: " << dtp_conf.toString();
+	rina::DTCPConfig dtcp_conf = cube->dtcp_config_;
+	ss << "DTCP Configuration: " << dtcp_conf.toString();
 	return ss.str();
 }
 
@@ -1359,10 +1361,14 @@ const rina::SerializedObject* FlowEncoder::encode(const void* object)
 	//qosParameters
 	gpf_flow.set_allocated_qosparameters(
 			Encoder::get_qosSpecification_t(flow->flow_specification));
-	//optional connectionPolicies_t connectionPolicies
-	gpf_flow.set_allocated_connectionpolicies(
-			Encoder::get_connectionPolicies_t(
-				flow->getActiveConnection()->getPolicies()));
+	//optional dtpConfig_t dtpConfig
+	gpf_flow.set_allocated_dtpconfig(
+			Encoder::get_dtpConfig_t(
+				flow->getActiveConnection()->getDTPConfig()));
+	//optional dtpConfig_t dtpConfig
+	gpf_flow.set_allocated_dtcpconfig(
+			Encoder::get_dtcpConfig_t(
+				flow->getActiveConnection()->getDTCPConfig()));
 	//accessControl
 	if (flow->access_control != 0)
 		gpf_flow.set_accesscontrol(flow->access_control);
@@ -1430,11 +1436,17 @@ void* FlowEncoder::decode(
 	delete fs;
 	fs = 0;
 
-	rina::ConnectionPolicies *conn_polc =
-		Encoder::get_ConnectionPolicies(gpf_flow.connectionpolicies());
-	flow->getActiveConnection()->setPolicies(*conn_polc);
-	delete conn_polc;
-	conn_polc = 0;
+	rina::DTPConfig *dtp_config =
+		Encoder::get_DTPConfig(gpf_flow.dtpconfig());
+	flow->getActiveConnection()->setDTPConfig(*dtp_config);
+	delete dtp_config;
+	dtp_config = 0;
+
+	rina::DTCPConfig *dtcp_config =
+		Encoder::get_DTCPConfig(gpf_flow.dtcpconfig());
+	flow->getActiveConnection()->setDTCPConfig(*dtcp_config);
+	delete dtcp_config;
+	dtcp_config = 0;
 
 	flow->access_control = const_cast<char*>(gpf_flow.accesscontrol()
 			.c_str());

--- a/rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
+++ b/rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
@@ -76,16 +76,16 @@ Flow * FlowAllocatorPs::newFlowRequest(IPCProcess * ipc_process,
 	connection->sourceAddress = ipc_process->get_address();
 	connection->setQosId(1);
 	connection->setFlowUserIpcProcessId(event.flowRequestorIpcProcessId);
-	rina::ConnectionPolicies connectionPolicies = rina::ConnectionPolicies(
-			qosCube->get_efcp_policies());
-	connectionPolicies.set_in_order_delivery(qosCube->is_ordered_delivery());
-	connectionPolicies.set_partial_delivery(qosCube->is_partial_delivery());
+        rina::DTPConfig dtpConfig = rina::DTPConfig(
+                        qosCube->get_dtp_config());
 	if (event.flowSpecification.maxAllowableGap < 0) {
-		connectionPolicies.set_max_sdu_gap(INT_MAX);
+		dtpConfig.set_max_sdu_gap(INT_MAX);
 	} else {
-		connectionPolicies.set_max_sdu_gap(qosCube->get_max_allowable_gap());
+		dtpConfig.set_max_sdu_gap(qosCube->get_max_allowable_gap());
 	}
-	connection->setPolicies(connectionPolicies);
+        rina::DTCPConfig dtcpConfig = rina::DTCPConfig(
+                        qosCube->get_dtcp_config());
+	connection->setDTCPConfig(dtcpConfig);
 	connections.push_back(connection);
 
 	flow->connections = connections;
@@ -108,13 +108,13 @@ rina::QoSCube * FlowAllocatorPs::selectQoSCube(
 	if (flowSpec.maxAllowableGap < 0) {
 	        for (iterator = qosCubes.begin(); iterator != qosCubes.end(); ++iterator) {
 		        cube = *iterator;
-		        if (cube->get_efcp_policies().is_dtcp_present()
-			    && !cube->get_efcp_policies().get_dtcp_configuration().is_rtx_control())
+		        if (cube->get_dtp_config().is_dtcp_present()
+			    && !cube->get_dtcp_config().is_rtx_control())
 			        return cube;
 		}
 		for (iterator = qosCubes.begin(); iterator != qosCubes.end(); ++iterator) {
 		        cube = *iterator;
-		        if (!cube->get_efcp_policies().is_dtcp_present()) {
+		        if (!cube->get_dtp_config().is_dtcp_present()) {
 				return cube;
 			}
 		}
@@ -123,8 +123,8 @@ rina::QoSCube * FlowAllocatorPs::selectQoSCube(
         //flowSpec.maxAllowableGap >=0
 	for (iterator = qosCubes.begin(); iterator != qosCubes.end(); ++iterator) {
 		cube = *iterator;
-		if (cube->get_efcp_policies().is_dtcp_present()) {
-			if (cube->get_efcp_policies().get_dtcp_configuration().is_rtx_control()) {
+		if (cube->get_dtp_config().is_dtcp_present()) {
+			if (cube->get_dtcp_config().is_rtx_control()) {
 				return cube;
 			}
 		}

--- a/rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
+++ b/rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
@@ -83,6 +83,7 @@ Flow * FlowAllocatorPs::newFlowRequest(IPCProcess * ipc_process,
 	} else {
 		dtpConfig.set_max_sdu_gap(qosCube->get_max_allowable_gap());
 	}
+	connection->setDTPConfig(dtpConfig);
         rina::DTCPConfig dtcpConfig = rina::DTCPConfig(
                         qosCube->get_dtcp_config());
 	connection->setDTCPConfig(dtcpConfig);


### PR DESCRIPTION
Fixes #264 

The connection_policies struct has been replaced by dtp_config and dtcp_config structs which are then passed to the dtp/dtcp componenent. 

RNL updated and user space updated to these changes.

ACKs required from @miqueltarzan, @edugrasa, @vmaffione, @msune 

F: librina/include/librina/configuration.h
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: librina/include/librina/ipc-process.h
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: librina/src/configuration.cc
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: librina/src/ipc-process.cc
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: librina/src/netlink-parsers.cc
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: librina/src/netlink-parsers.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/connection.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/connection.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dt-utils.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp-conf-utils.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp-conf-utils.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp-ps-common.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp-utils.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp-utils.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtcp.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtp-conf-utils.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtp-conf-utils.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtp-ps-common.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtp.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/dtp.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/efcp.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/efcp.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/ipcp-instances.h
	Vincenzo Maffione <v.maffione (at) nextworks.it>
F: linux/net/rina/ipcps/normal-ipcp.c
	Miquel Tarzan <miquel.tarzan (at) i2cat.net>
F: linux/net/rina/kipcm.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/rnl-utils.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/rnl-utils.h
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: linux/net/rina/rnl.c
	Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
F: rinad/src/common/encoder.cc
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: rinad/src/common/encoder.h
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: rinad/src/common/encoders/ConnectionPoliciesMessage.proto
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: rinad/src/common/encoders/FlowMessage.proto
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: rinad/src/common/encoders/QoSCubeMessage.proto
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: rinad/src/ipcm/configuration.cc
	Marc Sune <marc.sune (at) bisdn.de>
F: rinad/src/ipcp/flow-allocator.cc
	Eduard Grasa <eduard.grasa (at) i2cat.net>
	Eduard Grasa <eduard.grasa (at) i2cat.net>
F: rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
	Eduard Grasa <eduard.grasa (at) i2cat.net>
	Eduard Grasa <eduard.grasa (at) i2cat.net>