### PR TITLE
rinad: ipcm: implement plugin_load_kernel()

### DIFF
--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1157,7 +1157,7 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 // Returns IPCM_SUCCESS if a kernel plugin was successfully loaded/unloaded,
 // IPCM_FAILURE otherwise
 ipcm_res_t
-IPCManager_::plugin_load_kernel(Addon* callee, const std::string& plugin_name,
+IPCManager_::plugin_load_kernel(const std::string& plugin_name,
 				bool load)
 {
 	ostringstream ss;
@@ -1214,8 +1214,7 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 
 	try {
 		//First try to see if its a kernel module
-		if (plugin_load_kernel(callee, plugin_name,
-				       load) == IPCM_SUCCESS) {
+		if (plugin_load_kernel(plugin_name, load) == IPCM_SUCCESS) {
 			promise->ret = IPCM_SUCCESS;
 
 			return IPCM_SUCCESS;

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1174,14 +1174,10 @@ IPCManager_::plugin_load_kernel(const std::string& plugin_name,
 	} else if (pid == 0) {
 		// child
 		if (load) {
-			execl("modprobe", "modprobe", plugin_name.c_str(),
-			      NULL);
 			execlp("modprobe", "modprobe", plugin_name.c_str(),
 			       NULL);
 
 		} else {
-			execl("modprobe", "modprobe", "-r",
-			      plugin_name.c_str(), NULL);
 			execlp("modprobe", "modprobe", "-r",
 			       plugin_name.c_str(), NULL);
 		}

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1188,12 +1188,16 @@ IPCManager_::plugin_load_kernel(Addon* callee, Promise* promise,
 	} else if (pid == 0) {
 		// child
 		if (load) {
-			execl("modprobe", "modprobe", plugin_name.c_str(), NULL);
-			execlp("modprobe", "modprobe", plugin_name.c_str(), NULL);
+			execl("modprobe", "modprobe", plugin_name.c_str(),
+			      NULL);
+			execlp("modprobe", "modprobe", plugin_name.c_str(),
+			       NULL);
 
 		} else {
-			execl("rmmod", "rmmod", plugin_name.c_str(), NULL);
-			execlp("rmmod", "rmmod", plugin_name.c_str(), NULL);
+			execl("modprobe", "modprobe", "-r",
+			      plugin_name.c_str(), NULL);
+			execlp("modprobe", "modprobe", "-r",
+			       plugin_name.c_str(), NULL);
 		}
 
 		ss << "Kernel plugin (un)loading: exec() failed";

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -27,6 +27,9 @@
 #include <map>
 #include <vector>
 
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #include <librina/common.h>
 #include <librina/ipc-manager.h>
 #include <librina/plugin-info.h>
@@ -1151,6 +1154,69 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 	return IPCM_PENDING;
 }
 
+// Returns true if a kernel plugin was successfully loaded/unloaded
+ipcm_res_t
+IPCManager_::plugin_load_kernel(Addon* callee, Promise* promise,
+				const std::string& plugin_name, bool load)
+{
+	TransactionState* trans;
+	ostringstream ss;
+	ipcm_res_t result = IPCM_FAILURE;
+	pid_t pid;
+
+	trans = new TransactionState(callee, promise);
+	if (!trans){
+		ss << "Unable to allocate memory for the transaction object. Out of memory! ";
+		FLUSH_LOG(ERR, ss);
+		throw rina::Exception();
+	}
+
+	// Store transaction
+	if (add_transaction_state(trans) < 0){
+		ss << "Unable to add transaction; out of memory? ";
+		FLUSH_LOG(ERR, ss);
+		throw rina::Exception();
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		// parent, fork() failed
+		ss << "Kernel plugin (un)loading: fork() failed";
+		FLUSH_LOG(ERR, ss);
+		result = IPCM_FAILURE;
+
+	} else if (pid == 0) {
+		// child
+		if (load) {
+			execl("modprobe", "modprobe", plugin_name.c_str(), NULL);
+			execlp("modprobe", "modprobe", plugin_name.c_str(), NULL);
+
+		} else {
+			execl("rmmod", "rmmod", plugin_name.c_str(), NULL);
+			execlp("rmmod", "rmmod", plugin_name.c_str(), NULL);
+		}
+
+		ss << "Kernel plugin (un)loading: exec() failed";
+		FLUSH_LOG(ERR, ss);
+
+		exit(EXIT_FAILURE);
+
+	} else {
+		// parent, fork() successful
+		int child_status = 0;
+
+		waitpid(pid, &child_status, 0);
+
+		result = child_status ? IPCM_FAILURE : IPCM_SUCCESS;
+	}
+
+	// Mark as completed
+	trans->completed(result);
+	remove_transaction_state(trans->tid);
+
+	return result;
+}
+
 ipcm_res_t
 IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		const unsigned short ipcp_id,
@@ -1161,6 +1227,12 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 	IPCPTransState* trans;
 
 	try {
+		//First try to see if its a kernel module
+		if (plugin_load_kernel(callee, promise, plugin_name,
+				       load) == IPCM_SUCCESS) {
+			return IPCM_SUCCESS;
+		}
+
 		ipcp = lookup_ipcp_by_id(ipcp_id);
 
 		if(!ipcp){

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -691,16 +691,15 @@ protected:
 	//
 	// Load kernel space policy plugin
 	//
-	// @param promise Promise object containing the future result of the
-	// operation. The promise shall always be accessible until the
-	// operation has been finished, so promise->ret value is different than
-	// IPCM_PENDING.
-	//
+	// @param plugin_name Name of the kernel module containing the
+	//		      plugin to be loaded
+	// @param load        True if the plugin is to be loaded,
+	//                    false if the plugin is to be unloaded.
 	// @ret IPCM_SUCCESS when load/unload is successful, otherwise
-	//  IPCM_FAILURE
-	ipcm_res_t plugin_load_kernel(Addon* callee, Promise* promise,
-				const std::string& plugin_name,
-				bool load);
+	//	IPCM_FAILURE
+	ipcm_res_t plugin_load_kernel(Addon* callee,
+				      const std::string& plugin_name,
+				      bool load);
 
 	/*
 	* Get the transaction state. Template parameter is the type of the

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -697,8 +697,7 @@ protected:
 	//                    false if the plugin is to be unloaded.
 	// @ret IPCM_SUCCESS when load/unload is successful, otherwise
 	//	IPCM_FAILURE
-	ipcm_res_t plugin_load_kernel(Addon* callee,
-				      const std::string& plugin_name,
+	ipcm_res_t plugin_load_kernel(const std::string& plugin_name,
 				      bool load);
 
 	/*

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -688,6 +688,20 @@ protected:
 	void ipc_process_select_policy_set_response_handler(
 					rina::SelectPolicySetResponseEvent *e);
 
+	//
+	// Load kernel space policy plugin
+	//
+	// @param promise Promise object containing the future result of the
+	// operation. The promise shall always be accessible until the
+	// operation has been finished, so promise->ret value is different than
+	// IPCM_PENDING.
+	//
+	// @ret IPCM_SUCCESS when load/unload is successful, otherwise
+	//  IPCM_FAILURE
+	ipcm_res_t plugin_load_kernel(Addon* callee, Promise* promise,
+				const std::string& plugin_name,
+				bool load);
+
 	/*
 	* Get the transaction state. Template parameter is the type of the
 	* specific state required for the type of transaction


### PR DESCRIPTION
This patch allows ipcm to modprobe/rmmod plugin modules.

Maintainers: @msune 