### PR TITLE
Pristine 1.3 jain dtcp ps

### DIFF
--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -35,23 +35,15 @@
 #define W_INC_A_P_DEFAULT     1
 #define W_DEC_B_NUM_P_DEFAULT 7
 #define W_DEC_B_DEN_P_DEFAULT 3
-#define BITS_PER_BYTE 8
-#define BITS_PER_INT (sizeof(int) * BITS_PER_BYTE)
-#define VECTOR_SIZE(X) ((((X) / BITS_PER_INT) + 1) * sizeof(int))
-#define BIT_INDEX(X) ((X) / BITS_PER_INT)
-#define BIT_NUMBER(X) ((X) % BITS_PER_INT)
 
 struct cas_dtcp_ps_data {
-        bool         first_run;
         seq_num_t    wc;
         seq_num_t    wp;
-        seq_num_t    wc_lwe;
         unsigned int w_inc_a_p;
         unsigned int w_dec_b_num_p;
         unsigned int w_dec_b_den_p;
         unsigned int ecn_count;
         unsigned int rcv_count;
-        int *        rcv_vector;
         spinlock_t   lock;
 };
 
@@ -79,11 +71,7 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
 {
         struct dtcp *             dtcp = ps->dm;
         struct cas_dtcp_ps_data * data = ps->priv;
-        seq_num_t                 c_seq;
-        int                       ecn_bit;
-        size_t                    v_size_n, v_size_c;
-        cep_id_t		  src_cep_id;
-        unsigned long 		  flags;
+        unsigned long		  flags;
 
         if (!dtcp || !data) {
                 LOG_ERR("No instance passed, cannot run policy");
@@ -94,94 +82,50 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
                 return -1;
         }
 
-        c_seq   = pci_sequence_number_get(pci);
-        src_cep_id = pci_cep_source(pci);
-
 	/* FIXME: This has to be considered in the case the sender inactivity
 	 * timers is triggered */
 /*
         if (!data->first_run && (pci_flags_get(pci) & PDU_FLAGS_DATA_RUN)) {
                 LOG_DBG("DRF Flag, reseting...");
-                memset(data->rcv_vector, 0, VECTOR_SIZE(data->wc + data->wp));
                 data->ecn_count = 0;
                 data->rcv_count = 0;
-                data->wc_lwe    = c_seq;
         }
 */
+
         spin_lock_irqsave(&data->lock, flags);
-        if (data->first_run) {
-                data->wc_lwe = c_seq;
-                data->first_run = false;
-        }
-
-        LOG_DBG("C_Seq %u, data->wc_lwe: %u", c_seq, data->wc_lwe);
-        LOG_DBG("Bit index: %d, Bit number: %d",
-                BIT_INDEX(c_seq - data->wc_lwe), BIT_NUMBER(c_seq -data->wc_lwe));
-
-        ecn_bit = data->rcv_vector[BIT_INDEX(c_seq - data->wc_lwe)] & (1 << BIT_NUMBER(c_seq -data->wc_lwe));
-
-        LOG_DBG("ECN bit: %x, INT in vector: %d (%x)",
-                ecn_bit,
-                data->rcv_vector[BIT_INDEX(c_seq - data->wc_lwe)],
-                data->rcv_vector[BIT_INDEX(c_seq - data->wc_lwe)]);
-
-        if (ecn_bit) {
-                LOG_INFO("This pdu was already considered, exiting...");
-                LOG_INFO("Vector position: %d; seq-num: %u; lwe: %u",
-                	 BIT_INDEX(c_seq - data->wc_lwe), c_seq, data->wc_lwe);
-                goto exit;
-        }
-
-        /* mark seq num as received */
-        data->rcv_vector[BIT_INDEX(c_seq -data->wc_lwe)] |= (1 << BIT_NUMBER(c_seq - data->wc_lwe));
         /* if we passed the wp bits, consider ecn bit */
         if ((++data->rcv_count > data->wp) &&
              ((int) (pci_flags_get(pci) & PDU_FLAGS_EXPLICIT_CONGESTION))) {
                 data->ecn_count++;
-                LOG_DBG("ECN bit for PDU %u marked, total %u",
-                        c_seq, data->ecn_count);
+                LOG_DBG("ECN bit marked, total %u", data->ecn_count);
         }
 
         /* it is time to update the window's size & reset */
         if (data->rcv_count == data->wc + data->wp) {
                 LOG_DBG("Updating window size...");
-                v_size_c = VECTOR_SIZE(data->wp + data->wc);
                 data->wp = data->wc;
-                data->wc_lwe = dt_sv_rcv_lft_win(dtcp_dt(dtcp));
                 /*check number of ecn bits set */
                 LOG_DBG("ECN COUNT: %d, Wc: %u", data->ecn_count, data->wc);
-                if (data->ecn_count >= (data->wc >> 1)) {
+                if (data->ecn_count > (data->wc >> 1)) {
+                        if (data->wc != 1) {
                         /* decrease window's size*/
                         data->wc = (data->wc * data->w_dec_b_num_p) >> data->w_dec_b_den_p;
-                        LOG_DBG("(src cep-id %d): Window size decreased, new values are Wp: %u, Wc: %u, Wc_LWE: %u",
-                        		src_cep_id, data->wp, data->wc, data->wc_lwe);
+                        LOG_DBG("Window size decreased, new values are Wp: %u, Wc: %u",
+                                data->wp, data->wc);
+                	}
                 } else {
                         /*increment window's size */
                         data->wc += data->w_inc_a_p;
-                        LOG_DBG("(src cep-id %d): Window size increased, new values are Wp: %u, Wc: %u, Wc_LWE: %u",
-                                 src_cep_id, data->wp, data->wc, data->wc_lwe);
+                        LOG_DBG("Window size increased, new values are Wp: %u, Wc: %u",
+                        	data->wp, data->wc);
                 }
-
-		/* reset rcv_vector */
-		/* NOTE: maybe we should resize only when increasing... */
-                v_size_n = VECTOR_SIZE(data->wc + data->wp);
-                LOG_INFO("Int size %d", sizeof(int));
-                LOG_INFO("Value = %d, %u; old value: %d"
-                	 "Current Vsize %zu, old Vsize %zu"
-                	, src_cep_id, data->wc, data->wp,
-                	  v_size_n, v_size_c);
-		if (v_size_n != v_size_c) {
-                        rkfree(data->rcv_vector);
-                        data->rcv_vector = rkmalloc(v_size_n, GFP_ATOMIC);
-                        LOG_INFO("vector size is %zu", v_size_n);
-                }
-                memset(data->rcv_vector, 0, v_size_n);
+                LOG_INFO("Value = %d, %u", pci_cep_source(pci), data->wc);
                 data->rcv_count = 0;
                 data->ecn_count = 0;
                 dtcp_rcvr_credit_set(dtcp, data->wc);
         }
-exit:
 	spin_unlock_irqrestore(&data->lock, flags);
+
         update_rt_wind_edge(dtcp);
 
         LOG_DBG("Credit and RWE set: %u, %u", data->wc, rcvr_rt_wind_edge(dtcp));
@@ -257,7 +201,6 @@ dtcp_ps_cas_create(struct rina_component * component)
         ps->base.set_policy_set_param   = dtcp_ps_cas_set_policy_set_param;
         ps->dm                          = dtcp;
 
-        data->first_run                 = true;
         data->w_inc_a_p                 = W_INC_A_P_DEFAULT;
         data->w_dec_b_num_p             = W_DEC_B_NUM_P_DEFAULT;
         data->w_dec_b_den_p             = W_DEC_B_DEN_P_DEFAULT;
@@ -266,20 +209,11 @@ dtcp_ps_cas_create(struct rina_component * component)
         /*data->wc                        = ps->flowctrl.window.initial_credit;*/
         data->wc                        = dtcp_initial_credit(dtcp_cfg);;
         data->wp                        = 0;
-        data->wc_lwe                    = 0;
         data->ecn_count                 = 0;
         data->rcv_count                 = 0;
 
         LOG_DBG("Allocating %d bytes for rcv_vector with Wc %u, Wp %u",
                 VECTOR_SIZE(data->wc + data->wp), data->wc, data->wp);
-
-        data->rcv_vector = rkmalloc(VECTOR_SIZE(data->wc + data->wp), GFP_KERNEL);
-        if (!data->rcv_vector) {
-                LOG_ERR("Could not allocate memory for rcv_vector");
-                rkfree(data);
-                rkfree(ps);
-        }
-        memset(data->rcv_vector, 0, VECTOR_SIZE(data->wc + data->wp));
 
         ps->priv                        = data;
 
@@ -341,7 +275,6 @@ static void dtcp_ps_cas_destroy(struct ps_base * bps)
         if (bps) {
                 if (ps->priv) {
                         data = ps->priv;
-                        rkfree(data->rcv_vector);
                         rkfree(data);
                 }
                 rkfree(ps);

--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -107,11 +107,11 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
                 /*check number of ecn bits set */
                 LOG_DBG("ECN COUNT: %d, Wc: %u", data->ecn_count, data->wc);
                 if (data->ecn_count > (data->wc >> 1)) {
-                        if (data->wc != 1) {
-                        /* decrease window's size*/
-                        data->wc = (data->wc * data->w_dec_b_num_p) >> data->w_dec_b_den_p;
-                        LOG_DBG("Window size decreased, new values are Wp: %u, Wc: %u",
-                                data->wp, data->wc);
+                	if (data->wc != 1) {
+                		/* decrease window's size*/
+                		data->wc = (data->wc * data->w_dec_b_num_p) >> data->w_dec_b_den_p;
+                		LOG_DBG("Window size decreaased, new values are Wp: %u, Wc: %u",
+                				data->wp, data->wc);
                 	}
                 } else {
                         /*increment window's size */

--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -135,7 +135,9 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
                 LOG_DBG("ECN COUNT: %d, Wc: %u", data->ecn_count, data->wc);
                 if (data->ecn_count > (data->wc >> 1)) {
                 	if (data->wc != 1) {
-                		/* decrease window's size, multiplying by 0,875*/
+                		/* decrease window's size, multiplying by 0,875
+                		 * X*0,875 = x(1-0.125) = x -x/8
+                		 */
                 		data->real_window = data->real_window - (data->real_window >>3);
                 		data->wc = round_half_to_even(data->real_window);
                 		LOG_DBG("Window size decreased, new values are Wp: %u, Wc: %u",
@@ -237,7 +239,7 @@ dtcp_ps_cas_create(struct rina_component * component)
         /* Cannot use this because it is initialized later on in
          * dtcp_select_policy_set */
         /*data->wc                        = ps->flowctrl.window.initial_credit;*/
-        data->wc                        = dtcp_initial_credit(dtcp_cfg);;
+        data->wc                        = dtcp_initial_credit(dtcp_cfg);
         data->real_window		= data->wc << 16;
         data->wp                        = 0;
         data->ecn_count                 = 0;

--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -81,6 +81,7 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
         seq_num_t                 c_seq;
         int                       ecn_bit;
         size_t                    v_size_n, v_size_c;
+        cep_id_t		  src_cep_id;
 
         if (!dtcp || !data) {
                 LOG_ERR("No instance passed, cannot run policy");
@@ -92,6 +93,7 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
         }
 
         c_seq   = pci_sequence_number_get(pci);
+        src_cep_id = pci_cep_source(pci);
 
 	/* FIXME: This has to be considered in the case the sender inactivity
 	 * timers is triggered */
@@ -146,14 +148,15 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
                 if (data->ecn_count >= (data->wc >> 1)) {
                         /* decrease window's size*/
                         data->wc = (data->wc * data->w_dec_b_num_p) >> data->w_dec_b_den_p;
-                        LOG_DBG("Window size decreaased, new values are Wp: %u, Wc: %u, Wc_LWE: %u",
-                                data->wp, data->wc, data->wc_lwe);
+                        LOG_DBG("(src cep-id %d): Window size decreased, new values are Wp: %u, Wc: %u, Wc_LWE: %u",
+                        		src_cep_id, data->wp, data->wc, data->wc_lwe);
                 } else {
                         /*increment window's size */
                         data->wc += data->w_inc_a_p;
-                        LOG_DBG("Window size increased, new values are Wp: %u, Wc: %u, Wc_LWE: %u",
-                                data->wp, data->wc, data->wc_lwe);
+                        LOG_DBG("(src cep-id %d): Window size increased, new values are Wp: %u, Wc: %u, Wc_LWE: %u",
+                                 src_cep_id, data->wp, data->wc, data->wc_lwe);
                 }
+                LOG_INFO("Value = %d, %u", src_cep_id, data->wc);
 		/* reset rcv_vector */
 		/* NOTE: maybe we should resize only when increasing... */
                 v_size_n = VECTOR_SIZE(data->wc + data->wp);

--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -40,8 +40,6 @@ struct cas_dtcp_ps_data {
         seq_num_t    wc;
         seq_num_t    wp;
         unsigned int w_inc_a_p;
-        unsigned int w_dec_b_num_p;
-        unsigned int w_dec_b_den_p;
         unsigned int ecn_count;
         unsigned int rcv_count;
         spinlock_t   lock;
@@ -198,16 +196,6 @@ static int dtcp_ps_cas_set_policy_set_param(struct ps_base * bps,
                 if (!ret)
                         data->w_inc_a_p = bool_value;
         }
-        if (strcmp(name, "w_dec_b_num_p") == 0) {
-                ret = kstrtoint(value, 10, &bool_value);
-                if (!ret)
-                        data->w_dec_b_num_p = bool_value;
-        }
-        if (strcmp(name, "w_dec_b_den_p") == 0) {
-                ret = kstrtoint(value, 10, &bool_value);
-                if (!ret)
-                        data->w_dec_b_den_p = bool_value;
-        }
         return 0;
 }
 
@@ -234,8 +222,6 @@ dtcp_ps_cas_create(struct rina_component * component)
         ps->dm                          = dtcp;
 
         data->w_inc_a_p                 = W_INC_A_P_DEFAULT;
-        data->w_dec_b_num_p             = W_DEC_B_NUM_P_DEFAULT;
-        data->w_dec_b_den_p             = W_DEC_B_DEN_P_DEFAULT;
         /* Cannot use this because it is initialized later on in
          * dtcp_select_policy_set */
         /*data->wc                        = ps->flowctrl.window.initial_credit;*/
@@ -262,21 +248,6 @@ dtcp_ps_cas_create(struct rina_component * component)
         dtcp_ps_cas_set_policy_set_param(&ps->base,
                                          policy_param_name(ps_param),
                                          policy_param_value(ps_param));
-        ps_param = policy_param_find(ps_conf, "w_dec_b_num_p");
-        if (!ps_param) {
-                LOG_WARN("No PS param w_dec_b_num_p");
-        }
-        dtcp_ps_cas_set_policy_set_param(&ps->base,
-                                        policy_param_name(ps_param),
-                                        policy_param_value(ps_param));
-        ps_param = policy_param_find(ps_conf, "w_dec_b_den_p");
-        if (!ps_param) {
-                LOG_WARN("No PS param w_dec_b_den_p");
-        }
-        dtcp_ps_cas_set_policy_set_param(&ps->base,
-                                        policy_param_name(ps_param),
-                                        policy_param_value(ps_param));
-
 
         ps->flow_init                   = NULL;
         ps->lost_control_pdu            = cas_lost_control_pdu;

--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -45,6 +45,16 @@ struct cas_dtcp_ps_data {
         unsigned int ecn_count;
         unsigned int rcv_count;
         spinlock_t   lock;
+
+        /* Value of window in fixed point, most significant 16 bits are the
+         * integer part, less significant 16 bits are the decimal part (i.e.
+         * 0000 0000 0000 0000 0000 0000 0000 0001 represents 0.00001525878).
+         * With that we can get window values up to 65536 PDUs, and a
+         * resolution of almost 5 decimals. Window values must be computed
+         * using real numbers, otherwise a fair allocation of windows between
+         * competing flows is not guaranteed.
+         */
+        unsigned int real_window;
 };
 
 static int
@@ -65,6 +75,23 @@ cas_sending_ack(struct dtcp_ps * ps, seq_num_t seq)
 static int
 cas_receiving_flow_control(struct dtcp_ps * ps, const struct pci * pci)
 { return common_receiving_flow_control(ps, pci); }
+
+static unsigned int round_half_to_even(unsigned int real_window)
+{
+	unsigned int decimal_part = real_window & 0x0000FFFF;
+	unsigned int integer_part = (real_window & 0xFFFF0000) >> 16;
+
+	if (decimal_part > 0x00007FFF)
+		return integer_part +1;
+
+	if (decimal_part < 0x00007FFF)
+		return integer_part;
+
+	if ((integer_part & 0x00000001) == 0)
+		return integer_part +1;
+
+	return integer_part;
+}
 
 static int
 cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
@@ -108,18 +135,21 @@ cas_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
                 LOG_DBG("ECN COUNT: %d, Wc: %u", data->ecn_count, data->wc);
                 if (data->ecn_count > (data->wc >> 1)) {
                 	if (data->wc != 1) {
-                		/* decrease window's size*/
-                		data->wc = (data->wc * data->w_dec_b_num_p) >> data->w_dec_b_den_p;
-                		LOG_DBG("Window size decreaased, new values are Wp: %u, Wc: %u",
+                		/* decrease window's size, multiplying by 0,875*/
+                		data->real_window = data->real_window - (data->real_window >>3);
+                		data->wc = round_half_to_even(data->real_window);
+                		LOG_DBG("Window size decreased, new values are Wp: %u, Wc: %u",
                 				data->wp, data->wc);
                 	}
                 } else {
                         /*increment window's size */
-                        data->wc += data->w_inc_a_p;
+                	data->real_window += data->w_inc_a_p << 16;
+                	data->wc = round_half_to_even(data->real_window);
                         LOG_DBG("Window size increased, new values are Wp: %u, Wc: %u",
                         	data->wp, data->wc);
                 }
-                LOG_INFO("Value = %d, %u", pci_cep_source(pci), data->wc);
+                LOG_INFO("Value (%d) = %u, %u (ECN = %u)",
+                		pci_cep_source(pci), data->wc, data->real_window, data->ecn_count);
                 data->rcv_count = 0;
                 data->ecn_count = 0;
                 dtcp_rcvr_credit_set(dtcp, data->wc);
@@ -208,6 +238,7 @@ dtcp_ps_cas_create(struct rina_component * component)
          * dtcp_select_policy_set */
         /*data->wc                        = ps->flowctrl.window.initial_credit;*/
         data->wc                        = dtcp_initial_credit(dtcp_cfg);;
+        data->real_window		= data->wc << 16;
         data->wp                        = 0;
         data->ecn_count                 = 0;
         data->rcv_count                 = 0;

--- a/plugins/cong_avoidance/rmt-ps-cas.c
+++ b/plugins/cong_avoidance/rmt-ps-cas.c
@@ -125,17 +125,12 @@ struct cas_rmt_queue * cas_rmt_queue_find(struct cas_rmt_ps_data * data,
 static void cas_max_q_policy_tx(struct rmt_ps *      ps,
                                 struct pdu *         pdu,
                                 struct rmt_n1_port * port)
-{ printk("%s: called()\n", __func__); }
+{  }
 
 static void cas_max_q_policy_rx(struct rmt_ps *      ps,
                                 struct sdu *         sdu,
                                 struct rmt_n1_port * port)
-{ printk("%s: called()\n", __func__); }
-
-static int cas_rmt_requeue_scheduling_policy_tx(struct rmt_ps *      ps,
-                                         	struct rmt_n1_port * n1_port,
-                                         	struct pdu *         pdu)
-{ return common_rmt_requeue_scheduling_policy_tx(ps, n1_port, pdu); }
+{  }
 
 static void cas_rmt_q_monitor_policy_tx(struct rmt_ps *      ps,
                                         struct pdu *         pdu,
@@ -235,12 +230,11 @@ static void cas_rmt_q_monitor_policy_tx(struct rmt_ps *      ps,
         cur_cycle->avg_len = (cur_cycle->sum_area + prev_cycle->sum_area);
         cur_cycle->avg_len /= timespec_to_ns(&t_sub);
 
-
         LOG_DBG("The length for N-1 port %u just calculated is: %lu",
                 port->port_id, cur_cycle->avg_len);
 
         if (cur_cycle->avg_len >= 1) {
-                LOG_INFO("Congestion detected in port %u, marking packets...",
+                LOG_DBG("Congestion detected in port %u, marking packets...",
                          port->port_id);
                 pci = pdu_pci_get_rw(pdu);
                 if (!pci) {
@@ -259,7 +253,7 @@ static void cas_rmt_q_monitor_policy_tx(struct rmt_ps *      ps,
 static void cas_rmt_q_monitor_policy_rx(struct rmt_ps *      ps,
                                         struct sdu *         sdu,
                                         struct rmt_n1_port * port)
-{ printk("%s: called()\n", __func__); }
+{  }
 
 static struct pdu *
 cas_rmt_next_scheduled_policy_tx(struct rmt_ps *      ps,
@@ -287,6 +281,7 @@ cas_rmt_next_scheduled_policy_tx(struct rmt_ps *      ps,
                 LOG_ERR("Could not dequeue scheduled pdu");
                 return NULL;
         }
+
         return ret_pdu;
 }
 

--- a/plugins/cong_avoidance/rmt-ps-cas.c
+++ b/plugins/cong_avoidance/rmt-ps-cas.c
@@ -231,12 +231,13 @@ static void cas_rmt_q_monitor_policy_tx(struct rmt_ps *      ps,
 	t_sub_ns = timespec_to_ns(&t_sub);
         cur_cycle->avg_len = (cur_cycle->sum_area + prev_cycle->sum_area);
 
-	/* This raise a warning: WARNING: "__divdi3" undefined ?
-	cur_cycle->avg_len /= timespec_to_ns(&t_sub); */
-	if (abs64(t_sub_ns) & 0xFFFFFFFF00000000)
-		cur_cycle->avg_len = 0;
-	else
-		cur_cycle->avg_len /= (s32) timespec_to_ns(&t_sub);
+	/* This raise a warning: WARNING: "__divdi3" undefined. For some reason
+	 * it can not divide by a s64 variable but can do it by an insigned
+	 * long, both of size 64bits */
+	if (t_sub_ns < 0)
+		LOG_ERR("Time delta is < 0!");
+
+	cur_cycle->avg_len /=  (ulong) abs64(t_sub_ns);
 
         LOG_DBG("The length for N-1 port %u just calculated is: %lu",
                 port->port_id, cur_cycle->avg_len);

--- a/plugins/cong_avoidance/rmt-ps-cas.c
+++ b/plugins/cong_avoidance/rmt-ps-cas.c
@@ -29,6 +29,7 @@
 #include "debug.h"
 #include "rds/rmem.h"
 #include "rmt-ps.h"
+#include "rmt-ps-common.h"
 #include "pci.h"
 
 #define  N1_CYCLE_DURATION 100
@@ -131,9 +132,14 @@ static void cas_max_q_policy_rx(struct rmt_ps *      ps,
                                 struct rmt_n1_port * port)
 { printk("%s: called()\n", __func__); }
 
-static void cas_rmt_q_monitor_policy_tx_common(struct rmt_ps *      ps,
-                                               struct pdu *         pdu,
-                                               struct rmt_n1_port * port)
+static int cas_rmt_requeue_scheduling_policy_tx(struct rmt_ps *      ps,
+                                         	struct rmt_n1_port * n1_port,
+                                         	struct pdu *         pdu)
+{ return common_rmt_requeue_scheduling_policy_tx(ps, n1_port, pdu); }
+
+static void cas_rmt_q_monitor_policy_tx(struct rmt_ps *      ps,
+                                        struct pdu *         pdu,
+                                        struct rmt_n1_port * port)
 {
         struct cas_rmt_queue *   q;
         struct cas_rmt_ps_data * data;


### PR DESCRIPTION
This PR fixes and extends #703 which was originally nacked by me.

It implements the Jain binary congestion avoidance scheme as a pair of PSs for DTCP and RMT.
It has been tested and used in the first experiment scenario of D6.2.

Mainteiners: @miqueltarzan and myself.