### PR TITLE
Fix catalog for automatic loading of policy-sets

### DIFF
--- a/linux/net/rina/dtp.c
+++ b/linux/net/rina/dtp.c
@@ -979,8 +979,8 @@ struct dtp * dtp_create(struct dt *         dt,
                 ps_name = RINA_PS_DEFAULT_NAME;
 
         if (dtp_select_policy_set(tmp, "", ps_name)) {
-                dtp_destroy(tmp);
                 LOG_ERR("Could not load DTP PS %s", ps_name);
+                dtp_destroy(tmp);
                 return NULL;
         }
 

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -179,6 +179,14 @@ int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,
 	psinfo_from_psconfig(required_policy_sets, "routing",
 			     t->routingConfiguration.policy_set_);
 
+	for (list<rina::QoSCube>::const_iterator qit = t->qosCubes.begin();
+					qit != t->qosCubes.end(); qit++) {
+		psinfo_from_psconfig(required_policy_sets, "dtp",
+				     qit->dtp_config_.dtp_policy_set_);
+		psinfo_from_psconfig(required_policy_sets, "dtcp",
+				     qit->dtcp_config_.dtcp_policy_set_);
+	}
+
 	// Load all the policy sets in the list
 	for (list<rina::PsInfo>::iterator i=required_policy_sets.begin();
 			i != required_policy_sets.end(); i++) {


### PR DESCRIPTION
The processing of DTP and DTCP policy set configurations was
missing.

Maintainers:
@lbergesio 
@msune

@kewinrausch, this will solve your problem