### PR TITLE
Userspace plugins: replace init() function with get_factories()

### DIFF
--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -165,7 +165,7 @@ struct PsInfo {
 	PsInfo(const std::string& n, const std::string& c,
 	       const std::string& v) : name(n), app_entity(c), version(v) { }
 
-	std::string toString() const { return name + std::string("/") + app_entity; }
+	std::string toString() const { return app_entity + std::string("/") + name; }
 };
 
 struct PsFactory {

--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -191,6 +191,8 @@ struct PsFactory {
         /// Reference counter for the number of policy sets created
         /// by this factory
         unsigned int refcnt;
+
+	PsFactory() : create(NULL), destroy(NULL) { }
 };
 
 /// A class that can manage the policies of an application process

--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -164,6 +164,8 @@ struct PsInfo {
 	PsInfo() { }
 	PsInfo(const std::string& n, const std::string& c,
 	       const std::string& v) : name(n), app_entity(c), version(v) { }
+
+	std::string toString() const { return name + std::string("/") + app_entity; }
 };
 
 struct PsFactory {

--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -148,8 +148,8 @@ extern "C" {
         typedef IPolicySet *(*app_entity_factory_create_t)(
                                                 ApplicationEntity * ctx);
         typedef void (*app_entity_factory_destroy_t)(IPolicySet * ps);
-	typedef int (*plugin_get_factories_t)(const std::string& plugin_name,
-					      std::vector<struct rina::PsFactory>& factories);
+	typedef int (*plugin_get_factories_t)(
+		     std::vector<struct rina::PsFactory>& factories);
 }
 
 /// Info about a policy set
@@ -201,7 +201,6 @@ public:
 	virtual std::vector<PsFactory>::iterator
                   psFactoryLookup(const PsInfo& ps_info);
 	virtual int psFactoryPublish(const PsFactory& factory,
-				     const std::string& plugin_name,
 				     const std::list<PsInfo>& manifest_psets);
 	virtual int psFactoryUnpublish(const PsInfo& ps_info);
 	virtual IPolicySet * psCreate(const std::string& ae_name,

--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -142,12 +142,14 @@ private:
 	ThreadSafeMapOfPointers<std::string, ApplicationEntityInstance> instances;
 };
 
+struct PsFactory;
+
 extern "C" {
         typedef IPolicySet *(*app_entity_factory_create_t)(
                                                 ApplicationEntity * ctx);
         typedef void (*app_entity_factory_destroy_t)(IPolicySet * ps);
-        typedef int (*plugin_init_function_t)(AppPolicyManager * app_process,
-                                              const std::string& plugin_name);
+	typedef int (*plugin_get_factories_t)(const std::string& plugin_name,
+					      std::vector<struct rina::PsFactory>& factories);
 }
 
 /// Info about a policy set
@@ -165,7 +167,13 @@ struct PsInfo {
 	PsInfo(const std::string& n, const std::string& c,
 	       const std::string& v) : name(n), app_entity(c), version(v) { }
 
-	std::string toString() const { return app_entity + std::string("/") + name; }
+	std::string toString() const
+		{ return app_entity + std::string("/") + name; }
+
+	bool operator==(const PsInfo& o) const
+		{ return o.name == name && o.app_entity == app_entity; }
+
+	bool operator!=(const PsInfo& o) const { return !(*this == o); }
 };
 
 struct PsFactory {
@@ -192,7 +200,9 @@ public:
 	virtual ~AppPolicyManager();
 	virtual std::vector<PsFactory>::iterator
                   psFactoryLookup(const PsInfo& ps_info);
-	virtual int psFactoryPublish(const PsFactory& factory);
+	virtual int psFactoryPublish(const PsFactory& factory,
+				     const std::string& plugin_name,
+				     const std::list<PsInfo>& manifest_psets);
 	virtual int psFactoryUnpublish(const PsInfo& ps_info);
 	virtual IPolicySet * psCreate(const std::string& ae_name,
                                       const std::string& name,
@@ -209,7 +219,6 @@ protected:
 private:
 	std::vector<rina::PsFactory> ae_policy_factories;
 	std::map< std::string, void * > plugins_handles;
-	std::list<PsInfo> manifest_policy_sets;
 	ReadWriteLockable rwlock;
 };
 

--- a/librina/src/application.cc
+++ b/librina/src/application.cc
@@ -232,6 +232,17 @@ int AppPolicyManager::psFactoryPublish(const PsFactory& factory,
 				"published. Discarding it.",
 				factory.info.toString().c_str(),
 				factory.plugin_name.c_str());
+		return -1;
+	}
+
+	if (!factory.create || !factory.destroy) {
+		LOG_ERR("Factory %s in plugin %s has invalid factory "
+			"methods: constructor=%p, destructor=%p. "
+			"Discarding it.",
+			factory.info.toString().c_str(),
+			factory.plugin_name.c_str(),
+			factory.create, factory.destroy);
+		return -1;
 	}
 
 	/* Add the new factory to the internal factory list. */

--- a/librina/src/application.cc
+++ b/librina/src/application.cc
@@ -204,7 +204,6 @@ AppPolicyManager::psFactoryLookup(const PsInfo& ps_info)
 }
 
 int AppPolicyManager::psFactoryPublish(const PsFactory& factory,
-				       const std::string& plugin_name,
 				       const std::list<PsInfo>& manifest_psets)
 {
 	bool in_manifest = false;
@@ -222,7 +221,7 @@ int AppPolicyManager::psFactoryPublish(const PsFactory& factory,
 		LOG_WARN("Plugin %s contains policy set factory %s "
 				"but such factory was not declared in the "
 				"manifest. Discarding it.",
-				plugin_name.c_str(),
+				factory.plugin_name.c_str(),
 				factory.info.toString().c_str());
 		return -1;
 	}
@@ -232,7 +231,7 @@ int AppPolicyManager::psFactoryPublish(const PsFactory& factory,
 		LOG_ERR("Factory %s in plugin %s already "
 				"published. Discarding it.",
 				factory.info.toString().c_str(),
-				plugin_name.c_str());
+				factory.plugin_name.c_str());
 	}
 
 	/* Add the new factory to the internal factory list. */
@@ -362,7 +361,7 @@ int AppPolicyManager::plugin_load(const std::string& plugin_dir,
 
         /* Invoke the plugin initialization function, that will publish
          * pluggable components. */
-        ret = get_factories(plugin_name, factories);
+        ret = get_factories(factories);
         if (ret) {
                 dlclose(handle);
                 LOG_ERR("Failed to initialize plugin %s",
@@ -375,7 +374,8 @@ int AppPolicyManager::plugin_load(const std::string& plugin_dir,
         LOG_INFO("Plugin %s loaded successfully", plugin_name.c_str());
 
 	for (unsigned int i = 0; i < factories.size(); i++) {
-		psFactoryPublish(factories[i], plugin_name, manifest_psets);
+		factories[i].plugin_name = plugin_name;
+		psFactoryPublish(factories[i], manifest_psets);
 	}
 
         return 0;

--- a/librina/wrap/librina.i
+++ b/librina/wrap/librina.i
@@ -394,9 +394,10 @@ DOWNCAST_IPC_EVENT_CONSUMER(eventTimedWait);
 %rename(differs) rina::FlowInformation::operator!=(const FlowInformation &other) const;
 %rename(equals) rina::rib::RIBObjectData::operator==(const RIBObjectData &other) const;
 %rename(differs) rina::rib::RIBObjectData::operator!=(const RIBObjectData &other) const;
-
 %rename(equals) rina::Neighbor::operator==(const Neighbor &other) const;
 %rename(differs) rina::Neighbor::operator!=(const Neighbor &other) const;
+%rename(equals) rina::PsInfo::operator==(const PsInfo &other) const;
+%rename(differs) rina::PsInfo::operator!=(const PsInfo &other) const;
 
 %include "librina/exceptions.h"
 %include "librina/patterns.h"

--- a/rinad/etc/default.dif
+++ b/rinad/etc/default.dif
@@ -38,8 +38,8 @@
                         }
                    }
               }
-          } 
-       }, { 
+          }
+       }, {
      	 "name" : "reliablewithflowcontrol",
          "id" : 2,
          "partialDelivery" : false,
@@ -73,7 +73,7 @@
              		}
            	  }
          }
