### PR TITLE
pristine-1.3: kernel: dtcp: check ps->rtt_estimator is not NULL

### DIFF
--- a/linux/net/rina/dtcp.c
+++ b/linux/net/rina/dtcp.c
@@ -690,7 +690,8 @@ static int rcv_nack_ctl(struct dtcp * dtcp,
                         return -1;
                 }
                 rtxq_nack(q, seq_num, dt_sv_tr(dtcp->parent));
-                ps->rtt_estimator(ps, pci_control_ack_seq_num(pci));
+		if (ps->rtt_estimator)
+                	ps->rtt_estimator(ps, pci_control_ack_seq_num(pci));
         }
         rcu_read_unlock();
 
@@ -721,7 +722,8 @@ static int rcv_ack(struct dtcp * dtcp,
         ps = container_of(rcu_dereference(dtcp->base.ps),
                           struct dtcp_ps, base);
         ret = ps->sender_ack(ps, seq);
-        ps->rtt_estimator(ps, pci_control_ack_seq_num(pci));
+	if (ps->rtt_estimator)
+        	ps->rtt_estimator(ps, pci_control_ack_seq_num(pci));
         rcu_read_unlock();
 
         LOG_DBG("DTCP received ACK (CPU: %d)", smp_processor_id());
@@ -791,7 +793,8 @@ static int rcv_ack_and_flow_ctl(struct dtcp * dtcp,
         /* This updates sender LWE */
         if (ps->sender_ack(ps, seq))
                 LOG_ERR("Could not update RTXQ and LWE");
-        ps->rtt_estimator(ps, pci_control_ack_seq_num(pci));
+	if (ps->rtt_estimator)
+        	ps->rtt_estimator(ps, pci_control_ack_seq_num(pci));
         rcu_read_unlock();
 
         snd_rt_wind_edge_set(dtcp, pci_control_new_rt_wind_edge(pci));


### PR DESCRIPTION
Nothing prevents a PS to not define the rtt_estimator op and set it
to NULL. If this happens, the DTCP code executes the op without checking
if the pointer is not NULL and the system crashed.
The proper solution would be to check for mandatory ops in the PS, but in
the meanwhile this solves the problem.

I am the maintainer, but changes are trivial so anyone with rights can check and merge.