### PR TITLE
librina: Added bindings for C

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -252,6 +252,9 @@ F: librina/src/netlink*
 F: librina/src/rina-sys*
 F: librina/src/syscalls*
 
+C bindings
+M: Dimitri Staessens <dimitri.staessens (at) intec.ugent.be>
+F: librina/wrap/c/*
 
 RINA Daemons
 ------------

--- a/librina/Makefile.am
+++ b/librina/Makefile.am
@@ -9,7 +9,7 @@ DISTCLEANFILES            =
 MAINTAINERCLEANFILES      =
 BUILT_SOURCES             =
 DISTCHECK_CONFIGURE_FLAGS = \
-	--enable-java-wrappers --with-sysheaders=$(sysheaders)
+	--enable-java-bindings --with-sysheaders=$(sysheaders)
 
 SUBDIRS =					\
 	include					\

--- a/librina/configure.ac
+++ b/librina/configure.ac
@@ -131,7 +131,9 @@ PKG_CHECK_MODULES(OPENSSL, [openssl >= $OPENSSL_MIN_VERSION],, [
 ])
 
 build_bindings=no
+build_bindings_swig=no
 build_bindings_java=no
+build_bindings_c=yes
 AX_SELECTOR_ENABLE([java-bindings],[
     build_bindings_java=yes
 ],[
@@ -139,9 +141,19 @@ AX_SELECTOR_ENABLE([java-bindings],[
 ])
 AS_IF([test "$build_bindings_java" = "yes"],[
     build_bindings=yes
+    build_bindings_swig=yes
 ])
+AX_SELECTOR_ENABLE([c-bindings],[
+    build_bindings_c=yes
+],[
+    build_bindings_c=no
+])
+AS_IF([test "$build_bindings_c" = "yes"],[
+    build_bindings=yes
+])
+AM_CONDITIONAL(BUILD_BINDINGS_C, [test $build_bindings_c = yes])
 
-AS_IF([test "$build_bindings" = "yes"],[
+AS_IF([test "$build_bindings_swig" = "yes"],[
     AX_PKG_SWIG([2.0],[
         #
         # SWIG version > 2.0.4 && < 2.0.8 have a bug preventing correct
@@ -289,6 +301,10 @@ AC_CONFIG_FILES([
 
     wrap/Makefile
     wrap/java/Makefile
+    wrap/c/Makefile
+    wrap/c/src/Makefile
+    wrap/c/include/Makefile
+    wrap/c/include/librina-c/Makefile
 
     test/Makefile
 

--- a/librina/configure.ac
+++ b/librina/configure.ac
@@ -134,6 +134,7 @@ build_bindings=no
 build_bindings_swig=no
 build_bindings_java=no
 build_bindings_c=yes
+
 AX_SELECTOR_ENABLE([java-bindings],[
     build_bindings_java=yes
 ],[
@@ -143,7 +144,7 @@ AS_IF([test "$build_bindings_java" = "yes"],[
     build_bindings=yes
     build_bindings_swig=yes
 ])
-AX_SELECTOR_ENABLE([c-bindings],[
+AX_SELECTOR_DISABLE([c-bindings],[
     build_bindings_c=yes
 ],[
     build_bindings_c=no

--- a/librina/include/librina/Makefile.am
+++ b/librina/include/librina/Makefile.am
@@ -8,27 +8,27 @@ nobase_pkginclude_HEADERS = \
 	librina.h				\
 	logs.h					\
 	common.h				\
-	ipc-api.h               \
-	application.h		    \
-	configuration.h			\
-	internal-events.h       \
-	ipc-daemons.h			\
-	ipc-manager.h			\
-	ipc-process.h			\
-	faux-sockets.h			\
+	ipc-api.h               		\
+	application.h		    		\
+	configuration.h				\
+	internal-events.h       		\
+	ipc-daemons.h				\
+	ipc-manager.h				\
+	ipc-process.h				\
+	faux-sockets.h				\
 	cdap.h					\
 	security-manager.h			\
 	likely.h				\
 	rib.h                    		\
-	cdap_v2.h					\
+	cdap_v2.h				\
 	rib_v2.h                    		\
-	cdap_rib_structures.h		\
+	cdap_rib_structures.h			\
 	irm.h					\
-	enrollment.h		\
-	sdu-protection.h		\
+	enrollment.h				\
+	sdu-protection.h			\
 	patterns.h				\
-	exceptions.h			\
-	concurrency.h			\
+	exceptions.h				\
+	concurrency.h				\
 	time.h					\
 	timer.h					\
 	plugin-info.h

--- a/librina/m4/ax_selector_disable.m4
+++ b/librina/m4/ax_selector_disable.m4
@@ -1,0 +1,46 @@
+#
+# SYNOPSIS
+#
+#   AX_SELECTOR_ENABLE(FEATURE,[IF-WANT-FEATURE],[IF-DONT-WANT-FEATURE])
+#
+#   The feature is enabled by default, --disable-<feature> to manually switch
+#   it off
+#
+# WRITTEN BY:
+#
+#   Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
+#   Dimitri Staessens <dimitri DOT staessens AT ugent DOT be>
+#
+
+AC_DEFUN([AX_SELECTOR_DISABLE],[
+    pushdef([CANONICAL_UP],  translit([$1], [a-z-], [A-Z_]))
+    pushdef([CANONICAL_LOW], translit([$1], [A-Z-], [a-z_]))
+
+    AC_MSG_CHECKING([whether $1 related features have been enabled])
+
+    AC_ARG_ENABLE([$1],
+        AS_HELP_STRING([--disable-][$1],[disable $1 related features]),[
+        AS_IF([test ! $enableval = "yes"],[
+            ax_cv_want_[]CANONICAL_LOW=no
+        ],[
+            ax_cv_want_[]CANONICAL_LOW=yes
+        ])
+    ],[
+        ax_cv_want_[]CANONICAL_LOW=yes
+    ])
+    AC_MSG_RESULT([${ax_cv_want_[]CANONICAL_LOW}])
+    AS_IF([test "${ax_cv_want_[]CANONICAL_LOW}" = "yes"],[$2],[$3])
+
+    AM_CONDITIONAL(BUILD_[]CANONICAL_UP, [test "${ax_cv_want_[]CANONICAL_LOW}" = "yes"])
+
+    AS_IF([test "${ax_cv_want_[]CANONICAL_LOW}" = "yes"],[
+        ax_cv_define_[]CANONICAL_LOW=1
+    ],[
+        ax_cv_define_[]CANONICAL_LOW=0
+    ])
+
+    AC_DEFINE_UNQUOTED(WANT_[]CANONICAL_UP, [${ax_cv_define_[]CANONICAL_LOW}], [Define if you want $1])
+
+    popdef([CANONICAL_LOW])
+    popdef([CANONICAL_UP])
+])

--- a/librina/src/Makefile.am
+++ b/librina/src/Makefile.am
@@ -86,12 +86,12 @@ allsources =							\
         netlink-manager.cc   netlink-manager.h			\
         syscalls-wrappers.cc rina-systypes.h    rina-syscalls.h	\
         $(protoSOURCES)						\
-        cdap-impl.cc         cdap-impl.h			\
-	plugin-info.cc	      plugin-info.h
+        cdap-impl.cc	     cdap-impl.h			\
+	plugin-info.cc	     plugin-info.h
 
 librina_la_SOURCES  = $(allsources)
 librina_la_LDFLAGS  =
-librina_la_LIBADD   =			\
+librina_la_LIBADD   =				\
 	$(LIBNL3_LIBS)				\
 	$(LIBNLGENL3_LIBS)			\
 	$(LIBPROTOBUF_LIBS)			\
@@ -110,6 +110,7 @@ librina_la_CPPFLAGS =				\
 	$(CPPFLAGS_EXTRA)
 librina_la_CXXFLAGS =				\
 	$(CXXFLAGS_EXTRA)
+
 
 librina_stubbed_la_SOURCES  = $(allsources)
 librina_stubbed_la_LDFLAGS  =
@@ -151,13 +152,13 @@ test_linking_CPPFLAGS =				\
 	$(CPPFLAGS_EXTRA)
 test_linking_CXXFLAGS =				\
 	$(CXXFLAGS_EXTRA)
-test_linking_LDADD    =			\
+test_linking_LDADD    =				\
 	$(LIBNL3_LIBS)				\
 	$(LIBNLGENL3_LIBS)			\
 	$(LIBPROTOBUF_LIBS)			\
 	$(OPENSSL_LIBS)				\
         $(builddir)/librinajsoncpp.la           \
-	-ldl						\
+	-ldl					\
 	librina.la
 
 check-local: test-linking

--- a/librina/wrap/c/Makefile.am
+++ b/librina/wrap/c/Makefile.am
@@ -1,0 +1,9 @@
+#
+# Makefile.am
+#
+# Written by: Dimitri Staessens <dimitri DOT staessens AT ugent DOT be>
+#
+
+SUBDIRS = 			\
+	src			\
+	include

--- a/librina/wrap/c/include/Makefile.am
+++ b/librina/wrap/c/include/Makefile.am
@@ -5,9 +5,4 @@
 #
 
 SUBDIRS = 			\
-	c			\
-	java	
-
-EXTRA_DIST =			\
-	librina.i		\
-	stdlist.i
+	librina-c

--- a/librina/wrap/c/include/librina-c/Makefile.am
+++ b/librina/wrap/c/include/librina-c/Makefile.am
@@ -4,10 +4,7 @@
 # Written by: Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
 #
 
-SUBDIRS = 			\
-	c			\
-	java	
+librina_cdir=$(includedir)/librina-c
 
-EXTRA_DIST =			\
-	librina.i		\
-	stdlist.i
+nobase_librina_c_HEADERS = 			\
+	librina-c.h

--- a/librina/wrap/c/include/librina-c/librina-c.h
+++ b/librina/wrap/c/include/librina-c/librina-c.h
@@ -1,0 +1,115 @@
+/*
+ *  C wrapper for librina
+ *
+ *    Addy Bombeke      <addy.bombeke@ugent.be>
+ *    Sander Vrijders   <sander.vrijders@intec.ugent.be>
+ *    Dimitri Staessens <dimitri.staessens@intec.ugent.be>
+ *
+ *    Copyright (C) 2015
+ *
+ *  This software was written as part of the MSc thesis in electrical
+ *  engineering,
+ *
+ *  "Comparing RINA to TCP/IP for latency-constrained applications",
+ *
+ *  at Ghent University, Academic Year 2014-2015
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef LIBRINA_C_H
+#define LIBRINA_C_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef	       int rina_flow_t;
+struct	       rina_ipcevent;
+typedef struct rina_ipcevent rina_ipcevent;
+
+//RINA
+void rina_initializePort(unsigned int localport,
+			 const char  *loglevel,
+			 const char  *pathtologfile);
+
+void rina_initialize(const char *loglevel,  const char *pathtologfile);
+
+//RinaIPCManager
+unsigned int rinaIPCManager_requestApplicationRegistration(
+	const char *app,
+	const char *app_instance,
+	const char *dif);
+
+void rinaIPCManager_appUnregistrationResult(unsigned int seqnum, char success);
+
+void rinaIPCManager_commitPendingRegistration(unsigned int seqnum,
+					      const char  *dif);
+
+void rinaIPCManager_withdrawPendingRegistration(unsigned int seqnum);
+
+rina_flow_t rinaIPCManager_allocateFlowResponse(rina_ipcevent *event,
+						int            result,
+						char           notifySource);
+
+void rinaIPCManager_flowDeallocated(unsigned int port_id);
+
+void rinaIPCManager_flowDeallocationResult(int portId, char success);
+
+unsigned int rinaIPCManager_requestFlowAllocationInDIF(
+	const char *localAppName,
+	const char *localAppInstance,
+	const char *remoteAppName,
+	const char *remoteAppInstance,
+	const char *difName,
+	void       *qosspec);
+
+unsigned int rinaIPCManager_requestFlowAllocation(
+	const char *localAppName,
+	const char *localAppInstance,
+	const char *remoteAppName,
+	const char *remoteAppInstance,
+	void       *qosspec);
+
+rina_flow_t rinaIPCManager_commitPendingFlow(unsigned int sequenceNumber,
+					     int          portId,
+					     const char  *DIFName);
+
+//RinaIPCEventProducer
+rina_ipcevent *rinaIPCEventProducer_eventWait(void);
+rina_ipcevent *rinaIPCEventProducer_eventPoll(void);
+
+//RinaIPCEvent
+int rinaIPCEvent_eventType(rina_ipcevent *e);
+unsigned int rinaIPCEvent_sequenceNumber(rina_ipcevent *e);
+char *rinaAllocateFlowRequestResultEvent_difName(rina_ipcevent *e);
+char *rinaRegisterApplicationResponseEvent_DIFName(rina_ipcevent *e);
+int rinaBaseApplicationRegistrationResponseEvent_result(rina_ipcevent *e);
+int rinaAllocateFlowRequestResultEvent_portId(rina_ipcevent *e);
+
+//RinaFlow
+int rinaFlow_getPortId(rina_flow_t flow);
+int rinaFlow_readSDU(rina_flow_t flow, void *sdu, int maxBytes);
+void rinaFlow_writeSDU(rina_flow_t flow, void *sdu, int size);
+int rinaFlow_getState(rina_flow_t flow);
+char rinaFlow_isAllocated(rina_flow_t flow);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif//LIBRINA_C_H

--- a/librina/wrap/c/src/Makefile.am
+++ b/librina/wrap/c/src/Makefile.am
@@ -1,0 +1,54 @@
+#
+# Makefile.am
+#
+# Written by: Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
+#	      Dimitri Staessens     <dimitri DOT staessens AT ugent DOT be>
+#
+
+if BUILD_BINDINGS_C
+
+librina_c_la_SOURCES   = 	\
+	flow.cc			\
+	init.cc			\
+	ipcevent.cc		\
+	ipceventproducer.cc	\
+	ipcmanager.cc
+librina_c_la_LDFLAGS   =
+librina_c_la_LIBADD = 			\
+	$(top_builddir)/src/librina.la	\
+	-ldl
+librina_c_la_CPPFLAGS =			\
+	$(CXX_SYSINCLUDES)		\
+	-I$(top_srcdir)/include		\
+	-I$(srcdir)/../include		\
+	$(CPPFLAGS_EXTRA)
+librina_c_la_CXXFLAGS =		\
+	$(CXXFLAGS_EXTRA)
+
+lib_LTLIBRARIES = librina-c.la
+
+EXTRA_DIST =					\
+	librina-c.pc.in
+
+edit = $(SED)								\
+        -e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g'			\
+        -e 's|@PACKAGE_URL[@]|$(PACKAGE_URL)|g'				\
+        -e 's|@prefix[@]|$(prefix)|g'					\
+        -e 's|@includedir[@]|$(includedir)|g'				\
+        -e 's|@libdir[@]|$(libdir)|g'
+
+
+librina-c.pc: Makefile librina-c.pc.in
+	rm -f $@ $@.tmp
+	srcdir=''; \
+	  test -f ./$@.in || srcdir=$(srcdir)/; \
+	  $(edit) $${srcdir}$@.in >$@.tmp
+	chmod a-w $@.tmp
+	mv $@.tmp $@
+
+CLEANFILES = librina-c.pc
+
+pkgconfigdir   = $(libdir)/pkgconfig
+pkgconfig_DATA = librina-c.pc
+
+endif

--- a/librina/wrap/c/src/flow.cc
+++ b/librina/wrap/c/src/flow.cc
@@ -1,0 +1,69 @@
+/*
+ *  C wrapper for librina
+ *
+ *    Addy Bombeke      <addy.bombeke@ugent.be>
+ *    Sander Vrijders   <sander.vrijders@intec.ugent.be>
+ *    Dimitri Staessens <dimitri.staessens@intec.ugent.be>
+ *
+ *    Copyright (C) 2015
+ *
+ *  This software was written as part of the MSc thesis in electrical
+ *  engineering,
+ *
+ *  "Comparing RINA to TCP/IP for latency-constrained applications",
+ *
+ *  at Ghent University, Academic Year 2014-2015
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include <string>
+#include <librina/librina.h>
+#include "librina-c/librina-c.h"
+
+using namespace std;
+using namespace rina;
+
+extern "C"
+{
+
+int rinaFlow_getPortId(rina_flow_t flow)
+{
+	return flow;
+}
+
+int rinaFlow_readSDU(rina_flow_t flow, void *sdu, int maxBytes)
+{
+	return ipcManager->readSDU(flow, sdu, maxBytes);
+}
+
+void rinaFlow_writeSDU(rina_flow_t flow, void *sdu, int size)
+{
+	ipcManager->writeSDU(flow, sdu, size);
+}
+
+int rinaFlow_getState(rina_flow_t flow)
+{
+	return static_cast<int>(
+		ipcManager->getFlowInformation(flow).state);
+}
+
+char rinaFlow_isAllocated(rina_flow_t flow)
+{
+	return rinaFlow_getState(flow) == 1;
+}
+
+}

--- a/librina/wrap/c/src/init.cc
+++ b/librina/wrap/c/src/init.cc
@@ -1,0 +1,56 @@
+/*
+ *  C wrapper for librina
+ *
+ *    Addy Bombeke      <addy.bombeke@ugent.be>
+ *    Sander Vrijders   <sander.vrijders@intec.ugent.be>
+ *    Dimitri Staessens <dimitri.staessens@intec.ugent.be>
+ *
+ *    Copyright (C) 2015
+ *
+ *  This software was written as part of the MSc thesis in electrical
+ *  engineering,
+ *
+ *  "Comparing RINA to TCP/IP for latency-constrained applications",
+ *
+ *  at Ghent University, Academic Year 2014-2015
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include <string>
+#include <librina/librina.h>
+#include "librina-c/librina-c.h"
+
+
+using namespace std;
+using namespace rina;
+
+extern "C"
+{
+
+void rina_initializePort(unsigned int localport,
+			 const char  *loglevel,
+			 const char  *pathtologfile)
+{
+	rina::initialize(localport, loglevel, pathtologfile);
+}
+
+void rina_initialize(const char *loglevel,  const char *pathtologfile)
+{
+	rina::initialize(loglevel, pathtologfile);
+}
+
+}

--- a/librina/wrap/c/src/ipcevent.cc
+++ b/librina/wrap/c/src/ipcevent.cc
@@ -1,0 +1,86 @@
+/*
+ *  C wrapper for librina
+ *
+ *    Addy Bombeke      <addy.bombeke@ugent.be>
+ *    Sander Vrijders   <sander.vrijders@intec.ugent.be>
+ *    Dimitri Staessens <dimitri.staessens@intec.ugent.be>
+ *
+ *    Copyright (C) 2015
+ *
+ *  This software was written as part of the MSc thesis in electrical
+ *  engineering,
+ *
+ *  "Comparing RINA to TCP/IP for latency-constrained applications",
+ *
+ *  at Ghent University, Academic Year 2014-2015
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include <iostream>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <librina/librina.h>
+#include "librina-c/librina-c.h"
+
+using namespace std;
+using namespace rina;
+
+extern "C"
+{
+int rinaIPCEvent_eventType(rina_ipcevent *e)
+{
+	return static_cast<int>(
+		reinterpret_cast<IPCEvent*>(e)->eventType);
+}
+
+unsigned int rinaIPCEvent_sequenceNumber(rina_ipcevent *e)
+{
+	return reinterpret_cast<IPCEvent*>(e)->sequenceNumber;
+}
+
+//AllocateFlowRequestResultEvent
+char *rinaAllocateFlowRequestResultEvent_difName(rina_ipcevent *e)
+{
+	string temp(reinterpret_cast<AllocateFlowRequestResultEvent *>(e)->
+		    difName.toString());
+	char* ret = reinterpret_cast<char*>(malloc(temp.size() + 1));
+	strcpy(ret, temp.c_str());
+	return ret;
+}
+
+char *rinaRegisterApplicationResponseEvent_DIFName(rina_ipcevent *e)
+{
+	string temp(reinterpret_cast<RegisterApplicationResponseEvent *>(e)->
+		    DIFName.toString());
+	char* ret = reinterpret_cast<char*>(malloc(temp.size() + 1));
+	strcpy(ret, temp.c_str());
+	return ret;
+}
+
+int rinaBaseApplicationRegistrationResponseEvent_result(rina_ipcevent *e)
+{
+	return reinterpret_cast<BaseApplicationRegistrationResponseEvent *>(e)->
+		result;
+}
+
+int rinaAllocateFlowRequestResultEvent_portId(rina_ipcevent *e)
+{
+	return reinterpret_cast<AllocateFlowRequestResultEvent *>(e)->portId;
+}
+
+}

--- a/librina/wrap/c/src/ipceventproducer.cc
+++ b/librina/wrap/c/src/ipceventproducer.cc
@@ -1,0 +1,55 @@
+/*
+ *  C wrapper for librina
+ *
+ *    Addy Bombeke      <addy.bombeke@ugent.be>
+ *    Sander Vrijders   <sander.vrijders@intec.ugent.be>
+ *    Dimitri Staessens <dimitri.staessens@intec.ugent.be>
+ *
+ *    Copyright (C) 2015
+ *
+ *  This software was written as part of the MSc thesis in electrical
+ *  engineering,
+ *
+ *  "Comparing RINA to TCP/IP for latency-constrained applications",
+ *
+ *  at Ghent University, Academic Year 2014-2015
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include <string>
+#include <librina/librina.h>
+#include "librina-c/librina-c.h"
+
+using namespace std;
+using namespace rina;
+
+extern "C"
+{
+
+rina_ipcevent *rinaIPCEventProducer_eventWait(void)
+{
+	return reinterpret_cast<rina_ipcevent *>(
+		ipcEventProducer->eventWait());
+}
+
+rina_ipcevent *rinaIPCEventProducer_eventPoll(void)
+{
+	return reinterpret_cast<rina_ipcevent *>(
+		ipcEventProducer->eventPoll());
+}
+
+}

--- a/librina/wrap/c/src/ipcmanager.cc
+++ b/librina/wrap/c/src/ipcmanager.cc
@@ -1,0 +1,163 @@
+/*
+ *  C wrapper for librina
+ *
+ *    Addy Bombeke      <addy.bombeke@ugent.be>
+ *    Sander Vrijders   <sander.vrijders@intec.ugent.be>
+ *    Dimitri Staessens <dimitri.staessens@intec.ugent.be>
+ *
+ *    Copyright (C) 2015
+ *
+ *  This software was written as part of the MSc thesis in electrical
+ *  engineering,
+ *
+ *  "Comparing RINA to TCP/IP for latency-constrained applications",
+ *
+ *  at Ghent University, Academic Year 2014-2015
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include <string>
+#include <librina/librina.h>
+#include "librina-c/librina-c.h"
+
+using namespace std;
+using namespace rina;
+
+extern "C"
+{
+
+unsigned int rinaIPCManager_requestApplicationRegistration(
+	const char *app,
+	const char *app_instance,
+	const char *dif)
+{
+	ApplicationRegistrationInformation ari;
+	ari.ipcProcessId = 0; //application, not IPC process
+	ari.appName = ApplicationProcessNamingInformation(app,
+							  app_instance);
+	if(dif) {
+		ari.applicationRegistrationType =
+			static_cast<rina::ApplicationRegistrationType>
+			(0);  /* APPLICATION_REGISTRATION_SINGLE_DIF */
+		ari.difName = ApplicationProcessNamingInformation(
+			dif,
+			string());
+	}
+	else {
+		ari.applicationRegistrationType =
+			static_cast<rina::ApplicationRegistrationType>
+			(1);  /* APPLICATION_REGISTRATION_ANY_DIF */
+	}
+	return ipcManager->requestApplicationRegistration(ari);
+}
+
+void rinaIPCManager_appUnregistrationResult(unsigned int seqnum,
+					    char         success)
+{
+	ipcManager->appUnregistrationResult(seqnum, success);
+}
+
+void rinaIPCManager_commitPendingRegistration(unsigned int seqnum,
+					      const char  *dif)
+{
+	if(dif)
+		ipcManager->commitPendingRegistration(
+			seqnum,
+			ApplicationProcessNamingInformation(
+				dif,
+				string()));
+	else
+		ipcManager->commitPendingRegistration(
+			seqnum,
+			ApplicationProcessNamingInformation(
+				string(),
+				string()));
+}
+void rinaIPCManager_withdrawPendingRegistration(unsigned int seqnum)
+{
+	ipcManager->withdrawPendingFlow(seqnum);
+}
+
+rina_flow_t rinaIPCManager_allocateFlowResponse(rina_ipcevent *event,
+						int            result,
+						char           notifySource)
+{
+	return (ipcManager->allocateFlowResponse(
+			*reinterpret_cast<FlowRequestEvent *>(event),
+			result, notifySource)).portId;
+}
+
+void rinaIPCManager_flowDeallocated(unsigned int port_id)
+{
+	ipcManager->flowDeallocated(port_id);
+}
+
+void rinaIPCManager_flowDeallocationResult(int portId, char success)
+{
+	ipcManager->flowDeallocationResult(portId, success);
+}
+
+unsigned int rinaIPCManager_requestFlowAllocationInDIF(
+	const char *localAppName,
+	const char *localAppInstance,
+	const char *remoteAppName,
+	const char *remoteAppInstance,
+	const char *difName,
+	void       *qosspec)
+{
+	return ipcManager->requestFlowAllocationInDIF(
+		ApplicationProcessNamingInformation(
+			localAppName,
+			localAppInstance),
+		ApplicationProcessNamingInformation(
+			remoteAppName,
+			remoteAppInstance),
+		ApplicationProcessNamingInformation(
+			difName,
+			string()),
+		FlowSpecification());
+}
+
+unsigned int rinaIPCManager_requestFlowAllocation(
+	const char *localAppName,
+	const char *localAppInstance,
+	const char *remoteAppName,
+	const char *remoteAppInstance,
+	void       *qosspec)
+{
+	return ipcManager->requestFlowAllocation(
+		ApplicationProcessNamingInformation(
+			localAppName,
+			localAppInstance),
+		ApplicationProcessNamingInformation(
+			remoteAppName,
+			remoteAppInstance),
+		FlowSpecification());
+}
+
+rina_flow_t rinaIPCManager_commitPendingFlow(unsigned int sequenceNumber,
+					     int          portId,
+					     const char  *DIFName)
+{
+	return ipcManager->commitPendingFlow(
+                  sequenceNumber,
+                  portId,
+                  ApplicationProcessNamingInformation(
+                          DIFName,
+                          string())).portId;;
+}
+}

--- a/librina/wrap/c/src/librina-c.pc.in
+++ b/librina/wrap/c/src/librina-c.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: LibRINA-C
+Description: RINA support libraries for C
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Requires: librina
+Libs: -L${libdir} -lrina-c
+Cflags: -I${includedir}


### PR DESCRIPTION
Adds a library for calling librina from C programs. It is required for the upcoming ioq3 port. The c bindings are installed by default, but can be disabled by passing the --disable-c-bindings flag to ./configure (librina).

Maintainers: @msune for MAINTAINERS file, @dstaesse for the rest. 
Makefiles seem missing from MAINTAINERS, probably should be checked by @edugrasa and @vmaffione.