### PR TITLE
Track selected policy sets

### DIFF
--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -165,7 +165,7 @@ struct PsInfo {
 	PsInfo(const std::string& n, const std::string& c,
 	       const std::string& v) : name(n), app_entity(c), version(v) { }
 
-	std::string toString() const { return name + std::string("/") + app_entity; }
+	std::string toString() const { return app_entity + std::string("/") + name; }
 };
 
 struct PsFactory {

--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -164,6 +164,8 @@ struct PsInfo {
 	PsInfo() { }
 	PsInfo(const std::string& n, const std::string& c,
 	       const std::string& v) : name(n), app_entity(c), version(v) { }
+
+	std::string toString() const { return name + std::string("/") + app_entity; }
 };
 
 struct PsFactory {

--- a/rinad/etc/default.dif
+++ b/rinad/etc/default.dif
@@ -38,8 +38,8 @@
                         }
                    }
               }
-          } 
-       }, { 
+          }
+       }, {
      	 "name" : "reliablewithflowcontrol",
          "id" : 2,
          "partialDelivery" : false,
@@ -73,7 +73,7 @@
              		}
            	  }
          }
-     } ], 
+     } ],
      "knownIPCProcessAddresses" : [ {
     	 "apName" : "test1.IRATI",
     	 "apInstance" : "1",
@@ -82,16 +82,16 @@
     	 "apName" : "test2.IRATI",
     	 "apInstance" : "1",
     	 "address" : 17
-  	} ], 
+  	} ],
   	"addressPrefixes" : [ {
     	 "addressPrefix" : 0,
     	 "organization" : "N.Bourbaki"
   	  }, {
     	 "addressPrefix" : 16,
     	 "organization" : "IRATI"
-      } ], 
+      } ],
      "rmtConfiguration" : {
-        "pftConfiguration" : {     
+        "pffConfiguration" : {
           "policySet" : {
             "name" : "default",
             "version" : "0"
@@ -103,9 +103,9 @@
         }
      },
      "enrollmentTaskConfiguration" : {
-        "policySet" : { 
+        "policySet" : {
            "name" : "default",
-           "version" : "1", 
+           "version" : "1",
            "parameters" : [{
                "name"  : "enrollTimeoutInMs",
                "value" : "10000"
@@ -124,10 +124,10 @@
              }]
         }
      },
-     "flowAllocatorConfiguration" : { 
-         "policySet" : { 
+     "flowAllocatorConfiguration" : {
+         "policySet" : {
            "name" : "default",
-           "version" : "1" 
+           "version" : "1"
           }
      },
      "namespaceManagerConfiguration" : {
@@ -143,7 +143,7 @@
            }
      },
      "resourceAllocatorConfiguration" : {
-         "pduftgConfiguration" : {    
+         "pduftgConfiguration" : {
            "policySet" : {
              "name" : "default",
              "version" : "0"
@@ -171,7 +171,7 @@
              "value" : "101"
            },{
              "name"  : "waitUntilAgeIncrement",
-             "value" : "997" 
+             "value" : "997"
            },{
              "name"  : "routingAlgorithm",
              "value" : "Dijkstra"

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -148,7 +148,7 @@ IPCMConsole::IPCMConsole(const unsigned int port_) :
 				"<object-name>");
 	commands_map["show-catalog"] =
 			ConsoleCmdInfo(&IPCMConsole::show_catalog,
-				"USAGE: show-catalog");
+				"USAGE: show-catalog [<component-name>]");
 
 	rina::ThreadAttributes ta;
 	worker = new rina::Thread(console_function, this, &ta);
@@ -852,12 +852,17 @@ int IPCMConsole::read_ipcp_ribobj(std::vector<std::string>& args)
 
 int IPCMConsole::show_catalog(std::vector<std::string>& args)
 {
-	if (args.size() != 1) {
+	if (args.size() < 1) {
 		outstream << commands_map[args[0]].usage << endl;
 		return CMDRETCONT;
 	}
 
-	outstream << IPCManager->catalog.toString();
+	if (args.size() == 1) {
+		outstream << IPCManager->catalog.toString();
+
+	} else {
+		outstream << IPCManager->catalog.toString(args[1]);
+	}
 
 	return CMDRETCONT;
 }

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -856,11 +856,18 @@ int IPCMConsole::read_ipcp_ribobj(std::vector<std::string>& args)
 
 int IPCMConsole::show_catalog(std::vector<std::string>& args)
 {
-	if (args.size() == 1) {
+	switch (args.size()) {
+	case 1:
 		outstream << IPCManager->catalog.toString();
+		break;
 
-	} else {
+	case 2:
 		outstream << IPCManager->catalog.toString(args[1]);
+		break;
+
+	default:
+		outstream << commands_map[args[0]].usage << endl;
+		break;
 	}
 
 	return CMDRETCONT;

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -150,6 +150,10 @@ IPCMConsole::IPCMConsole(const unsigned int port_) :
 			ConsoleCmdInfo(&IPCMConsole::show_catalog,
 				"USAGE: show-catalog [<component-name>]");
 
+	commands_map["update-catalog"] =
+			ConsoleCmdInfo(&IPCMConsole::update_catalog,
+				"USAGE: update-catalog");
+
 	rina::ThreadAttributes ta;
 	worker = new rina::Thread(console_function, this, &ta);
 	worker->start();
@@ -852,11 +856,6 @@ int IPCMConsole::read_ipcp_ribobj(std::vector<std::string>& args)
 
 int IPCMConsole::show_catalog(std::vector<std::string>& args)
 {
-	if (args.size() < 1) {
-		outstream << commands_map[args[0]].usage << endl;
-		return CMDRETCONT;
-	}
-
 	if (args.size() == 1) {
 		outstream << IPCManager->catalog.toString();
 
@@ -866,4 +865,13 @@ int IPCMConsole::show_catalog(std::vector<std::string>& args)
 
 	return CMDRETCONT;
 }
+
+int IPCMConsole::update_catalog(std::vector<std::string>& args)
+{
+	IPCManager->update_catalog(this);
+	outstream << "Catalog updated" << endl;
+
+	return CMDRETCONT;
+}
+
 }//namespace rinad

--- a/rinad/src/ipcm/addons/console.h
+++ b/rinad/src/ipcm/addons/console.h
@@ -94,6 +94,7 @@ class IPCMConsole : public Addon {
                 int show_dif_templates(std::vector<std::string>& args);
                 int read_ipcp_ribobj(std::vector<std::string>& args);
                 int show_catalog(std::vector<std::string>& args);
+                int update_catalog(std::vector<std::string>& args);
 
         public:
                 IPCMConsole(const unsigned int port);

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -216,8 +216,8 @@ int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,
 		int ret = load_policy_set(addon, ipcp_id, *i);
 
 		if (ret) {
-			LOG_WARN("Failed to load policy-set %s/%s",
-				  i->app_entity.c_str(), i->name.c_str());
+			LOG_WARN("Failed to load policy-set %s",
+				 i->toString().c_str());
 		}
 
 		// Record that this IPCP has select this policy set (TODO

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -328,6 +328,7 @@ int Catalog::policy_set_selected(const rina::PsInfo& ps_info,
 	rsrc = rsrc_lookup(ps_info.app_entity, id);
 	if (rsrc) {
 		rsrc->ps->selected.erase(id);
+		rsrc->ps = cpsinfo;
 	} else {
 		add_resource(ps_info.app_entity, id, cpsinfo);
 	}

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -410,13 +410,13 @@ string Catalog::toString() const
 			   << endl << "    ps version: " << cps->version
 			   << endl << "    plugin: " << cps->plugin->path
 			   << "/" << cps->plugin->name
-			   << ", loaded for ipcps [ ";
+			   << endl << "    loaded for ipcps [ ";
 			for (set<unsigned int>::iterator
 				ii = cps->plugin->loaded.begin();
 					ii != cps->plugin->loaded.end(); ii++) {
 				ss << *ii << " ";
 			}
-			ss << "]" << ", selected for resources [ ";
+			ss << "]" << endl << "    selected for resources [ ";
 			for (set<unsigned int>::iterator
 				ii = cps->selected.begin();
 					ii != cps->selected.end(); ii++) {

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -413,6 +413,8 @@ string Catalog::toString(const CatalogPsInfo *cps) const
 		ss << *ii << " ";
 	}
 	ss << "]" << endl;
+
+	return ss.str();
 }
 
 string Catalog::toString() const
@@ -443,8 +445,7 @@ void Catalog::print() const
 	LOG_INFO("%s", toString().c_str());
 }
 
-string
-Catalog::toString(const string& component) const
+string Catalog::toString(const string& component) const
 {
 	rina::ReadScopedLock rlock(const_cast<Catalog *>(this)->rwlock);
 	map<string, map< string, CatalogPsInfo * > >::const_iterator mit;

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -164,11 +164,15 @@ void Catalog::psinfo_from_psconfig(list< rina::PsInfo >& psinfo_list,
 				   const string& component,
 				   const rina::PolicyConfig& pconfig)
 {
-	if (pconfig.name_ != string()) {
-		psinfo_list.push_back(rina::PsInfo(pconfig.name_,
-						   component,
-						   pconfig.version_));
+	std::string ps_name = pconfig.name_;
+	std::string ps_version = pconfig.version_;
+
+	if (ps_name == string()) {
+		ps_name = "default";
+		ps_version = "";
 	}
+
+	psinfo_list.push_back(rina::PsInfo(ps_name, component, ps_version));
 }
 
 int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -193,7 +193,8 @@ int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,
 	return 0;
 }
 
-int Catalog::plugin_loaded(const string& plugin_name, unsigned int ipcp_id)
+int Catalog::plugin_loaded(const string& plugin_name, unsigned int ipcp_id,
+			   bool load)
 {
 	// Lookup again (the plugin or policy set may have disappeared
 	// in the meanwhile) under the write lock, and update the
@@ -201,13 +202,17 @@ int Catalog::plugin_loaded(const string& plugin_name, unsigned int ipcp_id)
 	rina::WriteScopedLock wlock(rwlock);
 
 	if (plugins.count(plugin_name) == 0) {
-		LOG_WARN("Plugin %s disappeared while "
-				"loading", plugin_name.c_str());
+		LOG_WARN("Plugin %s it's not in the catalog",
+			 plugin_name.c_str());
 		return -1;
 	}
 
-	// Mark the plugin as loaded for the specified IPCP
-	plugins[plugin_name].loaded.insert(ipcp_id);
+	// Mark the plugin as (un)loaded for the specified IPCP
+	if (load) {
+		plugins[plugin_name].loaded.insert(ipcp_id);
+	} else {
+		plugins[plugin_name].loaded.erase(ipcp_id);
+	}
 }
 
 int Catalog::load_policy_set(Addon *addon, unsigned int ipcp_id,

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -443,7 +443,8 @@ void Catalog::print() const
 	LOG_INFO("%s", toString().c_str());
 }
 
-int Catalog::print(const string& component) const
+string
+Catalog::toString(const string& component) const
 {
 	rina::ReadScopedLock rlock(const_cast<Catalog *>(this)->rwlock);
 	map<string, map< string, CatalogPsInfo * > >::const_iterator mit;
@@ -452,7 +453,7 @@ int Catalog::print(const string& component) const
 
 	mit = policy_sets.find(component);
 	if (mit == policy_sets.end()) {
-		return -1;
+		return string();
 	}
 
 	for (cmit = mit->second.begin(); cmit != mit->second.end(); cmit++) {
@@ -463,9 +464,7 @@ int Catalog::print(const string& component) const
 
 	ss << "      ====================================" << endl;
 
-	LOG_INFO("%s", ss.str().c_str());
-
-	return 0;
+	return ss.str();
 }
 
 } // namespace rinad

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -408,6 +408,12 @@ string Catalog::toString() const
 					ii != cps->plugin->loaded.end(); ii++) {
 				ss << *ii << " ";
 			}
+			ss << "]" << ", selected for resources [ ";
+			for (set<unsigned int>::iterator
+				ii = cps->selected.begin();
+					ii != cps->selected.end(); ii++) {
+				ss << *ii << " ";
+			}
 			ss << "]" << endl;
 		}
 	}

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -102,9 +102,8 @@ public:
 	void ipcp_destroyed(unsigned int ipcp_id);
 
 	void print() const;
-	int print(const std::string& component) const;
 	std::string toString() const;
-	std::string toString(const CatalogPsInfo *cps) const;
+	std::string toString(const std::string& component) const;
 
 private:
 	void psinfo_from_psconfig(std::list< rina::PsInfo >& psinfo_list,
@@ -118,6 +117,8 @@ private:
 
 	int add_resource(const std::string& component,
 			 unsigned int id, CatalogPsInfo *);
+
+	std::string toString(const CatalogPsInfo *cps) const;
 
 	std::map<std::string,
 		 std::map<std::string, CatalogPsInfo*>

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -75,8 +75,8 @@ public:
 	int load_policy_set(Addon *addon, unsigned int ipcp_id,
 			    const rina::PsInfo& psinfo);
 
-	int load_plugin(Addon *addon, unsigned int ipcp_id,
-			const std::string& plugin_name);
+	int plugin_loaded(const std::string& plugin_name,
+			  unsigned int ipcp_id);
 
 	void ipcp_destroyed(unsigned int ipcp_id);
 

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -102,7 +102,9 @@ public:
 	void ipcp_destroyed(unsigned int ipcp_id);
 
 	void print() const;
+	int print(const std::string& component) const;
 	std::string toString() const;
+	std::string toString(const CatalogPsInfo *cps) const;
 
 private:
 	void psinfo_from_psconfig(std::list< rina::PsInfo >& psinfo_list,

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -75,6 +75,9 @@ public:
 	int load_policy_set(Addon *addon, unsigned int ipcp_id,
 			    const rina::PsInfo& psinfo);
 
+	int load_plugin(Addon *addon, unsigned int ipcp_id,
+			const std::string& plugin_name);
+
 	void ipcp_destroyed(unsigned int ipcp_id);
 
 	void print() const;

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -76,7 +76,7 @@ public:
 			    const rina::PsInfo& psinfo);
 
 	int plugin_loaded(const std::string& plugin_name,
-			  unsigned int ipcp_id);
+			  unsigned int ipcp_id, bool load);
 
 	void ipcp_destroyed(unsigned int ipcp_id);
 

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -644,7 +644,7 @@ rinad::DIFTemplate * parse_dif_template_config(const Json::Value & root,
 			     "policySet",
 			     rc.policy_set_);
 
-	        Json::Value pft_conf = rmt_conf["pftConfiguration"];
+	        Json::Value pft_conf = rmt_conf["pffConfiguration"];
                 if (pft_conf != 0) {
                         rina::PFTConfiguration pftc;
 

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -111,7 +111,7 @@ void IPCManager_::init(const std::string& loglevel, std::string& config_file)
 
 		// Load the plugins catalog
 		catalog.import();
-		catalog.print();
+		//catalog.print();
 
 		// Initialize the I/O thread
 		io_thread = new rina::Thread(io_loop_trampoline,

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1120,7 +1120,7 @@ extract_subcomponent_name(const string& cpath)
 	size_t l = cpath.rfind(".");
 
 	if (l == string::npos) {
-		return string();
+		return cpath;
 	}
 
 	return cpath.substr(l+1);
@@ -1143,7 +1143,6 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 
 		ps_info.name = ps_name;
 		ps_info.app_entity = extract_subcomponent_name(component_path);
-		LOG_INFO("EXTRACTED %s", ps_info.app_entity.c_str());
 		ret = catalog.load_policy_set(callee, ipcp_id, ps_info);
 		if (ret) {
 			throw rina::Exception();

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1259,7 +1259,7 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		//First try to see if its a kernel module
 		if (plugin_load_kernel(plugin_name, load) == IPCM_SUCCESS) {
 			promise->ret = IPCM_SUCCESS;
-			catalog.plugin_loaded(plugin_name, ipcp_id);
+			catalog.plugin_loaded(plugin_name, ipcp_id, load);
 
 			return IPCM_SUCCESS;
 		}
@@ -1275,7 +1275,8 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		//Auto release the read lock
 		rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-		trans = new IPCPpluginTransState(callee, promise, ipcp->get_id(), plugin_name);
+		trans = new IPCPpluginTransState(callee, promise, ipcp->get_id(),
+						 plugin_name, load);
 		if(!trans){
 			ss << "Unable to allocate memory for the transaction object. Out of memory! ";
 			FLUSH_LOG(ERR, ss);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1324,6 +1324,14 @@ IPCManager_::plugin_get_info(const std::string& plugin_name,
 }
 
 ipcm_res_t
+IPCManager_::update_catalog(Addon* callee)
+{
+	catalog.import();
+
+	return IPCM_SUCCESS;
+}
+
+ipcm_res_t
 IPCManager_::read_ipcp_ribobj(Addon* callee, Promise* promise,
 			      const unsigned short ipcp_id,
 			      const std::string& object_class,

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1253,12 +1253,13 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 {
 	ostringstream ss;
 	IPCMIPCProcess *ipcp;
-	IPCPTransState* trans;
+	IPCPpluginTransState* trans;
 
 	try {
 		//First try to see if its a kernel module
 		if (plugin_load_kernel(plugin_name, load) == IPCM_SUCCESS) {
 			promise->ret = IPCM_SUCCESS;
+			catalog.plugin_loaded(plugin_name, ipcp_id);
 
 			return IPCM_SUCCESS;
 		}
@@ -1274,7 +1275,7 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		//Auto release the read lock
 		rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-		trans = new IPCPTransState(callee, promise, ipcp->get_id());
+		trans = new IPCPpluginTransState(callee, promise, ipcp->get_id(), plugin_name);
 		if(!trans){
 			ss << "Unable to allocate memory for the transaction object. Out of memory! ";
 			FLUSH_LOG(ERR, ss);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1134,7 +1134,7 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 {
 	ostringstream ss;
 	IPCMIPCProcess *ipcp;
-	IPCPTransState* trans;
+	IPCPSelectPsTransState* trans;
 
 	try {
 		/* Load the policy set in the catalog. */
@@ -1160,7 +1160,8 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 		//Auto release the read lock
 		rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-		trans = new IPCPTransState(callee, promise, ipcp->get_id());
+		trans = new IPCPSelectPsTransState(callee, promise, ipcp->get_id(),
+						   ps_info, ipcp->get_id());
 		if(!trans){
 			ss << "Unable to allocate memory for the transaction object. Out of memory! ";
 			FLUSH_LOG(ERR, ss);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1114,6 +1114,18 @@ IPCManager_::set_policy_set_param(Addon* callee, Promise* promise,
 	return IPCM_PENDING;
 }
 
+static string
+extract_subcomponent_name(const string& cpath)
+{
+	size_t l = cpath.rfind(".");
+
+	if (l == string::npos) {
+		return string();
+	}
+
+	return cpath.substr(l+1);
+}
+
 ipcm_res_t
 IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 		const unsigned short ipcp_id,
@@ -1125,6 +1137,19 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 	IPCPTransState* trans;
 
 	try {
+		/* Load the policy set in the catalog. */
+		rina::PsInfo ps_info;
+		int ret;
+
+		ps_info.name = ps_name;
+		ps_info.app_entity = extract_subcomponent_name(component_path);
+		LOG_INFO("EXTRACTED %s", ps_info.app_entity.c_str());
+		ret = catalog.load_policy_set(callee, ipcp_id, ps_info);
+		if (ret) {
+			throw rina::Exception();
+		}
+
+		/* Select the policy set. */
 		ipcp = lookup_ipcp_by_id(ipcp_id);
 
 		if(!ipcp){

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -496,6 +496,13 @@ public:
 			      const std::string& object_name);
 
 	//
+	// Update policy-set catalog, with the plugins stored in
+	// the pluginsPaths configuration variable
+	//
+	// @ret IPCM_FAILURE on failure, otherwise the IPCM_SUCCESS
+	ipcm_res_t update_catalog(Addon* callee);
+
+	//
 	// Get the current logging debug level
 	//
 	std::string get_log_level() const;

--- a/rinad/src/ipcm/ipcp-handlers.h
+++ b/rinad/src/ipcm/ipcp-handlers.h
@@ -68,6 +68,25 @@ public:
 	int slave_ipcp_id;
 };
 
+/**
+* IPCP plugin load transaction state
+*/
+class IPCPpluginTransState: public TransactionState{
+
+public:
+	IPCPpluginTransState(Addon* callee, Promise* promise, int _ipcp_id,
+			   const std::string& _name)
+					: TransactionState(callee, promise),
+					  ipcp_id(_ipcp_id),
+					  plugin_name(_name) {}
+	virtual ~IPCPpluginTransState(){};
+
+	//IPCP identifier
+	int ipcp_id;
+	//Plugin name
+	std::string plugin_name;
+};
+
 }//rinad namespace
 
 #endif  /* __IPCP_HANDLERS_H__ */

--- a/rinad/src/ipcm/ipcp-handlers.h
+++ b/rinad/src/ipcm/ipcp-handlers.h
@@ -75,16 +75,20 @@ class IPCPpluginTransState: public TransactionState{
 
 public:
 	IPCPpluginTransState(Addon* callee, Promise* promise, int _ipcp_id,
-			   const std::string& _name)
+			   const std::string& _name, bool _l)
 					: TransactionState(callee, promise),
 					  ipcp_id(_ipcp_id),
-					  plugin_name(_name) {}
+					  plugin_name(_name), load(_l) {}
 	virtual ~IPCPpluginTransState(){};
 
-	//IPCP identifier
+	// IPCP identifier
 	int ipcp_id;
-	//Plugin name
+
+	// Plugin name
 	std::string plugin_name;
+
+	// Is this a load or unload operation ?
+	bool load;
 };
 
 }//rinad namespace

--- a/rinad/src/ipcm/ipcp-handlers.h
+++ b/rinad/src/ipcm/ipcp-handlers.h
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include <librina/common.h>
+#include <librina/application.h>
 #include <librina/ipc-manager.h>
 #include <librina/patterns.h>
 
@@ -89,6 +90,30 @@ public:
 
 	// Is this a load or unload operation ?
 	bool load;
+};
+
+/**
+* IPCP select-policy-set transaction state
+*/
+class IPCPSelectPsTransState: public TransactionState{
+
+public:
+	IPCPSelectPsTransState(Addon* callee, Promise* promise,
+			       unsigned _ipcp_id,
+			       const rina::PsInfo& _ps_info, int _id)
+					: TransactionState(callee, promise),
+					  ipcp_id(_ipcp_id),
+					  ps_info(_ps_info), id(_id) { }
+	virtual ~IPCPSelectPsTransState(){};
+
+	// IPCP identifier
+	unsigned int ipcp_id;
+
+	// The policy set to be selected
+	rina::PsInfo ps_info;
+
+	// IPCP or port-id identifier (to be used for the catalog)
+	unsigned int id;
 };
 
 }//rinad namespace

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -109,13 +109,14 @@ void IPCManager_::ipc_process_plugin_load_response_handler(rina::PluginLoadRespo
         rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
         ss << "plugin-load-op [plugin=" << trans->plugin_name <<
-	      "]completed on IPC process "
+	      ", load=" << trans->load << "] completed on IPC process "
 	       << ipcp->get_name().toString()
 	       << " [success=" << success << "]" << endl;
         FLUSH_LOG(INFO, ss);
 
 	if (success) {
-		catalog.plugin_loaded(trans->plugin_name, trans->ipcp_id);
+		catalog.plugin_loaded(trans->plugin_name, trans->ipcp_id,
+				      trans->load);
 	}
 
 	//Mark as completed

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -131,10 +131,11 @@ void IPCManager_::ipc_process_select_policy_set_response_handler(
 	ostringstream ss;
         int ret = -1;
 
-	IPCPTransState* trans = get_transaction_state<IPCPTransState>(event->sequenceNumber);
+	IPCPSelectPsTransState* trans = get_transaction_state<IPCPSelectPsTransState>(event->sequenceNumber);
 
 	if(!trans){
-		ss << ": Warning: unknown select policy response received: "<<event->sequenceNumber<<endl;
+		ss << ": Warning: unknown select policy response received: "
+			<<event->sequenceNumber<<endl;
 		FLUSH_LOG(WARN, ss);
 		return;
 	}
@@ -156,6 +157,10 @@ void IPCManager_::ipc_process_select_policy_set_response_handler(
 	       << ipcp->get_name().toString() <<
 		" [success=" << success << "]" << endl;
 	FLUSH_LOG(INFO, ss);
+
+	if (success) {
+		catalog.policy_set_selected(trans->ps_info, trans->id);
+	}
 
 	//Mark as completed
 	trans->completed(success ? IPCM_SUCCESS : IPCM_FAILURE);

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -84,7 +84,7 @@ void IPCManager_::ipc_process_plugin_load_response_handler(rina::PluginLoadRespo
 	ostringstream ss;
         int ret = -1;
 
-        IPCPTransState* trans = get_transaction_state<IPCPTransState>(event->sequenceNumber);
+        IPCPpluginTransState* trans = get_transaction_state<IPCPpluginTransState>(event->sequenceNumber);
 
         if(!trans){
         	ss << ": Warning: unknown plugin load response received: "
@@ -108,10 +108,15 @@ void IPCManager_::ipc_process_plugin_load_response_handler(rina::PluginLoadRespo
         //Auto release the read lock
         rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-        ss << "plugin-load-op completed on IPC process "
+        ss << "plugin-load-op [plugin=" << trans->plugin_name <<
+	      "]completed on IPC process "
 	       << ipcp->get_name().toString()
 	       << " [success=" << success << "]" << endl;
         FLUSH_LOG(INFO, ss);
+
+	if (success) {
+		catalog.plugin_loaded(trans->plugin_name, trans->ipcp_id);
+	}
 
 	//Mark as completed
 	trans->completed(success ? IPCM_SUCCESS : IPCM_FAILURE);


### PR DESCRIPTION
This PR introduces the following changes:
   - Add support to keep track of which policy-set is currently being selected for a given component of an IPCP.
   - Improved the show-catalog IPCM console command to show the new information
   - Improved the show-catalog IPCM console commend to show only information related to a single component (e.g. show-catalog pff).
   - Reworking of the catalog implementation, to use pointers instead of iterators.
   - Add update-catalog command, to rescan the pluginsPaths directory and update the catalog.
   - Some minor fixes to configuration files and implementation of a simple toString() method in librina

You can test by using select-policy-set command in the IPCM console and examining how the show-catalog output changes accordingly.

MAINTAINERS:
@edugrasa 
@msune 