### PR TITLE
Fix deployment of manifest files for kernel plugins

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -266,6 +266,7 @@ F: rinad/src/ipcp/plugins/default/default.manifest
 F: rinad/src/ipcp/plugins/default/namespace*
 F: rinad/src/ipcp/plugins/default/plugin.cc
 F: rinad/src/ipcp/plugins/default/test-encoder*
+F: rinad/src/ipcp/plugins/default/rina-default-plugin.manifest
 X: rinad/src/ipcp/plugins/
 X: rinad/src/ipcp/enroll*
 X: rinad/src/ipcp/flow-alloc*

--- a/plugins/cong_avoidance/Makefile
+++ b/plugins/cong_avoidance/Makefile
@@ -3,6 +3,7 @@
 #
 
 KDIR=../../linux
+KREL=`uname -r`
 
 ifneq ($(KERNELRELEASE),)
 
@@ -22,6 +23,7 @@ clean:
 
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
+	cp cas-plugin.manifest /lib/modules/$(KREL)/extra/
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/cong_avoidance/cas-plugin.manifest
+++ b/plugins/cong_avoidance/cas-plugin.manifest
@@ -1,0 +1,16 @@
+{
+        "PluginName": "cas-plugin",
+        "PluginVersion": "1",
+        "PolicySets" : [
+                {
+                        "Name": "cas-ps",
+                        "Component": "rmt",
+                        "Version" : "1"
+                },
+                {
+                        "Name": "cas-ps",
+                        "Component": "dtcp",
+                        "Version" : "1"
+                }
+        ]
+}

--- a/plugins/lfa/Makefile
+++ b/plugins/lfa/Makefile
@@ -3,6 +3,7 @@
 #
 
 KDIR=../../linux
+KREL=`uname -r`
 
 ifneq ($(KERNELRELEASE),)
 
@@ -22,6 +23,7 @@ clean:
 
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
+	cp pff-lfa.manifest /lib/modules/$(KREL)/extra/
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/tests/conf/ipcmanager.conf-appovereth
+++ b/tests/conf/ipcmanager.conf-appovereth
@@ -5,7 +5,8 @@
     	"logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-appovershimhv
+++ b/tests/conf/ipcmanager.conf-appovershimhv
@@ -5,7 +5,8 @@
     	"logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-mad
+++ b/tests/conf/ipcmanager.conf-mad
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovereth1
+++ b/tests/conf/ipcmanager.conf-normalovereth1
@@ -5,7 +5,8 @@
     	"logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovereth2
+++ b/tests/conf/ipcmanager.conf-normalovereth2
@@ -5,7 +5,8 @@
     	"logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	],
         "cdapTimeoutInMs": 10000
     },

--- a/tests/conf/ipcmanager.conf-normalovernormalovereth1
+++ b/tests/conf/ipcmanager.conf-normalovernormalovereth1
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovernormalovereth2
+++ b/tests/conf/ipcmanager.conf-normalovernormalovereth2
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovershimhv1
+++ b/tests/conf/ipcmanager.conf-normalovershimhv1
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovershimhv2
+++ b/tests/conf/ipcmanager.conf-normalovershimhv2
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovertcpudp1
+++ b/tests/conf/ipcmanager.conf-normalovertcpudp1
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/ipcmanager.conf-normalovertcpudp2
+++ b/tests/conf/ipcmanager.conf-normalovertcpudp2
@@ -5,7 +5,8 @@
     	"logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/vm-to-vm/ipcmanager.conf-pm
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-pm
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.1
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
+++ b/tests/conf/vm-to-vm/ipcmanager.conf-vm.2
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	]
     },
     "applicationToDIFMappings": [

--- a/tests/conf/vpn/ipcmanager.conf-pm.i2cat
+++ b/tests/conf/vpn/ipcmanager.conf-pm.i2cat
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	],
         "cdapTimeoutInMs": 10000,
         "enrollmentTimeoutInMs": 10000,

--- a/tests/conf/vpn/ipcmanager.conf-pm.nxw
+++ b/tests/conf/vpn/ipcmanager.conf-pm.nxw
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	],
         "cdapTimeoutInMs": 10000,
         "enrollmentTimeoutInMs": 10000,

--- a/tests/conf/vpn/ipcmanager.conf-vm.i2cat
+++ b/tests/conf/vpn/ipcmanager.conf-vm.i2cat
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	],
         "cdapTimeoutInMs": 10000,
         "enrollmentTimeoutInMs": 10000,

--- a/tests/conf/vpn/ipcmanager.conf-vm.nxw
+++ b/tests/conf/vpn/ipcmanager.conf-vm.nxw
@@ -5,7 +5,8 @@
         "logPath": "/usr/local/irati/var/log",
         "consolePort": 32766,
 	"pluginsPaths": [
-		"/usr/local/irati/lib/rinad/ipcp"
+		"/usr/local/irati/lib/rinad/ipcp",
+		"/lib/modules/3.15.0-irati/extra"
 	],
         "cdapTimeoutInMs": 10000,
         "enrollmentTimeoutInMs": 10000,


### PR DESCRIPTION
With this patch, non-default plugin manifests are installed in the system in the same place compiled modules are installed in the system - under /lib/modules/`uname -r`.

In this way IPCM configuration file can specify a single entry in pluginsPaths to indicate where the manifest files for kernel plugins can be found.

Maintainers:
  @lbergesio @msune 