### PR TITLE
misc/code-stats: add total diff w.r.t. IRATI v1.0.0

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -347,3 +347,9 @@ F: rina-tools/src/rina-cdap-echo/
 Test manager
 M: Bernat Gaston <bernat.gaston (at) i2cat.net>
 F: rina-tools/src/manager/
+
+
+Misc
+-------------
+M: Vincenzo Maffione <v.maffione (at) nextworks.it>
+F: misc/code-stats

--- a/misc/code-stats
+++ b/misc/code-stats
@@ -27,3 +27,6 @@ stats librina librina/include librina/src
 stats rinad rinad/src
 stats rina-tools rina-tools/src
 stats total linux/net/rina librina/include librina/src rinad/src rina-tools/src
+
+echo -e "\nCode editing statistics between IRATI 1.0.0 and current pristine development branch"
+git diff --stat v1.0.0 pristine-1.3 librina/ rinad/ rina-tools/src/ linux/ plugins/ | tail -n 1


### PR DESCRIPTION
This patch adds a code statistic, showing how many lines have
been edited since the end of IRATI.

maintainers:
@vmaffione
@msune 