### PR TITLE
Completing LFA implementation in userspace

### DIFF
--- a/librina/include/librina/ipc-process.h
+++ b/librina/include/librina/ipc-process.h
@@ -804,6 +804,14 @@ public:
         const std::string toString();
 };
 
+struct NHopAltList {
+	/** Next hop and its alternates */
+	std::list<unsigned int> alts;
+
+	NHopAltList() { }
+	NHopAltList(unsigned int x) { alts.push_back(x); }
+};
+
 /// Models an entry of the routing table
 class RoutingTableEntry {
 public:
@@ -817,7 +825,7 @@ public:
 	unsigned int cost;
 
 	/** The next hop addresses */
-	std::list<unsigned int> nextHopAddresses;
+	std::list<NHopAltList> nextHopAddresses;
 
 	RoutingTableEntry();
 };

--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -572,14 +572,14 @@ void LoopFreeAlternateAlgorithm::fortifyRoutingTable(const Graph& graph,
 		}
 	}
 
-	// For each node other than than the source node and its neighbors
+	// For each node X other than than the source node
 	for (std::list<unsigned int>::const_iterator it = graph.vertices_.begin();
 						it != graph.vertices_.end(); ++it) {
-		if ((*it) == source_address || neighbors_dist_trees.count(*it)) {
+		if ((*it) == source_address) {
 			continue;
 		}
 
-		// For each neighbor of the source node
+		// For each neighbor of the source node, excluding X
 		for (std::map<unsigned int, std::map<unsigned int, int> >::iterator
 			nit = neighbors_dist_trees.begin();
 				nit != neighbors_dist_trees.end(); nit++) {
@@ -588,6 +588,10 @@ void LoopFreeAlternateAlgorithm::fortifyRoutingTable(const Graph& graph,
 			// into account
 			std::map< unsigned int, int>& neigh_dist_map = nit->second;
 			unsigned int neigh = nit->first;
+
+			if (neigh == *it) {
+				continue;
+			}
 
 			// dist(neigh, target) < dist(neigh, source) + dist(source, target)
 			if (neigh_dist_map[*it] < src_dist_tree[neigh] + src_dist_tree[*it]) {

--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -360,7 +360,7 @@ std::list<rina::RoutingTableEntry *> DijkstraAlgorithm::computeRoutingTable(
 			if (nextHop != 0) {
 				entry = new rina::RoutingTableEntry();
 				entry->address = (*it);
-				entry->nextHopAddresses.push_back(nextHop);
+				entry->nextHopAddresses.push_back(rina::NHopAltList(nextHop));
 				entry->qosId = 1;
 				entry->cost = 1;
 				result.push_back(entry);
@@ -517,6 +517,7 @@ void LoopFreeAlternateAlgorithm::extendRoutingTableEntry(
 	std::list<rina::RoutingTableEntry *>::iterator rit;
 	bool found = false;
 
+	// Find the involved routing table entry
 	for (rit = rt.begin(); rit != rt.end(); rit++) {
 		if ((*rit)->address == target_address) {
 			break;
@@ -529,18 +530,22 @@ void LoopFreeAlternateAlgorithm::extendRoutingTableEntry(
 		return;
 	}
 
-	//Find the involved routing table entry, try to extend it
+	// Assume unicast and try to extend the routing table entry
+	// with the new alternative 'nexthop'
+	rina::NHopAltList& altlist = (*rit)->nextHopAddresses.front();
+
 	for (std::list<unsigned int>::iterator
-			hit = (*rit)->nextHopAddresses.begin();
-				hit != (*rit)->nextHopAddresses.end(); hit++) {
+			hit = altlist.alts.begin();
+				hit != altlist.alts.end(); hit++) {
 		if (*hit == nexthop) {
+			// The nexthop is already in the alternatives
 			found = true;
 			break;
 		}
 	}
 
 	if (!found) {
-		(*rit)->nextHopAddresses.push_back(nexthop);
+		altlist.alts.push_back(nexthop);
 		LOG_DBG("Node %u selected as LFA node towards the "
 			 "destination node %u", nexthop, target_address);
 	}


### PR DESCRIPTION
This patch series contains the modification necessary to correctly compute LFA nodes for the routing table and correctly translate NextHop information into PortId information, so that the resulting PDU Forwarding table (that includes lists of alternate port-ids) is pushed to kernelspace to the PFF component.