### PR TITLE
kernel: shim-eth-vlan: fixed bug in qdisc when device had multiple tx queues (only one was replaced)

### DIFF
--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -48,7 +48,7 @@
 #include "rinarp/rinarp.h"
 #include "rinarp/arp826-utils.h"
 
-#define DEFAULT_QDISC_MAX_SIZE 50
+#define DEFAULT_QDISC_MAX_SIZE 500
 #define DEFAULT_QDISC_ENABLE_SIZE 10
 
 /* FIXME: To be solved properly */
@@ -856,36 +856,39 @@ int eth_vlan_update_qdisc(struct net_device *    dev,
 {
 	struct Qdisc * sch;
 	struct nlattr  attr;
+	unsigned int q_index;
 
 	if (string_cmp(dev->qdisc->ops->id,
 		       shim_eth_qdisc_ops.id) == 0)
 		return 0;
 
-	sch = qdisc_create_dflt(netdev_get_tx_queue(dev, 0),
-			        &shim_eth_qdisc_ops, 0);
-	if (!sch) {
-		LOG_ERR("Problems creating shim-eth-qdisc");
-		return -1;
+	for (q_index = 0; q_index < dev->num_tx_queues; q_index++) {
+		sch = qdisc_create_dflt(netdev_get_tx_queue(dev, q_index),
+					&shim_eth_qdisc_ops, 0);
+		if (!sch) {
+			LOG_ERR("Problems creating shim-eth-qdisc");
+			return -1;
+		}
+
+		attr.nla_len = info->qdisc_max_size;
+		attr.nla_type = info->qdisc_enable_size;
+		if (shim_eth_qdisc_init(sch, &attr)) {
+			LOG_ERR("Problems initializing shim-eth-qdisc");
+			qdisc_destroy(sch);
+			return -1;
+		}
+
+		old_qdisc = dev->qdisc;
+
+		if (dev->flags & IFF_UP)
+			dev_deactivate(dev);
+
+		dev_graft_qdisc(netdev_get_tx_queue(dev, q_index), sch);
+		dev->qdisc = sch;
+
+		if (dev->flags & IFF_UP)
+			dev_activate(dev);
 	}
-
-	attr.nla_len = info->qdisc_max_size;
-	attr.nla_type = info->qdisc_enable_size;
-	if (shim_eth_qdisc_init(sch, &attr)) {
-		LOG_ERR("Problems initializing shim-eth-qdisc");
-		qdisc_destroy(sch);
-		return -1;
-	}
-
-	old_qdisc = dev->qdisc;
-
-	if (dev->flags & IFF_UP)
-		dev_deactivate(dev);
-
-	dev_graft_qdisc(netdev_get_tx_queue(dev, 0), sch);
-	dev->qdisc = sch;
-
-	if (dev->flags & IFF_UP)
-		dev_activate(dev);
 
 	return 0;
 }

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -878,8 +878,6 @@ int eth_vlan_update_qdisc(struct net_device *    dev,
 			return -1;
 		}
 
-		old_qdisc = dev->qdisc;
-
 		if (dev->flags & IFF_UP)
 			dev_deactivate(dev);
 
@@ -889,6 +887,8 @@ int eth_vlan_update_qdisc(struct net_device *    dev,
 		if (dev->flags & IFF_UP)
 			dev_activate(dev);
 	}
+
+	old_qdisc = dev->qdisc;
 
 	return 0;
 }

--- a/linux/net/rina/ipcps/shim-eth-vlan.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan.c
@@ -48,7 +48,7 @@
 #include "rinarp/rinarp.h"
 #include "rinarp/arp826-utils.h"
 
-#define DEFAULT_QDISC_MAX_SIZE 500
+#define DEFAULT_QDISC_MAX_SIZE 50
 #define DEFAULT_QDISC_ENABLE_SIZE 10
 
 /* FIXME: To be solved properly */

--- a/linux/net/rina/rmt.h
+++ b/linux/net/rina/rmt.h
@@ -58,6 +58,7 @@ struct rmt;
 enum flow_state {
         N1_PORT_STATE_ENABLED,
         N1_PORT_STATE_DISABLED,
+        N1_PORT_STATE_DO_NOT_DISABLE,
         N1_PORT_STATE_DEALLOCATED,
 };
 


### PR DESCRIPTION
Sander uncovered a bug in the qdisc used by the shim-eth-vlan: when the device had multiple tx queues only the first one was replaced (now all of them are). 

Also updated the default qdisc qsize to 500, since it seems a safe limit after testing in the VWall. The function of this qdisc is to cause the ports that use the physical device the qdisc is attached to to be blocked when the queue is full, and to unblock when the queue is almost empty (to avoid losing PDUs when the net device approaches saturation). 
Since the dev_queue_xmit operation cannot be called holding any locks, the sequence RMT write->call dev_queue_xmit, queue is full, shim returns -EAGAIN RMT blocks port can complete later than what it takes for the qdisc's queue to be drained and reach the "enable threshold", therefore the port may be enabled before it is disabled (it is a timing issue, race condition). The bigger is the difference between the qdisc q size and the enable threshold, the less likely this is to happen since it takes longer for the queue to be emptied (500 and 10 seem to be a safe value after experiments). Adding a timer that would unlock the port as a safety measure could be a plus, or other improvements/solutions for this issue can be considered after the review (with the limitation that we cannot change any of the Linux source code). The mechanism is ok for our current needs.
