### PR TITLE
kernel: shim-eth-vlan: Remove rinarp_mac_addr

### DIFF
--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -720,7 +720,6 @@ static int eth_vlan_sdu_write(struct ipcp_instance_data * data,
         struct shim_eth_flow *   flow;
         struct sk_buff *         skb;
         const unsigned char *    src_hw;
-        struct rinarp_mac_addr * desthw;
         const unsigned char *    dest_hw;
         unsigned char *          sdu_ptr;
         int                      hlen, tlen, length;
@@ -745,7 +744,6 @@ static int eth_vlan_sdu_write(struct ipcp_instance_data * data,
 
         hlen   = LL_RESERVED_SPACE(data->dev);
         tlen   = data->dev->needed_tailroom;
-        desthw = 0;
 
         flow = find_flow(data, id);
         if (!flow) {


### PR DESCRIPTION
This PR removes an unused variable in eth_vlan_sdu_write
that only adds to the confusion.

Tested with 2 nodes and rina-echo-time.

Maintainer: Myself, so can someone else ACK and merge this into pristine-1.3, integration-1.2, pristine-1.2?