-     } ], 
+     } ],
      "knownIPCProcessAddresses" : [ {
     	 "apName" : "test1.IRATI",
     	 "apInstance" : "1",
@@ -82,16 +82,16 @@
     	 "apName" : "test2.IRATI",
     	 "apInstance" : "1",
     	 "address" : 17
-  	} ], 
+  	} ],
   	"addressPrefixes" : [ {
     	 "addressPrefix" : 0,
     	 "organization" : "N.Bourbaki"
   	  }, {
     	 "addressPrefix" : 16,
     	 "organization" : "IRATI"
-      } ], 
+      } ],
      "rmtConfiguration" : {
-        "pftConfiguration" : {     
+        "pffConfiguration" : {
           "policySet" : {
             "name" : "default",
             "version" : "0"
@@ -103,9 +103,9 @@
         }
      },
      "enrollmentTaskConfiguration" : {
-        "policySet" : { 
+        "policySet" : {
            "name" : "default",
-           "version" : "1", 
+           "version" : "1",
            "parameters" : [{
                "name"  : "enrollTimeoutInMs",
                "value" : "10000"
@@ -124,10 +124,10 @@
              }]
         }
      },
-     "flowAllocatorConfiguration" : { 
-         "policySet" : { 
+     "flowAllocatorConfiguration" : {
+         "policySet" : {
            "name" : "default",
-           "version" : "1" 
+           "version" : "1"
           }
      },
      "namespaceManagerConfiguration" : {
@@ -143,7 +143,7 @@
            }
      },
      "resourceAllocatorConfiguration" : {
-         "pduftgConfiguration" : {    
+         "pduftgConfiguration" : {
            "policySet" : {
              "name" : "default",
              "version" : "0"
@@ -171,7 +171,7 @@
              "value" : "101"
            },{
              "name"  : "waitUntilAgeIncrement",
-             "value" : "997" 
+             "value" : "997"
            },{
              "name"  : "routingAlgorithm",
              "value" : "Dijkstra"

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -148,7 +148,7 @@ IPCMConsole::IPCMConsole(const unsigned int port_) :
 				"<object-name>");
 	commands_map["show-catalog"] =
 			ConsoleCmdInfo(&IPCMConsole::show_catalog,
-				"USAGE: show-catalog");
+				"USAGE: show-catalog [<component-name>]");
 
 	rina::ThreadAttributes ta;
 	worker = new rina::Thread(console_function, this, &ta);
@@ -852,12 +852,17 @@ int IPCMConsole::read_ipcp_ribobj(std::vector<std::string>& args)
 
 int IPCMConsole::show_catalog(std::vector<std::string>& args)
 {
-	if (args.size() != 1) {
+	if (args.size() < 1) {
 		outstream << commands_map[args[0]].usage << endl;
 		return CMDRETCONT;
 	}
 
-	outstream << IPCManager->catalog.toString();
+	if (args.size() == 1) {
+		outstream << IPCManager->catalog.toString();
+
+	} else {
+		outstream << IPCManager->catalog.toString(args[1]);
+	}
 
 	return CMDRETCONT;
 }

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -150,6 +150,10 @@ IPCMConsole::IPCMConsole(const unsigned int port_) :
 			ConsoleCmdInfo(&IPCMConsole::show_catalog,
 				"USAGE: show-catalog [<component-name>]");
 
+	commands_map["update-catalog"] =
+			ConsoleCmdInfo(&IPCMConsole::update_catalog,
+				"USAGE: update-catalog");
+
 	rina::ThreadAttributes ta;
 	worker = new rina::Thread(console_function, this, &ta);
 	worker->start();
@@ -852,11 +856,6 @@ int IPCMConsole::read_ipcp_ribobj(std::vector<std::string>& args)
 
 int IPCMConsole::show_catalog(std::vector<std::string>& args)
 {
-	if (args.size() < 1) {
-		outstream << commands_map[args[0]].usage << endl;
-		return CMDRETCONT;
-	}
-
 	if (args.size() == 1) {
 		outstream << IPCManager->catalog.toString();
 
@@ -866,4 +865,13 @@ int IPCMConsole::show_catalog(std::vector<std::string>& args)
 
 	return CMDRETCONT;
 }
+
+int IPCMConsole::update_catalog(std::vector<std::string>& args)
+{
+	IPCManager->update_catalog(this);
+	outstream << "Catalog updated" << endl;
+
+	return CMDRETCONT;
+}
+
 }//namespace rinad

--- a/rinad/src/ipcm/addons/console.h
+++ b/rinad/src/ipcm/addons/console.h
@@ -94,6 +94,7 @@ class IPCMConsole : public Addon {
                 int show_dif_templates(std::vector<std::string>& args);
                 int read_ipcp_ribobj(std::vector<std::string>& args);
                 int show_catalog(std::vector<std::string>& args);
+                int update_catalog(std::vector<std::string>& args);
 
         public:
                 IPCMConsole(const unsigned int port);

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -216,8 +216,8 @@ int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,
 		int ret = load_policy_set(addon, ipcp_id, *i);
 
 		if (ret) {
-			LOG_WARN("Failed to load policy-set %s/%s",
-				  i->app_entity.c_str(), i->name.c_str());
+			LOG_WARN("Failed to load policy-set %s",
+				 i->toString().c_str());
 		}
 
 		// Record that this IPCP has select this policy set (TODO

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -328,6 +328,7 @@ int Catalog::policy_set_selected(const rina::PsInfo& ps_info,
 	rsrc = rsrc_lookup(ps_info.app_entity, id);
 	if (rsrc) {
 		rsrc->ps->selected.erase(id);
+		rsrc->ps = cpsinfo;
 	} else {
 		add_resource(ps_info.app_entity, id, cpsinfo);
 	}

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -410,13 +410,13 @@ string Catalog::toString() const
 			   << endl << "    ps version: " << cps->version
 			   << endl << "    plugin: " << cps->plugin->path
 			   << "/" << cps->plugin->name
-			   << ", loaded for ipcps [ ";
+			   << endl << "    loaded for ipcps [ ";
 			for (set<unsigned int>::iterator
 				ii = cps->plugin->loaded.begin();
 					ii != cps->plugin->loaded.end(); ii++) {
 				ss << *ii << " ";
 			}
-			ss << "]" << ", selected for resources [ ";
+			ss << "]" << endl << "    selected for resources [ ";
 			for (set<unsigned int>::iterator
 				ii = cps->selected.begin();
 					ii != cps->selected.end(); ii++) {

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -413,6 +413,8 @@ string Catalog::toString(const CatalogPsInfo *cps) const
 		ss << *ii << " ";
 	}
 	ss << "]" << endl;
+
+	return ss.str();
 }
 
 string Catalog::toString() const
@@ -443,8 +445,7 @@ void Catalog::print() const
 	LOG_INFO("%s", toString().c_str());
 }
 
-string
-Catalog::toString(const string& component) const
+string Catalog::toString(const string& component) const
 {
 	rina::ReadScopedLock rlock(const_cast<Catalog *>(this)->rwlock);
 	map<string, map< string, CatalogPsInfo * > >::const_iterator mit;

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -164,11 +164,15 @@ void Catalog::psinfo_from_psconfig(list< rina::PsInfo >& psinfo_list,
 				   const string& component,
 				   const rina::PolicyConfig& pconfig)
 {
-	if (pconfig.name_ != string()) {
-		psinfo_list.push_back(rina::PsInfo(pconfig.name_,
-						   component,
-						   pconfig.version_));
+	std::string ps_name = pconfig.name_;
+	std::string ps_version = pconfig.version_;
+
+	if (ps_name == string()) {
+		ps_name = "default";
+		ps_version = "";
 	}
+
+	psinfo_list.push_back(rina::PsInfo(ps_name, component, ps_version));
 }
 
 int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -193,7 +193,8 @@ int Catalog::load_by_template(Addon *addon, unsigned int ipcp_id,
 	return 0;
 }
 
-int Catalog::plugin_loaded(const string& plugin_name, unsigned int ipcp_id)
+int Catalog::plugin_loaded(const string& plugin_name, unsigned int ipcp_id,
+			   bool load)
 {
 	// Lookup again (the plugin or policy set may have disappeared
 	// in the meanwhile) under the write lock, and update the
@@ -201,13 +202,17 @@ int Catalog::plugin_loaded(const string& plugin_name, unsigned int ipcp_id)
 	rina::WriteScopedLock wlock(rwlock);
 
 	if (plugins.count(plugin_name) == 0) {
-		LOG_WARN("Plugin %s disappeared while "
-				"loading", plugin_name.c_str());
+		LOG_WARN("Plugin %s it's not in the catalog",
+			 plugin_name.c_str());
 		return -1;
 	}
 
-	// Mark the plugin as loaded for the specified IPCP
-	plugins[plugin_name].loaded.insert(ipcp_id);
+	// Mark the plugin as (un)loaded for the specified IPCP
+	if (load) {
+		plugins[plugin_name].loaded.insert(ipcp_id);
+	} else {
+		plugins[plugin_name].loaded.erase(ipcp_id);
+	}
 }
 
 int Catalog::load_policy_set(Addon *addon, unsigned int ipcp_id,

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -443,7 +443,8 @@ void Catalog::print() const
 	LOG_INFO("%s", toString().c_str());
 }
 
-int Catalog::print(const string& component) const
+string
+Catalog::toString(const string& component) const
 {
 	rina::ReadScopedLock rlock(const_cast<Catalog *>(this)->rwlock);
 	map<string, map< string, CatalogPsInfo * > >::const_iterator mit;
@@ -452,7 +453,7 @@ int Catalog::print(const string& component) const
 
 	mit = policy_sets.find(component);
 	if (mit == policy_sets.end()) {
-		return -1;
+		return string();
 	}
 
 	for (cmit = mit->second.begin(); cmit != mit->second.end(); cmit++) {
@@ -463,9 +464,7 @@ int Catalog::print(const string& component) const
 
 	ss << "      ====================================" << endl;
 
-	LOG_INFO("%s", ss.str().c_str());
-
-	return 0;
+	return ss.str();
 }
 
 } // namespace rinad

--- a/rinad/src/ipcm/catalog.cc
+++ b/rinad/src/ipcm/catalog.cc
@@ -408,6 +408,12 @@ string Catalog::toString() const
 					ii != cps->plugin->loaded.end(); ii++) {
 				ss << *ii << " ";
 			}
+			ss << "]" << ", selected for resources [ ";
+			for (set<unsigned int>::iterator
+				ii = cps->selected.begin();
+					ii != cps->selected.end(); ii++) {
+				ss << *ii << " ";
+			}
 			ss << "]" << endl;
 		}
 	}

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -102,9 +102,8 @@ public:
 	void ipcp_destroyed(unsigned int ipcp_id);
 
 	void print() const;
-	int print(const std::string& component) const;
 	std::string toString() const;
-	std::string toString(const CatalogPsInfo *cps) const;
+	std::string toString(const std::string& component) const;
 
 private:
 	void psinfo_from_psconfig(std::list< rina::PsInfo >& psinfo_list,
@@ -118,6 +117,8 @@ private:
 
 	int add_resource(const std::string& component,
 			 unsigned int id, CatalogPsInfo *);
+
+	std::string toString(const CatalogPsInfo *cps) const;
 
 	std::map<std::string,
 		 std::map<std::string, CatalogPsInfo*>

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -75,8 +75,8 @@ public:
 	int load_policy_set(Addon *addon, unsigned int ipcp_id,
 			    const rina::PsInfo& psinfo);
 
-	int load_plugin(Addon *addon, unsigned int ipcp_id,
-			const std::string& plugin_name);
+	int plugin_loaded(const std::string& plugin_name,
+			  unsigned int ipcp_id);
 
 	void ipcp_destroyed(unsigned int ipcp_id);
 

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -102,7 +102,9 @@ public:
 	void ipcp_destroyed(unsigned int ipcp_id);
 
 	void print() const;
+	int print(const std::string& component) const;
 	std::string toString() const;
+	std::string toString(const CatalogPsInfo *cps) const;
 
 private:
 	void psinfo_from_psconfig(std::list< rina::PsInfo >& psinfo_list,

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -75,6 +75,9 @@ public:
 	int load_policy_set(Addon *addon, unsigned int ipcp_id,
 			    const rina::PsInfo& psinfo);
 
+	int load_plugin(Addon *addon, unsigned int ipcp_id,
+			const std::string& plugin_name);
+
 	void ipcp_destroyed(unsigned int ipcp_id);
 
 	void print() const;

--- a/rinad/src/ipcm/catalog.h
+++ b/rinad/src/ipcm/catalog.h
@@ -76,7 +76,7 @@ public:
 			    const rina::PsInfo& psinfo);
 
 	int plugin_loaded(const std::string& plugin_name,
-			  unsigned int ipcp_id);
+			  unsigned int ipcp_id, bool load);
 
 	void ipcp_destroyed(unsigned int ipcp_id);
 

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -644,7 +644,7 @@ rinad::DIFTemplate * parse_dif_template_config(const Json::Value & root,
 			     "policySet",
 			     rc.policy_set_);
 
-	        Json::Value pft_conf = rmt_conf["pftConfiguration"];
+	        Json::Value pft_conf = rmt_conf["pffConfiguration"];
                 if (pft_conf != 0) {
                         rina::PFTConfiguration pftc;
 

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -111,7 +111,7 @@ void IPCManager_::init(const std::string& loglevel, std::string& config_file)
 
 		// Load the plugins catalog
 		catalog.import();
-		catalog.print();
+		//catalog.print();
 
 		// Initialize the I/O thread
 		io_thread = new rina::Thread(io_loop_trampoline,

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1120,7 +1120,7 @@ extract_subcomponent_name(const string& cpath)
 	size_t l = cpath.rfind(".");
 
 	if (l == string::npos) {
-		return string();
+		return cpath;
 	}
 
 	return cpath.substr(l+1);
@@ -1143,7 +1143,6 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 
 		ps_info.name = ps_name;
 		ps_info.app_entity = extract_subcomponent_name(component_path);
-		LOG_INFO("EXTRACTED %s", ps_info.app_entity.c_str());
 		ret = catalog.load_policy_set(callee, ipcp_id, ps_info);
 		if (ret) {
 			throw rina::Exception();

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1259,7 +1259,7 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		//First try to see if its a kernel module
 		if (plugin_load_kernel(plugin_name, load) == IPCM_SUCCESS) {
 			promise->ret = IPCM_SUCCESS;
-			catalog.plugin_loaded(plugin_name, ipcp_id);
+			catalog.plugin_loaded(plugin_name, ipcp_id, load);
 
 			return IPCM_SUCCESS;
 		}
@@ -1275,7 +1275,8 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		//Auto release the read lock
 		rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-		trans = new IPCPpluginTransState(callee, promise, ipcp->get_id(), plugin_name);
+		trans = new IPCPpluginTransState(callee, promise, ipcp->get_id(),
+						 plugin_name, load);
 		if(!trans){
 			ss << "Unable to allocate memory for the transaction object. Out of memory! ";
 			FLUSH_LOG(ERR, ss);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1324,6 +1324,14 @@ IPCManager_::plugin_get_info(const std::string& plugin_name,
 }
 
 ipcm_res_t
+IPCManager_::update_catalog(Addon* callee)
+{
+	catalog.import();
+
+	return IPCM_SUCCESS;
+}
+
+ipcm_res_t
 IPCManager_::read_ipcp_ribobj(Addon* callee, Promise* promise,
 			      const unsigned short ipcp_id,
 			      const std::string& object_class,

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1253,12 +1253,13 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 {
 	ostringstream ss;
 	IPCMIPCProcess *ipcp;
-	IPCPTransState* trans;
+	IPCPpluginTransState* trans;
 
 	try {
 		//First try to see if its a kernel module
 		if (plugin_load_kernel(plugin_name, load) == IPCM_SUCCESS) {
 			promise->ret = IPCM_SUCCESS;
+			catalog.plugin_loaded(plugin_name, ipcp_id);
 
 			return IPCM_SUCCESS;
 		}
@@ -1274,7 +1275,7 @@ IPCManager_::plugin_load(Addon* callee, Promise* promise,
 		//Auto release the read lock
 		rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-		trans = new IPCPTransState(callee, promise, ipcp->get_id());
+		trans = new IPCPpluginTransState(callee, promise, ipcp->get_id(), plugin_name);
 		if(!trans){
 			ss << "Unable to allocate memory for the transaction object. Out of memory! ";
 			FLUSH_LOG(ERR, ss);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1134,7 +1134,7 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 {
 	ostringstream ss;
 	IPCMIPCProcess *ipcp;
-	IPCPTransState* trans;
+	IPCPSelectPsTransState* trans;
 
 	try {
 		/* Load the policy set in the catalog. */
@@ -1160,7 +1160,8 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 		//Auto release the read lock
 		rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-		trans = new IPCPTransState(callee, promise, ipcp->get_id());
+		trans = new IPCPSelectPsTransState(callee, promise, ipcp->get_id(),
+						   ps_info, ipcp->get_id());
 		if(!trans){
 			ss << "Unable to allocate memory for the transaction object. Out of memory! ";
 			FLUSH_LOG(ERR, ss);

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1114,6 +1114,18 @@ IPCManager_::set_policy_set_param(Addon* callee, Promise* promise,
 	return IPCM_PENDING;
 }
 
+static string
+extract_subcomponent_name(const string& cpath)
+{
+	size_t l = cpath.rfind(".");
+
+	if (l == string::npos) {
+		return string();
+	}
+
+	return cpath.substr(l+1);
+}
+
 ipcm_res_t
 IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 		const unsigned short ipcp_id,
@@ -1125,6 +1137,19 @@ IPCManager_::select_policy_set(Addon* callee, Promise* promise,
 	IPCPTransState* trans;
 
 	try {
+		/* Load the policy set in the catalog. */
+		rina::PsInfo ps_info;
+		int ret;
+
+		ps_info.name = ps_name;
+		ps_info.app_entity = extract_subcomponent_name(component_path);
+		LOG_INFO("EXTRACTED %s", ps_info.app_entity.c_str());
+		ret = catalog.load_policy_set(callee, ipcp_id, ps_info);
+		if (ret) {
+			throw rina::Exception();
+		}
+
+		/* Select the policy set. */
 		ipcp = lookup_ipcp_by_id(ipcp_id);
 
 		if(!ipcp){

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -496,6 +496,13 @@ public:
 			      const std::string& object_name);
 
 	//
+	// Update policy-set catalog, with the plugins stored in
+	// the pluginsPaths configuration variable
+	//
+	// @ret IPCM_FAILURE on failure, otherwise the IPCM_SUCCESS
+	ipcm_res_t update_catalog(Addon* callee);
+
+	//
 	// Get the current logging debug level
 	//
 	std::string get_log_level() const;

--- a/rinad/src/ipcm/ipcp-handlers.h
+++ b/rinad/src/ipcm/ipcp-handlers.h
@@ -68,6 +68,25 @@ public:
 	int slave_ipcp_id;
 };
 
+/**
+* IPCP plugin load transaction state
+*/
+class IPCPpluginTransState: public TransactionState{
+
+public:
+	IPCPpluginTransState(Addon* callee, Promise* promise, int _ipcp_id,
+			   const std::string& _name)
+					: TransactionState(callee, promise),
+					  ipcp_id(_ipcp_id),
+					  plugin_name(_name) {}
+	virtual ~IPCPpluginTransState(){};
+
+	//IPCP identifier
+	int ipcp_id;
+	//Plugin name
+	std::string plugin_name;
+};
+
 }//rinad namespace
 
 #endif  /* __IPCP_HANDLERS_H__ */

--- a/rinad/src/ipcm/ipcp-handlers.h
+++ b/rinad/src/ipcm/ipcp-handlers.h
@@ -75,16 +75,20 @@ class IPCPpluginTransState: public TransactionState{
 
 public:
 	IPCPpluginTransState(Addon* callee, Promise* promise, int _ipcp_id,
-			   const std::string& _name)
+			   const std::string& _name, bool _l)
 					: TransactionState(callee, promise),
 					  ipcp_id(_ipcp_id),
-					  plugin_name(_name) {}
+					  plugin_name(_name), load(_l) {}
 	virtual ~IPCPpluginTransState(){};
 
-	//IPCP identifier
+	// IPCP identifier
 	int ipcp_id;
-	//Plugin name
+
+	// Plugin name
 	std::string plugin_name;
+
+	// Is this a load or unload operation ?
+	bool load;
 };
 
 }//rinad namespace

--- a/rinad/src/ipcm/ipcp-handlers.h
+++ b/rinad/src/ipcm/ipcp-handlers.h
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include <librina/common.h>
+#include <librina/application.h>
 #include <librina/ipc-manager.h>
 #include <librina/patterns.h>
 
@@ -89,6 +90,30 @@ public:
 
 	// Is this a load or unload operation ?
 	bool load;
+};
+
+/**
+* IPCP select-policy-set transaction state
+*/
+class IPCPSelectPsTransState: public TransactionState{
+
+public:
+	IPCPSelectPsTransState(Addon* callee, Promise* promise,
+			       unsigned _ipcp_id,
+			       const rina::PsInfo& _ps_info, int _id)
+					: TransactionState(callee, promise),
+					  ipcp_id(_ipcp_id),
+					  ps_info(_ps_info), id(_id) { }
+	virtual ~IPCPSelectPsTransState(){};
+
+	// IPCP identifier
+	unsigned int ipcp_id;
+
+	// The policy set to be selected
+	rina::PsInfo ps_info;
+
+	// IPCP or port-id identifier (to be used for the catalog)
+	unsigned int id;
 };
 
 }//rinad namespace

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -109,13 +109,14 @@ void IPCManager_::ipc_process_plugin_load_response_handler(rina::PluginLoadRespo
         rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
         ss << "plugin-load-op [plugin=" << trans->plugin_name <<
-	      "]completed on IPC process "
+	      ", load=" << trans->load << "] completed on IPC process "
 	       << ipcp->get_name().toString()
 	       << " [success=" << success << "]" << endl;
         FLUSH_LOG(INFO, ss);
 
 	if (success) {
-		catalog.plugin_loaded(trans->plugin_name, trans->ipcp_id);
+		catalog.plugin_loaded(trans->plugin_name, trans->ipcp_id,
+				      trans->load);
 	}
 
 	//Mark as completed

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -131,10 +131,11 @@ void IPCManager_::ipc_process_select_policy_set_response_handler(
 	ostringstream ss;
         int ret = -1;
 
-	IPCPTransState* trans = get_transaction_state<IPCPTransState>(event->sequenceNumber);
+	IPCPSelectPsTransState* trans = get_transaction_state<IPCPSelectPsTransState>(event->sequenceNumber);
 
 	if(!trans){
-		ss << ": Warning: unknown select policy response received: "<<event->sequenceNumber<<endl;
+		ss << ": Warning: unknown select policy response received: "
+			<<event->sequenceNumber<<endl;
 		FLUSH_LOG(WARN, ss);
 		return;
 	}
@@ -156,6 +157,10 @@ void IPCManager_::ipc_process_select_policy_set_response_handler(
 	       << ipcp->get_name().toString() <<
 		" [success=" << success << "]" << endl;
 	FLUSH_LOG(INFO, ss);
+
+	if (success) {
+		catalog.policy_set_selected(trans->ps_info, trans->id);
+	}
 
 	//Mark as completed
 	trans->completed(success ? IPCM_SUCCESS : IPCM_FAILURE);

--- a/rinad/src/ipcm/policies-handlers.cc
+++ b/rinad/src/ipcm/policies-handlers.cc
@@ -84,7 +84,7 @@ void IPCManager_::ipc_process_plugin_load_response_handler(rina::PluginLoadRespo
 	ostringstream ss;
         int ret = -1;
 
-        IPCPTransState* trans = get_transaction_state<IPCPTransState>(event->sequenceNumber);
+        IPCPpluginTransState* trans = get_transaction_state<IPCPpluginTransState>(event->sequenceNumber);
 
         if(!trans){
         	ss << ": Warning: unknown plugin load response received: "
@@ -108,10 +108,15 @@ void IPCManager_::ipc_process_plugin_load_response_handler(rina::PluginLoadRespo
         //Auto release the read lock
         rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
-        ss << "plugin-load-op completed on IPC process "
+        ss << "plugin-load-op [plugin=" << trans->plugin_name <<
+	      "]completed on IPC process "
 	       << ipcp->get_name().toString()
 	       << " [success=" << success << "]" << endl;
         FLUSH_LOG(INFO, ss);
+
+	if (success) {
+		catalog.plugin_loaded(trans->plugin_name, trans->ipcp_id);
+	}
 
 	//Mark as completed
 	trans->completed(success ? IPCM_SUCCESS : IPCM_FAILURE);

--- a/rinad/src/ipcp/plugins/default/plugin.cc
+++ b/rinad/src/ipcp/plugins/default/plugin.cc
@@ -57,8 +57,7 @@ extern "C" void
 destroyRoutingComponentPs(rina::IPolicySet * instance);
 
 extern "C" int
-get_factories(const std::string& plugin_name,
-	      std::vector<struct rina::PsFactory>& factories)
+get_factories(std::vector<struct rina::PsFactory>& factories)
 {
         struct rina::PsFactory sm_factory;
         struct rina::PsFactory auth_none_factory;
@@ -71,49 +70,42 @@ get_factories(const std::string& plugin_name,
         struct rina::PsFactory rc_factory;
         int ret;
 
-        sm_factory.plugin_name = plugin_name;
         sm_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         sm_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         sm_factory.create = createSecurityManagerPs;
         sm_factory.destroy = destroySecurityManagerPs;
 	factories.push_back(sm_factory);
 
-        auth_none_factory.plugin_name = plugin_name;
         auth_none_factory.info.name = rina::IAuthPolicySet::AUTH_NONE;
         auth_none_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         auth_none_factory.create = createAuthNonePs;
         auth_none_factory.destroy = destroyAuthNonePs;
 	factories.push_back(auth_none_factory);
 
-        auth_password_factory.plugin_name = plugin_name;
         auth_password_factory.info.name = rina::IAuthPolicySet::AUTH_PASSWORD;
         auth_password_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         auth_password_factory.create = createAuthPasswordPs;
         auth_password_factory.destroy = destroyAuthPasswordPs;
 	factories.push_back(auth_password_factory);
 
-        auth_ssh2_factory.plugin_name = plugin_name;
         auth_ssh2_factory.info.name = rina::IAuthPolicySet::AUTH_SSH2;
         auth_ssh2_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         auth_ssh2_factory.create = createAuthSSH2Ps;
         auth_ssh2_factory.destroy = destroyAuthSSH2Ps;
 	factories.push_back(auth_ssh2_factory);
 
-        fa_factory.plugin_name = plugin_name;
         fa_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         fa_factory.info.app_entity = IFlowAllocator::FLOW_ALLOCATOR_AE_NAME;
         fa_factory.create = createFlowAllocatorPs;
         fa_factory.destroy = destroyFlowAllocatorPs;
 	factories.push_back(fa_factory);
 
-        nsm_factory.plugin_name = plugin_name;
         nsm_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         nsm_factory.info.app_entity = INamespaceManager::NAMESPACE_MANAGER_AE_NAME;
         nsm_factory.create = createNamespaceManagerPs;
         nsm_factory.destroy = destroyNamespaceManagerPs;
 	factories.push_back(nsm_factory);
 
-        pduft_gen_factory.plugin_name = plugin_name;
         pduft_gen_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         pduft_gen_factory.info.app_entity =
 				IResourceAllocator::RESOURCE_ALLOCATOR_AE_NAME;
@@ -121,14 +113,12 @@ get_factories(const std::string& plugin_name,
         pduft_gen_factory.destroy = destroyPDUFTGenPs;
 	factories.push_back(pduft_gen_factory);
 
-        et_factory.plugin_name = plugin_name;
         et_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         et_factory.info.app_entity = rina::ApplicationEntity::ENROLLMENT_TASK_AE_NAME;
         et_factory.create = createEnrollmentTaskPs;
         et_factory.destroy = destroyEnrollmentTaskPs;
 	factories.push_back(et_factory);
 
-        rc_factory.plugin_name = plugin_name;
         rc_factory.info.name = "link-state";
         rc_factory.info.app_entity = IRoutingComponent::ROUTING_COMPONENT_AE_NAME;
         rc_factory.create = createRoutingComponentPs;

--- a/rinad/src/ipcp/plugins/default/plugin.cc
+++ b/rinad/src/ipcp/plugins/default/plugin.cc
@@ -57,7 +57,8 @@ extern "C" void
 destroyRoutingComponentPs(rina::IPolicySet * instance);
 
 extern "C" int
-init(IPCProcess * ipc_process, const std::string& plugin_name)
+get_factories(const std::string& plugin_name,
+	      std::vector<struct rina::PsFactory>& factories)
 {
         struct rina::PsFactory sm_factory;
         struct rina::PsFactory auth_none_factory;
@@ -75,66 +76,42 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
         sm_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         sm_factory.create = createSecurityManagerPs;
         sm_factory.destroy = destroySecurityManagerPs;
-
-        ret = ipc_process->psFactoryPublish(sm_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(sm_factory);
 
         auth_none_factory.plugin_name = plugin_name;
         auth_none_factory.info.name = rina::IAuthPolicySet::AUTH_NONE;
         auth_none_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         auth_none_factory.create = createAuthNonePs;
         auth_none_factory.destroy = destroyAuthNonePs;
-
-        ret = ipc_process->psFactoryPublish(auth_none_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(auth_none_factory);
 
         auth_password_factory.plugin_name = plugin_name;
         auth_password_factory.info.name = rina::IAuthPolicySet::AUTH_PASSWORD;
         auth_password_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         auth_password_factory.create = createAuthPasswordPs;
         auth_password_factory.destroy = destroyAuthPasswordPs;
-
-        ret = ipc_process->psFactoryPublish(auth_password_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(auth_password_factory);
 
         auth_ssh2_factory.plugin_name = plugin_name;
         auth_ssh2_factory.info.name = rina::IAuthPolicySet::AUTH_SSH2;
         auth_ssh2_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
         auth_ssh2_factory.create = createAuthSSH2Ps;
         auth_ssh2_factory.destroy = destroyAuthSSH2Ps;
-
-        ret = ipc_process->psFactoryPublish(auth_ssh2_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(auth_ssh2_factory);
 
         fa_factory.plugin_name = plugin_name;
         fa_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         fa_factory.info.app_entity = IFlowAllocator::FLOW_ALLOCATOR_AE_NAME;
         fa_factory.create = createFlowAllocatorPs;
         fa_factory.destroy = destroyFlowAllocatorPs;
-
-        ret = ipc_process->psFactoryPublish(fa_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(fa_factory);
 
         nsm_factory.plugin_name = plugin_name;
         nsm_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         nsm_factory.info.app_entity = INamespaceManager::NAMESPACE_MANAGER_AE_NAME;
         nsm_factory.create = createNamespaceManagerPs;
         nsm_factory.destroy = destroyNamespaceManagerPs;
-
-        ret = ipc_process->psFactoryPublish(nsm_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(nsm_factory);
 
         pduft_gen_factory.plugin_name = plugin_name;
         pduft_gen_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
@@ -142,35 +119,23 @@ init(IPCProcess * ipc_process, const std::string& plugin_name)
 				IResourceAllocator::RESOURCE_ALLOCATOR_AE_NAME;
         pduft_gen_factory.create = createPDUFTGenPs;
         pduft_gen_factory.destroy = destroyPDUFTGenPs;
-
-        ret = ipc_process->psFactoryPublish(pduft_gen_factory);
-        if (ret) {
-                return ret;
-        }
+	factories.push_back(pduft_gen_factory);
 
         et_factory.plugin_name = plugin_name;
         et_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         et_factory.info.app_entity = rina::ApplicationEntity::ENROLLMENT_TASK_AE_NAME;
         et_factory.create = createEnrollmentTaskPs;
         et_factory.destroy = destroyEnrollmentTaskPs;
-
-        ret = ipc_process->psFactoryPublish(et_factory);
-        if (ret) {
-        	return ret;
-        }
+	factories.push_back(et_factory);
 
         rc_factory.plugin_name = plugin_name;
         rc_factory.info.name = "link-state";
         rc_factory.info.app_entity = IRoutingComponent::ROUTING_COMPONENT_AE_NAME;
         rc_factory.create = createRoutingComponentPs;
         rc_factory.destroy = destroyRoutingComponentPs;
+	factories.push_back(rc_factory);
 
-        ret = ipc_process->psFactoryPublish(rc_factory);
-        if (ret) {
-        	return ret;
-        }
-
-        return 0;
+	return 0;
 }
 
 }   // namespace rinad

--- a/rinad/src/ipcp/plugins/sm-passwd/security-manager-passwd.cc
+++ b/rinad/src/ipcp/plugins/sm-passwd/security-manager-passwd.cc
@@ -90,13 +90,11 @@ destroySecurityManagerPasswdPs(rina::IPolicySet * ps)
 }
 
 extern "C" int
-get_factories(const std::string& plugin_name,
-		std::vector<struct rina::PsFactory>& factories)
+get_factories(std::vector<struct rina::PsFactory>& factories)
 {
 	struct rina::PsFactory factory;
 	int ret;
 
-	factory.plugin_name = plugin_name;
 	factory.info.name = "passwd";
 	factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
 	factory.create = createSecurityManagerPasswdPs;

--- a/rinad/src/ipcp/plugins/sm-passwd/security-manager-passwd.cc
+++ b/rinad/src/ipcp/plugins/sm-passwd/security-manager-passwd.cc
@@ -6,6 +6,7 @@
 
 #include "ipcp/components.h"
 
+
 namespace rinad {
 
 class SecurityManagerPasswdPs: public ISecurityManagerPs {
@@ -13,25 +14,28 @@ public:
 	SecurityManagerPasswdPs(IPCPSecurityManager * dm);
 	bool isAllowedToJoinDIF(const rina::Neighbor& newMember);
 	bool acceptFlow(const Flow& newFlow);
-        int set_policy_set_param(const std::string& name,
-                                 const std::string& value);
-        virtual ~SecurityManagerPasswdPs() {}
+	int set_policy_set_param(const std::string& name,
+			const std::string& value);
+	virtual ~SecurityManagerPasswdPs() {}
 
 private:
-        // Data model of the security manager component.
-        IPCPSecurityManager * dm;
+	// Data model of the security manager component.
+	IPCPSecurityManager * dm;
 
-        int max_retries;
+	int max_retries;
 };
 
-SecurityManagerPasswdPs::SecurityManagerPasswdPs(IPCPSecurityManager * dm_) : dm(dm_)
+SecurityManagerPasswdPs::SecurityManagerPasswdPs(IPCPSecurityManager * dm_)
+						: dm(dm_)
 {
 }
 
 
-bool SecurityManagerPasswdPs::isAllowedToJoinDIF(const rina::Neighbor& newMember)
+bool SecurityManagerPasswdPs::isAllowedToJoinDIF(const rina::Neighbor&
+						 newMember)
 {
-	LOG_IPCP_DBG("Allowing IPC Process %s to join the DIF", newMember.name_.processName.c_str());
+	LOG_IPCP_DBG("Allowing IPC Process %s to join the DIF",
+		     newMember.name_.processName.c_str());
 	return true;
 }
 
@@ -43,26 +47,26 @@ bool SecurityManagerPasswdPs::acceptFlow(const Flow& newFlow)
 }
 
 int SecurityManagerPasswdPs::set_policy_set_param(const std::string& name,
-                                                  const std::string& value)
+						  const std::string& value)
 {
-        if (name == "max_retries") {
-                int x;
-                std::stringstream ss;
+	if (name == "max_retries") {
+		int x;
+		std::stringstream ss;
 
-                ss << value;
-                ss >> x;
-                if (ss.fail()) {
-                        LOG_IPCP_ERR("Invalid value '%s'", value.c_str());
-                        return -1;
-                }
+		ss << value;
+		ss >> x;
+		if (ss.fail()) {
+			LOG_IPCP_ERR("Invalid value '%s'", value.c_str());
+			return -1;
+		}
 
-                max_retries = x;
-        } else {
-                LOG_IPCP_ERR("Unknown parameter '%s'", name.c_str());
-                return -1;
-        }
+		max_retries = x;
+	} else {
+		LOG_IPCP_ERR("Unknown parameter '%s'", name.c_str());
+		return -1;
+	}
 
-        return 0;
+	return 0;
 }
 
 extern "C" rina::IPolicySet *
@@ -70,36 +74,36 @@ createSecurityManagerPasswdPs(rina::ApplicationEntity * ctx)
 {
 	IPCPSecurityManager * sm = dynamic_cast<IPCPSecurityManager *>(ctx);
 
-        if (!sm) {
-                return NULL;
-        }
+	if (!sm) {
+		return NULL;
+	}
 
-        return new SecurityManagerPasswdPs(sm);
+	return new SecurityManagerPasswdPs(sm);
 }
 
 extern "C" void
 destroySecurityManagerPasswdPs(rina::IPolicySet * ps)
 {
-        if (ps) {
-                delete ps;
-        }
+	if (ps) {
+		delete ps;
+	}
 }
 
 extern "C" int
-init(IPCProcess * ipc_process, const std::string& plugin_name)
+get_factories(const std::string& plugin_name,
+		std::vector<struct rina::PsFactory>& factories)
 {
-        struct rina::PsFactory factory;
-        int ret;
+	struct rina::PsFactory factory;
+	int ret;
 
-        factory.plugin_name = plugin_name;
-        factory.info.name = "passwd";
-        factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
-        factory.create = createSecurityManagerPasswdPs;
-        factory.destroy = destroySecurityManagerPasswdPs;
+	factory.plugin_name = plugin_name;
+	factory.info.name = "passwd";
+	factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
+	factory.create = createSecurityManagerPasswdPs;
+	factory.destroy = destroySecurityManagerPasswdPs;
+	factories.push_back(factory);
 
-        ret = ipc_process->psFactoryPublish(factory);
-
-        return ret;
+	return 0;
 }
 
 }   // namespace rinad


### PR DESCRIPTION
 With this patch, the plugin init() function is replaced by the get_factories() function. In this way, the IPCP acts as a master and asks the plugin for its policy sets. This simplifies the implementation and remove thread-safety-related problems.

This PR depends on #739 (includes it).

MAINTAINERS:
@edugrasa 
