### PR TITLE
Fixed two bugs in kernel space (non-present SDU protection config handling and destruction of normal over normal)

### DIFF
--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -653,7 +653,7 @@ static int normal_assign_to_dif(struct ipcp_instance_data * data,
 
         sdup_config = dif_information->configuration->sdup_config;
         if (!sdup_config) {
-        	LOG_WARN("No SDU protection configuration specified");
+        	LOG_INFO("No SDU protection config specified, using default");
         } else {
         	rmt_sdup_config_set(data->rmt, sdup_config);
         }

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -396,11 +396,15 @@ static int normal_flow_unbinding_user_ipcp(struct ipcp_instance_data * data,
 
         spin_lock_irqsave(&data->lock, flags);
         flow = find_flow(data, pid);
-        if (!flow || !flow->active) {
+        if (!flow || !is_cep_id_ok(flow->active)) {
                 spin_unlock_irqrestore(&data->lock, flags);
                 LOG_ERR("Could not find flow with port %d to unbind user IPCP",
                         pid);
                 return -1;
+        }
+
+        if (flow->user_ipcp) {
+        	flow->user_ipcp = NULL;
         }
         spin_unlock_irqrestore(&data->lock, flags);
 
@@ -581,13 +585,19 @@ static int normal_deallocate(struct ipcp_instance_data * data,
                 return -1;
         }
 
-        user_ipcp_name = flow->user_ipcp->ops->ipcp_name(flow->user_ipcp->data);
+        if (flow->user_ipcp && flow->user_ipcp->ops->ipcp_name &&
+            flow->user_ipcp->data) {
+        	user_ipcp_name =
+        		flow->user_ipcp->ops->ipcp_name(flow->user_ipcp->data);
+        } else {
+        	user_ipcp_name = NULL;
+        }
         state          = flow->state;
         flow->state    = PORT_STATE_DEALLOCATED;
         list_del(&flow->list);
         spin_unlock_irqrestore(&data->lock, flags);
 
-        if (state == PORT_STATE_PENDING) {
+        if (state == PORT_STATE_PENDING && flow->user_ipcp) {
                 flow->user_ipcp->ops->flow_unbinding_ipcp(flow->user_ipcp->data,
                                                           port_id);
         } else {

--- a/linux/net/rina/rnl-utils.c
+++ b/linux/net/rina/rnl-utils.c
@@ -1744,6 +1744,11 @@ static int parse_dif_config(struct nlattr *     dif_config_attr,
                 if (parse_sdup_config(attrs[DCONF_ATTR_SECMANC],
                 		      dif_config->sdup_config))
                 	goto parse_fail;
+
+                if (!dif_config->sdup_config->default_dup_conf) {
+                	sdup_config_destroy(dif_config->sdup_config);
+                	dif_config->sdup_config = NULL;
+                }
         }
 
         return 0;


### PR DESCRIPTION
* Fixed null pointer access when destroying a normal IPCP over a normal IPCP with a flow allocated
* Fix handling of not-present SDU protection configuration in kernel space (Fixes issue #675)

Maintainers: @lbergesio @miqueltarzan 
