### PR TITLE
build & wrap: add wrapping for manager-MAD classes

### DIFF
--- a/install-user-from-scratch
+++ b/install-user-from-scratch
@@ -37,6 +37,13 @@ if test -n "$BUILDDIR" ; then
     }
 fi
 
+echo "$ME: Java directory will be \`$BUILDDIR/java'"
+if test -n "$BUILDDIR/java" ; then
+    mkdir -p $BUILDDIR/java || {
+        echo "$ME: Cannot create directory \`$BUILDDIR/java'"
+    }
+fi
+
 echo "$ME: Starting librina phase"
 (cd librina && ./bootstrap) || {
     echo "$ME: Cannot bootstrap"
@@ -52,7 +59,7 @@ echo "$ME: Starting rinad phase"
     echo "$ME: Cannot bootstrap"
     exit 1
 }
-(mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$PREFIX $FLAGS && make $MAKEFLAGS clean install installcheck) || {
+(mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$PREFIX --enable-java-bindings $FLAGS && make $MAKEFLAGS clean install installcheck) || {
     echo "$ME: Cannot complete rinad phase"
     exit 1
 }

--- a/librina/include/librina/cdap_rib_structures.h
+++ b/librina/include/librina/cdap_rib_structures.h
@@ -28,7 +28,7 @@
 namespace rina {
 namespace cdap_rib {
 
-typedef struct SerializedObject {
+typedef struct{
 	int size_;
 	void* message_;
 } ser_obj_t;
@@ -45,7 +45,7 @@ typedef struct auth_policy {
 	/// Supported versions
 	std::list<std::string> versions;
 	/// Policy-specific options, encoded in a char array
-	SerializedObject options;
+	ser_obj_t options;
 } auth_policy_t;
 
 // End-point information

--- a/librina/include/librina/cdap_v2.h
+++ b/librina/include/librina/cdap_v2.h
@@ -254,7 +254,7 @@ public:
 	///
 	/// Process an incoming CDAP message
 	///
-	virtual void process_message(cdap_rib::SerializedObject &message,
+	virtual void process_message(cdap_rib::ser_obj_t &message,
 				unsigned int port) = 0;
 
 	virtual void destroy_session(int port){ (void)port; /*FIXME*/ };
@@ -345,7 +345,7 @@ public:
 	std::string obj_name_;
 
 	/// ObjectValueInterface (ObjectValueInterface). The value of the object.
-	cdap_rib::SerializedObject obj_value_;
+	cdap_rib::ser_obj_t obj_value_;
 
 	/// Opcode (enum, int32), mandatory.
 	/// Message type of this message.
@@ -409,12 +409,12 @@ public:
 	/// @return
 	/// @throws CDAPException
 	virtual const cdap_m_t* deserializeMessage(
-			const cdap_rib::SerializedObject &message) = 0;
+			const cdap_rib::ser_obj_t &message) = 0;
 	/// Convert from CDAP messages to wire format
 	/// @param cdapMessage
 	/// @return
 	/// @throws CDAPException
-	virtual const cdap_rib::SerializedObject* serializeMessage(
+	virtual const cdap_rib::ser_obj_t* serializeMessage(
 			const cdap_m_t &cdapMessage) = 0;
 };
 

--- a/librina/include/librina/rib_v2.h
+++ b/librina/include/librina/rib_v2.h
@@ -24,7 +24,6 @@
 #define RIB_PROVIDER_H_
 #include "cdap_rib_structures.h"
 #include <string>
-#include <inttypes.h>
 #include <list>
 #include <map>
 #include <algorithm>
@@ -191,33 +190,6 @@ public:
 			const cdap_rib::res_info_t &res) = 0;
 };
 
-class AbstractEncoder {
-
-public:
-	virtual ~AbstractEncoder();
-};
-
-template<class T>
-class Encoder: public AbstractEncoder {
-
-public:
-	virtual ~Encoder(){}
-
-	/// Converts an object to a byte array, if this object is recognized by the encoder
-	/// @param object
-	/// @throws exception if the object is not recognized by the encoder
-	/// @return
-	virtual void encode(const T &obj, cdap_rib::ser_obj_t& serobj) = 0;
-	/// Converts a byte array to an object of the type specified by "className"
-	/// @param byte[] serializedObject
-	/// @param objectClass The type of object to be decoded
-	/// @throws exception if the byte array is not an encoded in a way that the
-	/// encoder can recognize, or the byte array value doesn't correspond to an
-	/// object of the type "className"
-	/// @return
-	virtual void decode(const cdap_rib::ser_obj_t &serobj,
-			T& des_obj) = 0;
-};
 
 ///
 /// Base RIB Object. API for the create/delete/read/write/start/stop RIB
@@ -269,8 +241,8 @@ protected:
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res);
 	///
 	/// Process a remote delete operation
@@ -313,7 +285,7 @@ protected:
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
 					const int invoke_id,
-					cdap_rib::SerializedObject &obj_reply,
+					cdap_rib::ser_obj_t &obj_reply,
 					cdap_rib::res_info_t& res);
 
 	///
@@ -359,8 +331,8 @@ protected:
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res);
 
 	///
@@ -386,8 +358,8 @@ protected:
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res);
 
 	///
@@ -413,8 +385,8 @@ protected:
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res);
 
 	///
@@ -529,8 +501,8 @@ typedef void (*create_cb_t)(const rib_handle_t rib,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res);
 
 ///

--- a/librina/src/cdap_v2.cc
+++ b/librina/src/cdap_v2.cc
@@ -345,11 +345,11 @@ class CDAPSession
 	~CDAPSession() throw ();
 	//const CDAPSessionInvokeIdManagerInterface* getInvokeIdManager();
 	//bool isConnected() const;
-	const cdap_rib::SerializedObject* encodeNextMessageToBeSent(
+	const cdap_rib::ser_obj_t* encodeNextMessageToBeSent(
 			const cdap_m_t &cdap_message);
 	void messageSent(const cdap_m_t &cdap_message);
 	const cdap_m_t* messageReceived(
-			const cdap_rib::SerializedObject &message);
+			const cdap_rib::ser_obj_t &message);
 	void messageReceived(const cdap_m_t &cdap_message);
 	void set_session_descriptor(cdap_session_t *session_descriptor);
 	int get_port_id() const;
@@ -380,7 +380,7 @@ class CDAPSession
 	const cdap_rib::ser_obj_t* serializeMessage(
 			const cdap_m_t &cdap_message) const;
 	const cdap_m_t* deserializeMessage(
-			const cdap_rib::SerializedObject &message) const;
+			const cdap_rib::ser_obj_t &message) const;
 	void populateSessionDescriptor(const cdap_m_t &cdap_message, bool send);
 	void emptySessionDescriptor();
 	/// This map contains the invokeIds of the messages that
@@ -414,15 +414,15 @@ class CDAPSessionManager
 	CDAPSession* createCDAPSession(int port_id);
 	void getAllCDAPSessionIds(std::vector<int> &vector);
 	CDAPSession* get_cdap_session(int port_id);
-	const cdap_rib::SerializedObject* encodeCDAPMessage(
+	const cdap_rib::ser_obj_t* encodeCDAPMessage(
 			const cdap_m_t &cdap_message);
 	const cdap_m_t* decodeCDAPMessage(
-			const cdap_rib::SerializedObject &cdap_message);
+			const cdap_rib::ser_obj_t &cdap_message);
 	void removeCDAPSession(int portId);
-	const cdap_rib::SerializedObject* encodeNextMessageToBeSent(
+	const cdap_rib::ser_obj_t* encodeNextMessageToBeSent(
 			const cdap_m_t &cdap_message, int port_id);
 	const cdap_m_t* messageReceived(
-			const cdap_rib::SerializedObject &encodedcdap_m_t,
+			const cdap_rib::ser_obj_t &encodedcdap_m_t,
 			int portId);
 	void messageSent(const cdap_m_t &cdap_message, int port_id);
 	int get_port_id(std::string destination_application_process_name);
@@ -584,7 +584,7 @@ class CDAPProvider : public CDAPProviderInterface
 
 	// Process and incoming CDAP message
 
-	void process_message(cdap_rib::SerializedObject &message,
+	void process_message(cdap_rib::ser_obj_t &message,
 			     unsigned int port);
  protected:
 	CDAPSessionManager *manager_;
@@ -616,8 +616,8 @@ class GPBSerializer : public SerializerInterface
 {
  public:
 	const cdap_m_t* deserializeMessage(
-			const cdap_rib::SerializedObject &message);
-	const cdap_rib::SerializedObject* serializeMessage(
+			const cdap_rib::ser_obj_t &message);
+	const cdap_rib::ser_obj_t* serializeMessage(
 			const cdap_m_t &cdapMessage);
 };
 
@@ -1604,7 +1604,7 @@ CDAPSession::~CDAPSession() throw ()
 	}
 	cancel_read_pending_messages_.clear();
 }
-const cdap_rib::SerializedObject* CDAPSession::encodeNextMessageToBeSent(
+const cdap_rib::ser_obj_t* CDAPSession::encodeNextMessageToBeSent(
 		const cdap_m_t &cdap_message)
 {
 	CDAPMessageValidator::validate(&cdap_message);
@@ -1700,7 +1700,7 @@ void CDAPSession::messageSent(const cdap_m_t &cdap_message)
 	messageSentOrReceived(cdap_message, true);
 }
 const cdap_m_t* CDAPSession::messageReceived(
-		const cdap_rib::SerializedObject &message)
+		const cdap_rib::ser_obj_t &message)
 {
 	const cdap_m_t *cdap_message = deserializeMessage(message);
 	messageSentOrReceived(*cdap_message, false);
@@ -2053,13 +2053,13 @@ void CDAPSession::cancelReadResponseMessageSentOrReceived(
 	else
 		pending_messages_recv_.erase(cdap_message.invoke_id_);
 }
-const cdap_rib::SerializedObject* CDAPSession::serializeMessage(
+const cdap_rib::ser_obj_t* CDAPSession::serializeMessage(
 		const cdap_m_t &cdap_message) const
 {
 	return serializer_->serializeMessage(cdap_message);
 }
 const cdap_m_t* CDAPSession::deserializeMessage(
-		const cdap_rib::SerializedObject &message) const
+		const cdap_rib::ser_obj_t &message) const
 {
 	return serializer_->deserializeMessage(message);
 }
@@ -2173,13 +2173,13 @@ CDAPSession* CDAPSessionManager::get_cdap_session(int port_id)
 	else
 		return 0;
 }
-const cdap_rib::SerializedObject* CDAPSessionManager::encodeCDAPMessage(
+const cdap_rib::ser_obj_t* CDAPSessionManager::encodeCDAPMessage(
 		const cdap_m_t &cdap_message)
 {
 	return serializer_->serializeMessage(cdap_message);
 }
 const CDAPMessage* CDAPSessionManager::decodeCDAPMessage(
-		const cdap_rib::SerializedObject &cdap_message)
+		const cdap_rib::ser_obj_t &cdap_message)
 {
 	return serializer_->deserializeMessage(cdap_message);
 }
@@ -2193,7 +2193,7 @@ void CDAPSessionManager::removeCDAPSession(int port_id)
 		cdap_sessions_.erase(itr);
 	}
 }
-const cdap_rib::SerializedObject* CDAPSessionManager::encodeNextMessageToBeSent(
+const cdap_rib::ser_obj_t* CDAPSessionManager::encodeNextMessageToBeSent(
 		const CDAPMessage &cdap_message, int port_id)
 {
 	std::map<int, CDAPSession*>::iterator it = cdap_sessions_.find(port_id);
@@ -2215,7 +2215,7 @@ const cdap_rib::SerializedObject* CDAPSessionManager::encodeNextMessageToBeSent(
 	return cdap_session->encodeNextMessageToBeSent(cdap_message);
 }
 const cdap_m_t* CDAPSessionManager::messageReceived(
-		const cdap_rib::SerializedObject &encoded_cdap_message,
+		const cdap_rib::ser_obj_t &encoded_cdap_message,
 		int port_id)
 {
 	const CDAPMessage *cdap_message = decodeCDAPMessage(
@@ -2490,7 +2490,7 @@ void CDAPSessionManager::assignInvokeId(cdap_m_t &cdap_message, bool invoke_id,
 
 // CLASS GPBWireMessageProvider
 const cdap_m_t* GPBSerializer::deserializeMessage(
-		const cdap_rib::SerializedObject &message)
+		const cdap_rib::ser_obj_t &message)
 {
 	cdap::impl::googleprotobuf::CDAPMessage gpfCDAPMessage;
 	cdap_m_t *cdapMessage = new cdap_m_t;
@@ -2598,7 +2598,7 @@ const cdap_m_t* GPBSerializer::deserializeMessage(
 	return cdapMessage;
 }
 // FIXME: check existanc of fields before seting
-const cdap_rib::SerializedObject* GPBSerializer::serializeMessage(
+const cdap_rib::ser_obj_t* GPBSerializer::serializeMessage(
 		const cdap_m_t &cdapMessage)
 {
 	cdap::impl::googleprotobuf::CDAPMessage gpfCDAPMessage;
@@ -2675,7 +2675,7 @@ const cdap_rib::SerializedObject* GPBSerializer::serializeMessage(
 	char *buffer = new char[size];
 	gpfCDAPMessage.SerializeToArray(buffer, size);
 	cdap_rib::ser_obj_t *serialized_message =
-			new cdap_rib::SerializedObject;
+			new cdap_rib::ser_obj_t;
 	serialized_message->message_ = buffer;
 	serialized_message->size_ = size;
 
@@ -2980,7 +2980,7 @@ void CDAPProvider::send_stop_result(unsigned int port,
 	delete m_sent;
 }
 
-void CDAPProvider::process_message(cdap_rib::SerializedObject &message,
+void CDAPProvider::process_message(cdap_rib::ser_obj_t &message,
 				   unsigned int port)
 {
 	const cdap_m_t *m_rcv;
@@ -3116,7 +3116,7 @@ AppCDAPProvider::AppCDAPProvider(cdap::CDAPCallbackInterface *callback,
 
 void AppCDAPProvider::send(const cdap_m_t *m_sent, int port)
 {
-	const cdap_rib::SerializedObject *ser_sent_m = manager_
+	const cdap_rib::ser_obj_t *ser_sent_m = manager_
 			->encodeNextMessageToBeSent(*m_sent, port);
 	manager_->messageSent(*m_sent, port);
 	rina::ipcManager->writeSDU(port, ser_sent_m->message_,
@@ -3133,7 +3133,7 @@ IPCPCDAPProvider::IPCPCDAPProvider(cdap::CDAPCallbackInterface *callback,
 
 void IPCPCDAPProvider::send(const cdap_m_t *m_sent, int port)
 {
-	const cdap_rib::SerializedObject *ser_sent_m = manager_
+	const cdap_rib::ser_obj_t *ser_sent_m = manager_
 			->encodeNextMessageToBeSent(*m_sent, port);
 	manager_->messageSent(*m_sent, port);
 	rina::kernelIPCProcess->writeMgmgtSDUToPortId(ser_sent_m->message_,

--- a/librina/src/rib_v2.cc
+++ b/librina/src/rib_v2.cc
@@ -2413,12 +2413,6 @@ void RIBDaemon::stop_request(const cdap_rib::con_handle_t &con,
 	rib->stop_request(con, obj, filt, invoke_id);
 }
 
-//
-// Encoder AbstractEncoder and base class
-//
-
-AbstractEncoder::~AbstractEncoder() {
-}
 
 //RIBObj/RIBObj_
 void RIBObj::create(const cdap_rib::con_handle_t &con,
@@ -2426,8 +2420,8 @@ void RIBObj::create(const cdap_rib::con_handle_t &con,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res){
 
 	operation_not_supported(res);
@@ -2449,7 +2443,7 @@ void RIBObj::read(const cdap_rib::con_handle_t &con,
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
 					const int invoke_id,
-					cdap_rib::SerializedObject &obj_reply,
+					cdap_rib::ser_obj_t &obj_reply,
 					cdap_rib::res_info_t& res){
 	operation_not_supported(res);
 }
@@ -2468,8 +2462,8 @@ void RIBObj::write(const cdap_rib::con_handle_t &con,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res){
 	operation_not_supported(res);
 }
@@ -2479,8 +2473,8 @@ void RIBObj::start(const cdap_rib::con_handle_t &con,
 			const std::string& class_,
 			const cdap_rib::filt_info_t &filt,
 			const int invoke_id,
-			const cdap_rib::SerializedObject &obj_req,
-			cdap_rib::SerializedObject &obj_reply,
+			const cdap_rib::ser_obj_t &obj_req,
+			cdap_rib::ser_obj_t &obj_reply,
 			cdap_rib::res_info_t& res){
 	operation_not_supported(res);
 }
@@ -2490,8 +2484,8 @@ void RIBObj::stop(const cdap_rib::con_handle_t &con,
 			const std::string& class_,
 			const cdap_rib::filt_info_t &filt,
 			const int invoke_id,
-			const cdap_rib::SerializedObject &obj_req,
-			cdap_rib::SerializedObject &obj_reply,
+			const cdap_rib::ser_obj_t &obj_req,
+			cdap_rib::ser_obj_t &obj_reply,
 			cdap_rib::res_info_t& res){
 	operation_not_supported(res);
 }

--- a/librina/test/test-rib_v2.cc
+++ b/librina/test/test-rib_v2.cc
@@ -266,7 +266,7 @@ public:
 					  const cdap_rib::flags_t &flags,
 					  const cdap_rib::res_info_t &res,
 					  int invoke_id){};
-	virtual void process_message(cdap_rib::SerializedObject &message,
+	virtual void process_message(cdap_rib::ser_obj_t &message,
 				     unsigned int port){};
 
 	virtual void destroy_session(int port){ (void)port; /*FIXME*/ };
@@ -274,28 +274,6 @@ public:
 
 static CDAPProviderMockup cdap_provider_mockup;
 static cdap::CDAPCallbackInterface* rib_provider = NULL;
-//
-//
-//
-
-class MyObjEncoder: public Encoder<uint32_t> {
-
-public:
-	virtual ~MyObjEncoder(){}
-
-	void encode(const uint32_t &obj, cdap_rib::ser_obj_t& serobj){
-		//TODO fill in
-		(void)obj;
-		(void)serobj;
-	};
-
-	virtual void decode(const cdap_rib::ser_obj_t &serobj,
-							uint32_t& des_obj){
-		//TODO fill in
-		(void)serobj;
-		(void)des_obj;
-	};
-};
 
 //A type
 class MyObj : public RIBObj {
@@ -309,7 +287,7 @@ public:
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
 					const int invoke_id,
-					cdap_rib::SerializedObject &obj_reply,
+					cdap_rib::ser_obj_t &obj_reply,
 					cdap_rib::res_info_t& res){
 
 
@@ -327,8 +305,6 @@ public:
 		res.code_ = cdap_rib::CDAP_SUCCESS;
 		return true;
 	}
-
-	MyObjEncoder encoder;
 	static const std::string class_;
 };
 
@@ -346,13 +322,9 @@ public:
 					const std::string& class_,
 					const cdap_rib::filt_info_t &filt,
 					const int invoke_id,
-					cdap_rib::SerializedObject &obj_reply,
+					cdap_rib::ser_obj_t &obj_reply,
 					cdap_rib::res_info_t& res){
 	};
-
-
-
-	MyObjEncoder encoder;
 	static const std::string class_;
 };
 
@@ -371,17 +343,13 @@ public:
 		return class_;
 	}
 
-	AbstractEncoder* get_encoder(){
-		return &encoder;
-	};
-
 	void start(const cdap_rib::con_handle_t &con,
 				const std::string& fqn,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res){
 
 		fprintf(stderr, "Got a START operation for path: '%s'\n", fqn.c_str());
@@ -396,8 +364,6 @@ public:
 		res.code_ = cdap_rib::CDAP_SUCCESS;
 		deleg_start_operations++;
 	}
-
-	MyObjEncoder encoder;
 	static const std::string class_;
 };
 
@@ -415,8 +381,8 @@ void create_callback_1(const rib_handle_t rib,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res){
 	CPPUNIT_ASSERT_MESSAGE("Invalid invoke id during create generic", invoke_id==7);
 	res.code_ = cdap_rib::CDAP_SUCCESS;
@@ -429,8 +395,8 @@ void create_callback_2(const rib_handle_t rib,
 				const std::string& class_,
 				const cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				const cdap_rib::SerializedObject &obj_req,
-				cdap_rib::SerializedObject &obj_reply,
+				const cdap_rib::ser_obj_t &obj_req,
+				cdap_rib::ser_obj_t &obj_reply,
 				cdap_rib::res_info_t& res){
 	CPPUNIT_ASSERT_MESSAGE("Invalid invoke id during create specific", invoke_id==6);
 	res.code_ = cdap_rib::CDAP_SUCCESS;

--- a/librina/wrap/java/Makefile.am
+++ b/librina/wrap/java/Makefile.am
@@ -6,6 +6,7 @@
 
 if BUILD_BINDINGS_JAVA
 
+JAVA_DIR		= $(top_builddir)/../java
 SWIG_DEBUG      = -v
 SWIG_CPPFLAGS   = -I$(top_srcdir)/include
 SWIG_FLAGS      = $(SWIG_DEBUG) $(SWIG_CPPFLAGS) -Werror -Wall
@@ -17,35 +18,36 @@ CLEANFILES =
 wrap.stamp: $(top_srcdir)/wrap/*.i $(top_srcdir)/include/librina/*.h
 	rm -f wrap.tmp
 	touch wrap.tmp
-	rm -r -f eu/irati/librina   &&			\
-	$(MKDIR_P) eu/irati/librina &&			\
+	rm -r -f $(JAVA_DIR)/eu/irati/librina   &&			\
+	$(MKDIR_P) $(JAVA_DIR)/eu/irati/librina &&			\
 	$(SWIG) $(SWIG_FLAGS) $(SWIG_JAVA_FLAGS)	\
 		-c++					\
 		-o librina_java.cc			\
-		-outdir ./eu/irati/librina		\
+		-outdir $(JAVA_DIR)/eu/irati/librina		\
 		$(top_srcdir)/wrap/librina.i || {	\
 		echo "Cannot wrap input file" ;		\
 		rm -f wrap.tmp ;			\
-		rm -r -f eu/irati/librina ;		\
+		rm -r -f $(JAVA_DIR)/eu/irati/librina ;		\
 		exit 1 ;				\
 	}
 	mv -f wrap.tmp $@
 
 CLEANFILES += wrap.stamp wrap.tmp
-CLEANFILES += librina_java.cc
+CLEANFILES += librina_java.cc+
 
 librina-java-classes: wrap.stamp
-	$(JAVAC) eu/irati/librina/*.java
+	$(JAVAC) $(JAVA_DIR)/eu/irati/librina/*.java
 
 librina.jar: librina-java-classes
+	cd $(JAVA_DIR) &&	\
 	$(JAR) -cvf librina.jar eu/irati/librina/*.class
-
+	mv $(JAVA_DIR)/librina.jar $(builddir)
 CLEANFILES += librina.jar
 
 pkgdata_DATA = librina.jar
 
 clean-local:
-	rm -r -f eu/irati/librina
+	rm -r -f $(JAVA_DIR)/eu/irati/librina
 
 librina_java.cc: wrap.stamp
 

--- a/rina-tools/src/manager/manager.cc
+++ b/rina-tools/src/manager/manager.cc
@@ -27,6 +27,7 @@
 #include <librina/cdap_v2.h>
 #include <librina/common.h>
 #include <rinad/ipcm/encoders_mad.h>
+#include <rinad/ipcm/structures_mad.h>
 
 #include "manager.h"
 
@@ -67,7 +68,7 @@ void ConnectionCallback::remote_read_result(
 	std::cout << "Query Rib operation returned result " << res.code_
 			<< std::endl;
 	std::string query_rib;
-	rinad::mad_manager::encoders::StringEncoder().decode(obj.value_,
+	rinad::mad_manager::StringEncoder().decode(obj.value_,
 								query_rib);
 	std::cout << "QueryRIB:" << std::endl << query_rib << std::endl;
 }
@@ -121,7 +122,7 @@ void ManagerWorker::cacep(int port_id)
 {
 	char buffer[max_sdu_size_in_bytes];
 	int bytes_read = ipcManager->readSDU(port_id, buffer, max_sdu_size_in_bytes);
-	cdap_rib::SerializedObject message;
+	cdap_rib::ser_obj_t message;
 	message.message_ = buffer;
 	message.size_ = bytes_read;
 	cdap::getProvider()->process_message(message, port_id);
@@ -131,7 +132,7 @@ bool ManagerWorker::createIPCP_1(int port_id)
 {
 	char buffer[max_sdu_size_in_bytes];
 
-	mad_manager::structures::ipcp_config_t ipc_config;
+	mad_manager::ipcp_config_t ipc_config;
 	ipc_config.process_instance = "1";
 	ipc_config.process_name = "test1.IRATI";
 	ipc_config.process_type = "normal-ipc";
@@ -142,11 +143,8 @@ bool ManagerWorker::createIPCP_1(int port_id)
 	obj.name_ = IPCP_1;
 	obj.class_ = "IPCProcess";
 	obj.inst_ = 0;
-	mad_manager::encoders::IPCPConfigEncoder().encode(ipc_config,
+	mad_manager::IPCPConfigEncoder().encode(ipc_config,
 								obj.value_);
-	mad_manager::structures::ipcp_config_t object;
-	mad_manager::encoders::IPCPConfigEncoder().decode(obj.value_, object);
-
 	cdap_rib::flags_t flags;
 	flags.flags_ = cdap_rib::flags_t::NONE_FLAGS;
 
@@ -161,7 +159,7 @@ bool ManagerWorker::createIPCP_1(int port_id)
 	try {
 		int bytes_read = ipcManager->readSDU(port_id, buffer,
 							max_sdu_size_in_bytes);
-		cdap_rib::SerializedObject message;
+		cdap_rib::ser_obj_t message;
 		message.message_ = buffer;
 		message.size_ = bytes_read;
 		cdap_prov_->process_message(message, port_id);
@@ -176,7 +174,7 @@ bool ManagerWorker::createIPCP_1(int port_id)
 bool ManagerWorker::createIPCP_2(int port_id) {
 	char buffer[max_sdu_size_in_bytes];
 
-	mad_manager::structures::ipcp_config_t ipc_config;
+	mad_manager::ipcp_config_t ipc_config;
 	ipc_config.process_instance = "1";
 	ipc_config.process_name = "test2.IRATI";
 	ipc_config.process_type = "normal-ipc";
@@ -191,10 +189,10 @@ bool ManagerWorker::createIPCP_2(int port_id) {
 	obj.name_ = IPCP_2;
 	obj.class_ = "IPCProcess";
 	obj.inst_ = 0;
-	mad_manager::encoders::IPCPConfigEncoder().encode(ipc_config,
+	mad_manager::IPCPConfigEncoder().encode(ipc_config,
 								obj.value_);
-	mad_manager::structures::ipcp_config_t object;
-	mad_manager::encoders::IPCPConfigEncoder().decode(obj.value_, object);
+	mad_manager::ipcp_config_t object;
+	mad_manager::IPCPConfigEncoder().decode(obj.value_, object);
 
 	cdap_rib::flags_t flags;
 	flags.flags_ = cdap_rib::flags_t::NONE_FLAGS;
@@ -210,7 +208,7 @@ bool ManagerWorker::createIPCP_2(int port_id) {
 	try {
 		int bytes_read = ipcManager->readSDU(port_id, buffer,
 							max_sdu_size_in_bytes);
-		cdap_rib::SerializedObject message;
+		cdap_rib::ser_obj_t message;
 		message.message_ = buffer;
 		message.size_ = bytes_read;
 		cdap_prov_->process_message(message, port_id);
@@ -225,7 +223,7 @@ bool ManagerWorker::createIPCP_2(int port_id) {
 bool ManagerWorker::createIPCP_3(int port_id) {
 	char buffer[max_sdu_size_in_bytes];
 
-	mad_manager::structures::ipcp_config_t ipc_config;
+	mad_manager::ipcp_config_t ipc_config;
 	ipc_config.process_instance = "1";
 	ipc_config.process_name = "test3.IRATI";
 	ipc_config.process_type = "normal-ipc";
@@ -239,10 +237,10 @@ bool ManagerWorker::createIPCP_3(int port_id) {
 	obj.name_ = IPCP_3;
 	obj.class_ = "IPCProcess";
 	obj.inst_ = 0;
-	mad_manager::encoders::IPCPConfigEncoder().encode(ipc_config,
+	mad_manager::IPCPConfigEncoder().encode(ipc_config,
 								obj.value_);
-	mad_manager::structures::ipcp_config_t object;
-	mad_manager::encoders::IPCPConfigEncoder().decode(obj.value_, object);
+	mad_manager::ipcp_config_t object;
+	mad_manager::IPCPConfigEncoder().decode(obj.value_, object);
 
 	cdap_rib::flags_t flags;
 	flags.flags_ = cdap_rib::flags_t::NONE_FLAGS;
@@ -258,7 +256,7 @@ bool ManagerWorker::createIPCP_3(int port_id) {
 	try {
 		int bytes_read = ipcManager->readSDU(port_id, buffer,
 							max_sdu_size_in_bytes);
-		cdap_rib::SerializedObject message;
+		cdap_rib::ser_obj_t message;
 		message.message_ = buffer;
 		message.size_ = bytes_read;
 		cdap_prov_->process_message(message, port_id);
@@ -292,7 +290,7 @@ void ManagerWorker::queryRIB(int port_id, std::string name)
         int bytes_read = ipcManager->readSDU(port_id,
         				     buffer,
         				     max_sdu_size_in_bytes);
-        cdap_rib::SerializedObject message;
+        cdap_rib::ser_obj_t message;
         message.message_ = buffer;
         message.size_ = bytes_read;
         cdap_prov_->process_message(message, port_id);

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-client.cc
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-client.cc
@@ -165,7 +165,7 @@ void Client::cacep()
         	}
         }
 
-        cdap_rib::SerializedObject message;
+        cdap_rib::ser_obj_t message;
         message.message_ = buffer;
         message.size_ = bytes_read;
         cdap_prov_->process_message(message, flow_.portId);
@@ -238,7 +238,7 @@ void Client::sendReadRMessage()
                         		break;
                         	}
                         }
-                        cdap_rib::SerializedObject message;
+                        cdap_rib::ser_obj_t message;
                         message.message_ = buffer;
                         message.size_ = bytes_read;
                         cdap_prov_->process_message(message,flow_.portId);
@@ -271,7 +271,7 @@ void Client::release()
         	}
         }
 
-        cdap_rib::SerializedObject message;
+        cdap_rib::ser_obj_t message;
         message.message_ = buffer;
         message.size_ = bytes_read;
         cdap_prov_->process_message(message, flow_.portId);

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-server.cc
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-server.cc
@@ -123,7 +123,7 @@ void CDAPEchoWorker::serveEchoFlow(int port_id)
 			break;
 		}
 
-		cdap_rib::SerializedObject message;
+		cdap_rib::ser_obj_t message;
 		message.message_ = buffer;
 		message.size_ = bytes_read;
 		cdap_prov->process_message(message, port_id);

--- a/rinad/Makefile.am
+++ b/rinad/Makefile.am
@@ -14,7 +14,8 @@ SUBDIRS =					\
 	src					\
 	doc					\
 	tools					\
-	etc
+	etc					\
+	wrap
 
 EXTRA_DIST =					\
 	bootstrap				\

--- a/rinad/configure.ac
+++ b/rinad/configure.ac
@@ -133,6 +133,47 @@ PKG_CHECK_MODULES(LIBPROTOBUF, [protobuf >= $LIBPROTOBUF_MIN_VERSION],, [
 AC_PATH_PROG([PERL], [perl], [no])
 AM_CONDITIONAL([HAVE_PERL], [ test "$PERL" != "no" ])
 
+build_bindings=yes
+build_bindings_java=yes
+AS_IF([test "$build_bindings" = "yes"],[
+    AX_PKG_SWIG([2.0],[
+        #
+        # SWIG version > 2.0.4 && < 2.0.8 have a bug preventing correct
+        # bindings generation
+        #
+
+        SWIG_VERSION=`$SWIG -version 2>&1 | $GREP 'SWIG Version' | $SED 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`
+        AX_COMPARE_VERSION($SWIG_VERSION, le, [2.0.4],,[
+            AX_COMPARE_VERSION($SWIG_VERSION, ge, [2.0.8],,[
+                AC_MSG_ERROR([SWIG versions in 2.0.4, ..., 2.0.8 range will not compile])
+            ])
+        ])
+    ],[
+        AC_MSG_ERROR([Your system lacks of SWIG (>2.0) support, bindings generation is not possible])
+    ])
+])
+
+AS_IF([test "$build_bindings_java" = "yes"],[
+    AX_PROG_JAVAC
+    AX_JNI_INCLUDE_DIR
+
+    # FIXME: Ugly as hell ...
+    JNI_CPPFLAGS=""
+    for JNI_INCLUDE_DIR in $JNI_INCLUDE_DIRS ;
+    do
+        JNI_CPPFLAGS="$JNI_CPPFLAGS -I$JNI_INCLUDE_DIR" ;
+    done
+    AC_SUBST(JNI_CPPFLAGS, $JNI_CPPFLAGS)
+    AX_PROG_JAR
+])
+AM_CONDITIONAL(BUILD_BINDINGS_JAVA, [test $build_bindings_java = yes])
+
+AC_PATH_PROG([MVN],[mvn],[])
+AS_IF([test x"$MVN" != x""],[
+    AC_MSG_WARN([Your system lacks of maven support, Java parts will not be built/installed])
+])
+AM_CONDITIONAL(BUILD_MAVEN_SUPPORT, [test x"$MVN" != x""])
+
 AC_CONFIG_FILES([
     Makefile
 
@@ -150,6 +191,9 @@ AC_CONFIG_FILES([
     src/ipcm/addons/ma/ribs/Makefile
     src/ipcm/include/Makefile
     src/ipcm/include/ipcm/Makefile
+
+    wrap/Makefile
+    wrap/java/Makefile
 
     doc/Makefile
     tools/Makefile

--- a/rinad/m4/ax_compare_version.m4
+++ b/rinad/m4/ax_compare_version.m4
@@ -1,0 +1,177 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_compare_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPARE_VERSION(VERSION_A, OP, VERSION_B, [ACTION-IF-TRUE], [ACTION-IF-FALSE])
+#
+# DESCRIPTION
+#
+#   This macro compares two version strings. Due to the various number of
+#   minor-version numbers that can exist, and the fact that string
+#   comparisons are not compatible with numeric comparisons, this is not
+#   necessarily trivial to do in a autoconf script. This macro makes doing
+#   these comparisons easy.
+#
+#   The six basic comparisons are available, as well as checking equality
+#   limited to a certain number of minor-version levels.
+#
+#   The operator OP determines what type of comparison to do, and can be one
+#   of:
+#
+#    eq  - equal (test A == B)
+#    ne  - not equal (test A != B)
+#    le  - less than or equal (test A <= B)
+#    ge  - greater than or equal (test A >= B)
+#    lt  - less than (test A < B)
+#    gt  - greater than (test A > B)
+#
+#   Additionally, the eq and ne operator can have a number after it to limit
+#   the test to that number of minor versions.
+#
+#    eq0 - equal up to the length of the shorter version
+#    ne0 - not equal up to the length of the shorter version
+#    eqN - equal up to N sub-version levels
+#    neN - not equal up to N sub-version levels
+#
+#   When the condition is true, shell commands ACTION-IF-TRUE are run,
+#   otherwise shell commands ACTION-IF-FALSE are run. The environment
+#   variable 'ax_compare_version' is always set to either 'true' or 'false'
+#   as well.
+#
+#   Examples:
+#
+#     AX_COMPARE_VERSION([3.15.7],[lt],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[lt],[3.15.8])
+#
+#   would both be true.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[gt],[3.15.8])
+#
+#   would both be false.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq2],[3.15.8])
+#
+#   would be true because it is only comparing two minor versions.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq0],[3.15])
+#
+#   would be true because it is only comparing the lesser number of minor
+#   versions of the two values.
+#
+#   Note: The characters that separate the version numbers do not matter. An
+#   empty string is the same as version 0. OP is evaluated by autoconf, not
+#   configure, so must be a string, not a variable.
+#
+#   The author would like to acknowledge Guido Draheim whose advice about
+#   the m4_case and m4_ifvaln functions make this macro only include the
+#   portions necessary to perform the specific comparison specified by the
+#   OP argument in the final configure script.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tim Toolan <toolan@ele.uri.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+dnl #########################################################################
+AC_DEFUN([AX_COMPARE_VERSION], [
+  AC_REQUIRE([AC_PROG_AWK])
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+  AS_VAR_PUSHDEF([A],[ax_compare_version_A])
+  A=`echo "$1" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  AS_VAR_PUSHDEF([B],[ax_compare_version_B])
+  B=`echo "$3" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  dnl # In the case of le, ge, lt, and gt, the strings are sorted as necessary
+  dnl # then the first line is used to determine if the condition is true.
+  dnl # The sed right after the echo is to remove any indented white space.
+  m4_case(m4_tolower($2),
+  [lt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [gt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [le],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],
+  [ge],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],[
+    dnl Split the operator from the subversion count if present.
+    m4_bmatch(m4_substr($2,2),
+    [0],[
+      # A count of zero means use the length of the shorter version.
+      # Determine the number of characters in A and B.
+      ax_compare_version_len_A=`echo "$A" | $AWK '{print(length)}'`
+      ax_compare_version_len_B=`echo "$B" | $AWK '{print(length)}'`
+
+      # Set A to no more than B's length and B to no more than A's length.
+      A=`echo "$A" | sed "s/\(.\{$ax_compare_version_len_B\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(.\{$ax_compare_version_len_A\}\).*/\1/"`
+    ],
+    [[0-9]+],[
+      # A count greater than zero means use only that many subversions
+      A=`echo "$A" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+    ],
+    [.+],[
+      AC_WARNING(
+        [illegal OP numeric parameter: $2])
+    ],[])
+
+    # Pad zeros at end of numbers to make same length.
+    ax_compare_version_tmp_A="$A`echo $B | sed 's/./0/g'`"
+    B="$B`echo $A | sed 's/./0/g'`"
+    A="$ax_compare_version_tmp_A"
+
+    # Check for equality or inequality as necessary.
+    m4_case(m4_tolower(m4_substr($2,0,2)),
+    [eq],[
+      test "x$A" = "x$B" && ax_compare_version=true
+    ],
+    [ne],[
+      test "x$A" != "x$B" && ax_compare_version=true
+    ],[
+      AC_WARNING([illegal OP parameter: $2])
+    ])
+  ])
+
+  AS_VAR_POPDEF([A])dnl
+  AS_VAR_POPDEF([B])dnl
+
+  dnl # Execute ACTION-IF-TRUE / ACTION-IF-FALSE.
+  if test "$ax_compare_version" = "true" ; then
+    m4_ifvaln([$4],[$4],[:])dnl
+    m4_ifvaln([$5],[else $5])dnl
+  fi
+]) dnl AX_COMPARE_VERSION

--- a/rinad/m4/ax_jni_include_dir.m4
+++ b/rinad/m4/ax_jni_include_dir.m4
@@ -1,0 +1,132 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_jni_include_dir.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_JNI_INCLUDE_DIR
+#
+# DESCRIPTION
+#
+#   AX_JNI_INCLUDE_DIR finds include directories needed for compiling
+#   programs using the JNI interface.
+#
+#   JNI include directories are usually in the Java distribution. This is
+#   deduced from the value of $JAVA_HOME, $JAVAC, or the path to "javac", in
+#   that order. When this macro completes, a list of directories is left in
+#   the variable JNI_INCLUDE_DIRS.
+#
+#   Example usage follows:
+#
+#     AX_JNI_INCLUDE_DIR
+#
+#     for JNI_INCLUDE_DIR in $JNI_INCLUDE_DIRS
+#     do
+#             CPPFLAGS="$CPPFLAGS -I$JNI_INCLUDE_DIR"
+#     done
+#
+#   If you want to force a specific compiler:
+#
+#   - at the configure.in level, set JAVAC=yourcompiler before calling
+#   AX_JNI_INCLUDE_DIR
+#
+#   - at the configure level, setenv JAVAC
+#
+#   Note: This macro can work with the autoconf M4 macros for Java programs.
+#   This particular macro is not part of the original set of macros.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Don Anderson <dda@sleepycat.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+AU_ALIAS([AC_JNI_INCLUDE_DIR], [AX_JNI_INCLUDE_DIR])
+AC_DEFUN([AX_JNI_INCLUDE_DIR],[
+
+JNI_INCLUDE_DIRS=""
+
+if test "x$JAVA_HOME" != x; then
+	_JTOPDIR="$JAVA_HOME"
+else
+	if test "x$JAVAC" = x; then
+		JAVAC=javac
+	fi
+	AC_PATH_PROG([_ACJNI_JAVAC], [$JAVAC], [no])
+	if test "x$_ACJNI_JAVAC" = xno; then
+		AC_MSG_ERROR([cannot find JDK; try setting \$JAVAC or \$JAVA_HOME])
+	fi
+	_ACJNI_FOLLOW_SYMLINKS("$_ACJNI_JAVAC")
+	_JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
+fi
+
+case "$host_os" in
+        darwin*)        # Apple JDK is at /System location and has headers symlinked elsewhere
+                        case "$_JTOPDIR" in
+                        /System/Library/Frameworks/JavaVM.framework/*)
+				_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
+				_JINC="$_JTOPDIR/Headers";;
+			*)      _JINC="$_JTOPDIR/include";;
+                        esac;;
+        *)              _JINC="$_JTOPDIR/include";;
+esac
+_AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])
+_AS_ECHO_LOG([_JINC=$_JINC])
+
+# On Mac OS X 10.6.4, jni.h is a symlink:
+# /System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers/jni.h
+# -> ../../CurrentJDK/Headers/jni.h.
+AC_CHECK_FILE([$_JINC/jni.h],
+	[JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JINC"],
+	[_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
+	 AC_CHECK_FILE([$_JTOPDIR/include/jni.h],
+		[JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JTOPDIR/include"],
+                AC_MSG_ERROR([cannot find JDK header files]))
+	])
+
+# get the likely subdirectories for system specific java includes
+case "$host_os" in
+bsdi*)          _JNI_INC_SUBDIRS="bsdos";;
+freebsd*)       _JNI_INC_SUBDIRS="freebsd";;
+darwin*)        _JNI_INC_SUBDIRS="darwin";;
+linux*)         _JNI_INC_SUBDIRS="linux genunix";;
+osf*)           _JNI_INC_SUBDIRS="alpha";;
+solaris*)       _JNI_INC_SUBDIRS="solaris";;
+mingw*)		_JNI_INC_SUBDIRS="win32";;
+cygwin*)	_JNI_INC_SUBDIRS="win32";;
+*)              _JNI_INC_SUBDIRS="genunix";;
+esac
+
+# add any subdirectories that are present
+for JINCSUBDIR in $_JNI_INC_SUBDIRS
+do
+    if test -d "$_JTOPDIR/include/$JINCSUBDIR"; then
+         JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JTOPDIR/include/$JINCSUBDIR"
+    fi
+done
+])
+
+# _ACJNI_FOLLOW_SYMLINKS <path>
+# Follows symbolic links on <path>,
+# finally setting variable _ACJNI_FOLLOWED
+# ----------------------------------------
+AC_DEFUN([_ACJNI_FOLLOW_SYMLINKS],[
+# find the include directory relative to the javac executable
+_cur="$1"
+while ls -ld "$_cur" 2>/dev/null | grep " -> " >/dev/null; do
+        AC_MSG_CHECKING([symlink for $_cur])
+        _slink=`ls -ld "$_cur" | sed 's/.* -> //'`
+        case "$_slink" in
+        /*) _cur="$_slink";;
+        # 'X' avoids triggering unwanted echo options.
+        *) _cur=`echo "X$_cur" | sed -e 's/^X//' -e 's:[[^/]]*$::'`"$_slink";;
+        esac
+        AC_MSG_RESULT([$_cur])
+done
+_ACJNI_FOLLOWED="$_cur"
+])# _ACJNI

--- a/rinad/m4/ax_pkg_swig.m4
+++ b/rinad/m4/ax_pkg_swig.m4
@@ -1,0 +1,135 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_pkg_swig.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PKG_SWIG([major.minor.micro], [action-if-found], [action-if-not-found])
+#
+# DESCRIPTION
+#
+#   This macro searches for a SWIG installation on your system. If found,
+#   then SWIG is AC_SUBST'd; if not found, then $SWIG is empty.  If SWIG is
+#   found, then SWIG_LIB is set to the SWIG library path, and AC_SUBST'd.
+#
+#   You can use the optional first argument to check if the version of the
+#   available SWIG is greater than or equal to the value of the argument. It
+#   should have the format: N[.N[.N]] (N is a number between 0 and 999. Only
+#   the first N is mandatory.) If the version argument is given (e.g.
+#   1.3.17), AX_PKG_SWIG checks that the swig package is this version number
+#   or higher.
+#
+#   As usual, action-if-found is executed if SWIG is found, otherwise
+#   action-if-not-found is executed.
+#
+#   In configure.in, use as:
+#
+#     AX_PKG_SWIG(1.3.17, [], [ AC_MSG_ERROR([SWIG is required to build..]) ])
+#     AX_SWIG_ENABLE_CXX
+#     AX_SWIG_MULTI_MODULE_SUPPORT
+#     AX_SWIG_PYTHON
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Sebastian Huber <sebastian-huber@web.de>
+#   Copyright (c) 2008 Alan W. Irwin
+#   Copyright (c) 2008 Rafael Laboissiere <rafael@laboissiere.net>
+#   Copyright (c) 2008 Andrew Collier
+#   Copyright (c) 2011 Murray Cumming <murrayc@openismus.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 11
+
+AC_DEFUN([AX_PKG_SWIG],[
+        # Ubuntu has swig 2.0 as /usr/bin/swig2.0
+        AC_PATH_PROGS([SWIG],[swig swig2.0])
+        if test -z "$SWIG" ; then
+                m4_ifval([$3],[$3],[:])
+        elif test -n "$1" ; then
+                AC_MSG_CHECKING([SWIG version])
+                [swig_version=`$SWIG -version 2>&1 | grep 'SWIG Version' | sed 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`]
+                AC_MSG_RESULT([$swig_version])
+                if test -n "$swig_version" ; then
+                        # Calculate the required version number components
+                        [required=$1]
+                        [required_major=`echo $required | sed 's/[^0-9].*//'`]
+                        if test -z "$required_major" ; then
+                                [required_major=0]
+                        fi
+                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
+                        [required_minor=`echo $required | sed 's/[^0-9].*//'`]
+                        if test -z "$required_minor" ; then
+                                [required_minor=0]
+                        fi
+                        [required=`echo $required | sed 's/[0-9]*[^0-9]//'`]
+                        [required_patch=`echo $required | sed 's/[^0-9].*//'`]
+                        if test -z "$required_patch" ; then
+                                [required_patch=0]
+                        fi
+                        # Calculate the available version number components
+                        [available=$swig_version]
+                        [available_major=`echo $available | sed 's/[^0-9].*//'`]
+                        if test -z "$available_major" ; then
+                                [available_major=0]
+                        fi
+                        [available=`echo $available | sed 's/[0-9]*[^0-9]//'`]
+                        [available_minor=`echo $available | sed 's/[^0-9].*//'`]
+                        if test -z "$available_minor" ; then
+                                [available_minor=0]
+                        fi
+                        [available=`echo $available | sed 's/[0-9]*[^0-9]//'`]
+                        [available_patch=`echo $available | sed 's/[^0-9].*//'`]
+                        if test -z "$available_patch" ; then
+                                [available_patch=0]
+                        fi
+                        # Convert the version tuple into a single number for easier comparison.
+                        # Using base 100 should be safe since SWIG internally uses BCD values
+                        # to encode its version number.
+                        required_swig_vernum=`expr $required_major \* 10000 \
+                            \+ $required_minor \* 100 \+ $required_patch`
+                        available_swig_vernum=`expr $available_major \* 10000 \
+                            \+ $available_minor \* 100 \+ $available_patch`
+
+                        if test $available_swig_vernum -lt $required_swig_vernum; then
+                                AC_MSG_WARN([SWIG version >= $1 is required.  You have $swig_version.])
+                                SWIG=''
+                                m4_ifval([$3],[$3],[])
+                        else
+                                AC_MSG_CHECKING([for SWIG library])
+                                SWIG_LIB=`$SWIG -swiglib`
+                                AC_MSG_RESULT([$SWIG_LIB])
+                                m4_ifval([$2],[$2],[])
+                        fi
+                else
+                        AC_MSG_WARN([cannot determine SWIG version])
+                        SWIG=''
+                        m4_ifval([$3],[$3],[])
+                fi
+        fi
+        AC_SUBST([SWIG_LIB])
+])

--- a/rinad/m4/ax_prog_jar.m4
+++ b/rinad/m4/ax_prog_jar.m4
@@ -1,0 +1,52 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_prog_jar.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_JAR
+#
+# DESCRIPTION
+#
+#   AX_PROG_JAR tests for an existing jar program. It uses the environment
+#   variable JAR then tests in sequence various common jar programs.
+#
+#   If you want to force a specific compiler:
+#
+#   - at the configure.in level, set JAR=yourcompiler before calling
+#   AX_PROG_JAR
+#
+#   - at the configure level, setenv JAR
+#
+#   You can use the JAR variable in your Makefile.in, with @JAR@.
+#
+#   Note: This macro depends on the autoconf M4 macros for Java programs. It
+#   is VERY IMPORTANT that you download that whole set, some macros depend
+#   on other. Unfortunately, the autoconf archive does not support the
+#   concept of set of macros, so I had to break it for submission.
+#
+#   The general documentation of those macros, as well as the sample
+#   configure.in, is included in the AX_PROG_JAVA macro.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Egon Willighagen <e.willighagen@science.ru.nl>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AU_ALIAS([AC_PROG_JAR], [AX_PROG_JAR])
+AC_DEFUN([AX_PROG_JAR],[
+AC_REQUIRE([AC_EXEEXT])dnl
+if test "x$JAVAPREFIX" = x; then
+        test "x$JAR" = x && AC_CHECK_PROGS(JAR, jar$EXEEXT)
+else
+        test "x$JAR" = x && AC_CHECK_PROGS(JAR, jar, $JAVAPREFIX)
+fi
+test "x$JAR" = x && AC_MSG_ERROR([no acceptable jar program found in \$PATH])
+AC_PROVIDE([$0])dnl
+])

--- a/rinad/m4/ax_prog_javac.m4
+++ b/rinad/m4/ax_prog_javac.m4
@@ -1,0 +1,79 @@
+# ===========================================================================
+#       http://www.gnu.org/software/autoconf-archive/ax_prog_javac.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_JAVAC
+#
+# DESCRIPTION
+#
+#   AX_PROG_JAVAC tests an existing Java compiler. It uses the environment
+#   variable JAVAC then tests in sequence various common Java compilers. For
+#   political reasons, it starts with the free ones.
+#
+#   If you want to force a specific compiler:
+#
+#   - at the configure.in level, set JAVAC=yourcompiler before calling
+#   AX_PROG_JAVAC
+#
+#   - at the configure level, setenv JAVAC
+#
+#   You can use the JAVAC variable in your Makefile.in, with @JAVAC@.
+#
+#   *Warning*: its success or failure can depend on a proper setting of the
+#   CLASSPATH env. variable.
+#
+#   TODO: allow to exclude compilers (rationale: most Java programs cannot
+#   compile with some compilers like guavac).
+#
+#   Note: This is part of the set of autoconf M4 macros for Java programs.
+#   It is VERY IMPORTANT that you download the whole set, some macros depend
+#   on other. Unfortunately, the autoconf archive does not support the
+#   concept of set of macros, so I had to break it for submission. The
+#   general documentation, as well as the sample configure.in, is included
+#   in the AX_PROG_JAVA macro.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Stephane Bortzmeyer <bortzmeyer@pasteur.fr>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 6
+
+AU_ALIAS([AC_PROG_JAVAC], [AX_PROG_JAVAC])
+AC_DEFUN([AX_PROG_JAVAC],[
+if test "x$JAVAPREFIX" = x; then
+        test "x$JAVAC" = x && AC_CHECK_PROGS(JAVAC, "gcj -C" guavac jikes javac)
+else
+        test "x$JAVAC" = x && AC_CHECK_PROGS(JAVAC, "gcj -C" guavac jikes javac, $JAVAPREFIX)
+fi
+test "x$JAVAC" = x && AC_MSG_ERROR([no acceptable Java compiler found in \$PATH])
+AX_PROG_JAVAC_WORKS
+AC_PROVIDE([$0])dnl
+])

--- a/rinad/m4/ax_prog_javac_works.m4
+++ b/rinad/m4/ax_prog_javac_works.m4
@@ -1,0 +1,72 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_prog_javac_works.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_JAVAC_WORKS
+#
+# DESCRIPTION
+#
+#   Internal use ONLY.
+#
+#   Note: This is part of the set of autoconf M4 macros for Java programs.
+#   It is VERY IMPORTANT that you download the whole set, some macros depend
+#   on other. Unfortunately, the autoconf archive does not support the
+#   concept of set of macros, so I had to break it for submission. The
+#   general documentation, as well as the sample configure.in, is included
+#   in the AX_PROG_JAVA macro.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Stephane Bortzmeyer <bortzmeyer@pasteur.fr>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 6
+
+AU_ALIAS([AC_PROG_JAVAC_WORKS], [AX_PROG_JAVAC_WORKS])
+AC_DEFUN([AX_PROG_JAVAC_WORKS],[
+AC_CACHE_CHECK([if $JAVAC works], ac_cv_prog_javac_works, [
+JAVA_TEST=Test.java
+CLASS_TEST=Test.class
+cat << \EOF > $JAVA_TEST
+/* [#]line __oline__ "configure" */
+public class Test {
+}
+EOF
+if AC_TRY_COMMAND($JAVAC $JAVACFLAGS $JAVA_TEST) >/dev/null 2>&1; then
+  ac_cv_prog_javac_works=yes
+else
+  AC_MSG_ERROR([The Java compiler $JAVAC failed (see config.log, check the CLASSPATH?)])
+  echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+  cat $JAVA_TEST >&AS_MESSAGE_LOG_FD
+fi
+rm -f $JAVA_TEST $CLASS_TEST
+])
+AC_PROVIDE([$0])dnl
+])

--- a/rinad/src/common/Makefile.am
+++ b/rinad/src/common/Makefile.am
@@ -14,7 +14,8 @@ lib_LTLIBRARIES = librinad.la
 librinad_ladir = $(pkgincludedir)/ipcm
 
 #Distributable headers
-librinad_la_HEADERS = encoders_mad.h
+librinad_la_HEADERS = structures_mad.h \
+					  encoders_mad.h
 
 librinad_la_CFLAGS   =
 librinad_la_CPPFLAGS =				\
@@ -32,5 +33,6 @@ librinad_la_SOURCES  =					\
 	debug.cc              debug.h                   \
 	rina-configuration.cc rina-configuration.h	\
 	encoder.cc	      encoder.h			\
+	structures_mad.h 					\
 	encoders_mad.cc	      encoders_mad.h			\
 			      concurrency.h

--- a/rinad/src/common/encoders_mad.cc
+++ b/rinad/src/common/encoders_mad.cc
@@ -27,7 +27,6 @@
 
 namespace rinad {
 namespace mad_manager {
-namespace encoders {
 
 //
 // Simple types
@@ -57,7 +56,7 @@ void StringEncoder::decode(const rina::cdap_rib::ser_obj_t& ser_obj,
 
 namespace ipcpConfigEncoder {
 
-void encode_enrollment(const structures::enrollment_config_t &obj,
+void encode_enrollment(const enrollment_config_t &obj,
 			messages::enrollment_config &ser_obj) {
 	ser_obj.set_neighbor_name(obj.neighbor_name);
 	ser_obj.set_neighbor_instance(obj.neighbor_instance);
@@ -65,7 +64,7 @@ void encode_enrollment(const structures::enrollment_config_t &obj,
 	ser_obj.set_enrollment_underlying_dif(obj.enr_un_dif);
 }
 void decode_enrollment(const messages::enrollment_config &ser_obj,
-			structures::enrollment_config_t &obj) {
+			enrollment_config_t &obj) {
 	obj.neighbor_name = ser_obj.neighbor_name();
 	obj.neighbor_instance = ser_obj.neighbor_instance();
 	obj.enr_dif = ser_obj.enrollment_dif();
@@ -73,7 +72,7 @@ void decode_enrollment(const messages::enrollment_config &ser_obj,
 }
 }
 
-void IPCPConfigEncoder::encode(const structures::ipcp_config_t& obj,
+void IPCPConfigEncoder::encode(const rinad::mad_manager::ipcp_config_t& obj,
 				rina::cdap_rib::ser_obj_t& ser_obj) {
 	messages::ipcp_config gpf_obj;
 	gpf_obj.set_process_name(obj.process_name);
@@ -104,7 +103,7 @@ void IPCPConfigEncoder::encode(const structures::ipcp_config_t& obj,
 }
 
 void IPCPConfigEncoder::decode(const rina::cdap_rib::ser_obj_t& ser_obj,
-				structures::ipcp_config_t& obj) {
+				rinad::mad_manager::ipcp_config_t& obj) {
 	messages::ipcp_config gpf_obj;
 	gpf_obj.ParseFromArray(ser_obj.message_, ser_obj.size_);
 	obj.process_name = gpf_obj.process_name();
@@ -125,8 +124,8 @@ void IPCPConfigEncoder::decode(const rina::cdap_rib::ser_obj_t& ser_obj,
 //
 //IPCP encoder (read)
 //
-void IPCPEncoder::encode(const structures::ipcp_t& obj,
-				rina::cdap_rib::SerializedObject& serobj) {
+void IPCPEncoder::encode(const ipcp_t& obj,
+				rina::cdap_rib::ser_obj_t& serobj) {
 
 	messages::ipcp m;
 	m.set_processid(obj.process_id);
@@ -144,8 +143,8 @@ void IPCPEncoder::encode(const structures::ipcp_t& obj,
 	m.SerializeToArray(serobj.message_, serobj.size_);
 }
 
-void IPCPEncoder::decode(const rina::cdap_rib::SerializedObject& serobj,
-				structures::ipcp_t& des_obj) {
+void IPCPEncoder::decode(const rina::cdap_rib::ser_obj_t& serobj,
+				ipcp_t& des_obj) {
 
 	messages::ipcp m;
 	if (!m.ParseFromArray(serobj.message_, serobj.size_))
@@ -154,6 +153,5 @@ void IPCPEncoder::decode(const rina::cdap_rib::SerializedObject& serobj,
 	des_obj.process_id = m.processid();
 }
 
-}  //namespace encoders
 }  //namespace mad_manager
 }  //namespace rinad

--- a/rinad/src/common/encoders_mad.h
+++ b/rinad/src/common/encoders_mad.h
@@ -1,5 +1,5 @@
 /*
- * Common interfaces and classes for encoding/decoding RIB objects for MAD-Manager communication
+ * Common encoders for RIB objects for MAD-Manager communication
  *
  *    Bernat Gaston <bernat.gaston@i2cat.net>
  *    Marc Sune <marc.sune@bisdn.de>
@@ -21,91 +21,48 @@
 #ifndef ENCODERS_MAD_H_
 #define ENCODERS_MAD_H_
 
-#include <librina/rib_v2.h>
+#include <librina/cdap_rib_structures.h>
+#include "structures_mad.h"
 
 namespace rinad {
 namespace mad_manager {
-namespace structures{
-
-/**
-* IPCP (read) struct
-*/
-typedef struct ipcp{
-	int32_t process_id;
-	std::string name;
-	//TODO: add missing info
-}ipcp_t;
-
-typedef struct enrollment_config{
-	std::string neighbor_name;
-	std::string neighbor_instance;
-	std::string enr_dif;
-	std::string enr_un_dif;
-}enrollment_config_t;
-
-/**
-* IPCP configuration struct
-*/
-typedef struct ipcp_config{
-	std::string process_name;
-	std::string process_instance;
-	std::string process_type;
-	std::list<std::string> difs_to_register;
-	std::string dif_to_assign;
-	enrollment_config_t enr_conf;
-}ipcp_config_t;
-
-} //namespace structures
-
-
-namespace encoders {
 
 // Generic (simple) types
 
-/**
- * String encoder
- */
-class StringEncoder : public rina::rib::Encoder<std::string>{
+/// String encoder
+class StringEncoder : public Encoder<std::string>{
 public:
-	virtual void encode(const std::string &obj,
-			rina::cdap_rib::SerializedObject& serobj);
-	virtual void decode(const rina::cdap_rib::SerializedObject &serobj,
-			std::string& des_obj);
+	void encode(const std::string &obj,
+			rina::cdap_rib::ser_obj_t& serobj);
+	void decode(const rina::cdap_rib::ser_obj_t &serobj,
+			std::string &des_obj);
 
 	std::string get_type() const{ return "string"; };
 };
 
 
-
-
-//
-// Encoder of IPCPConfig
-//
-class IPCPConfigEncoder: public rina::rib::Encoder<structures::ipcp_config_t> {
+/// Encoder of IPCPConfig
+class IPCPConfigEncoder: public Encoder<ipcp_config_t> {
 
 public:
-	void encode (const structures::ipcp_config_t &obj,
+	void encode (const ipcp_config_t &obj,
 					rina::cdap_rib::ser_obj_t& ser_obj);
 	void decode(const rina::cdap_rib::ser_obj_t &ser_obj,
-			structures::ipcp_config_t& obj);
+			ipcp_config_t& obj);
 	std::string get_type() const{ return "ipcp-config"; };
 };
 
 
-/**
- * Encoder IPCP
- */
-class IPCPEncoder : public rina::rib::Encoder<structures::ipcp_t>{
+/// Encoder IPCP
+class IPCPEncoder : public Encoder<ipcp_t>{
 public:
-	virtual void encode(const structures::ipcp_t &obj,
-			rina::cdap_rib::SerializedObject& serobj);
-	virtual void decode(const rina::cdap_rib::SerializedObject &serobj,
-			structures::ipcp_t& des_obj);
+	void encode(const ipcp_t &obj,
+			rina::cdap_rib::ser_obj_t& serobj);
+	void decode(const rina::cdap_rib::ser_obj_t &serobj,
+			ipcp_t& des_obj);
 
 	std::string get_type() const{ return "ipcp"; };
 };
-
-} //namespace encoders
 
 } //namespace mad_manager
 } //namespace rinad

--- a/rinad/src/common/structures_mad.h
+++ b/rinad/src/common/structures_mad.h
@@ -1,0 +1,80 @@
+/*
+ * Common structures for MAD-Manager communication
+ *
+ *    Bernat Gaston <bernat.gaston@i2cat.net>
+ *    Marc Sune <marc.sune@bisdn.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#ifndef STRUCTURES_MAD_H_
+#define STRUCTURES_MAD_H_
+
+#include <inttypes.h>
+#include <librina/cdap_rib_structures.h>
+
+namespace rinad {
+namespace mad_manager {
+
+template<class T>
+class Encoder{
+public:
+	virtual ~Encoder(){}
+	/// Converts an object to a byte array, if this object is recognized by the encoder
+	/// @param object
+	/// @throws exception if the object is not recognized by the encoder
+	/// @return
+	virtual void encode(const T &obj, rina::cdap_rib::ser_obj_t& serobj) = 0;
+	/// Converts a byte array to an object of the type specified by "className"
+	/// @param byte[] serializedObject
+	/// @param objectClass The type of object to be decoded
+	/// @throws exception if the byte array is not an encoded in a way that the
+	/// encoder can recognize, or the byte array value doesn't correspond to an
+	/// object of the type "className"
+	/// @return
+	virtual void decode(const rina::cdap_rib::ser_obj_t &serobj,
+			T& des_obj) = 0;
+};
+
+/**
+* IPCP (read) struct
+*/
+typedef struct {
+	int32_t process_id;
+	std::string name;
+	//TODO: add missing info
+}ipcp_t;
+
+typedef struct {
+	std::string neighbor_name;
+	std::string neighbor_instance;
+	std::string enr_dif;
+	std::string enr_un_dif;
+}enrollment_config_t;
+
+/**
+* IPCP configuration struct
+*/
+typedef struct {
+	std::string process_name;
+	std::string process_instance;
+	std::string process_type;
+	std::list<std::string> difs_to_register;
+	std::string dif_to_assign;
+	enrollment_config_t enr_conf;
+}ipcp_config_t;
+
+} //namespace mad_manager
+} //namespace rinad
+#endif /* STRUCTURES_MAD_H_ */

--- a/rinad/src/ipcm/addons/ma/flowm.cc
+++ b/rinad/src/ipcm/addons/ma/flowm.cc
@@ -335,11 +335,11 @@ void* ActiveWorker::run(void* param)
 				LOG_ERR("Cannot read from flow with port id: %u anymore", port_id);
 			}
 
-			rina::cdap_rib::SerializedObject message;
+			rina::cdap_rib::ser_obj_t message;
 			message.message_ = buffer;
 			message.size_ = bytes_read;
 
-			//Instruct CDAP provider to process the message
+			//Instruct CDAP provider to process the CACEP message
 			try{
 				rina::cdap::getProvider()->process_message(message,
 							port_id);
@@ -359,11 +359,11 @@ void* ActiveWorker::run(void* param)
 					LOG_ERR("Cannot read from flow with port id: %u anymore", port_id);
 				}
 
-				rina::cdap_rib::SerializedObject message;
+				rina::cdap_rib::ser_obj_t message;
 				message.message_ = buffer;
 				message.size_ = bytes_read;
 
-				//Instruct CDAP provider to process the message
+				//Instruct CDAP provider to process the RIB operation message
 				try{
 					rina::cdap::getProvider()->process_message(
 									message,

--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
@@ -26,11 +26,11 @@ void IPCPObj::read(const rina::cdap_rib::con_handle_t &con,
 				const std::string& class_,
 				const rina::cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				rina::cdap_rib::SerializedObject &obj_reply,
+				rina::cdap_rib::ser_obj_t &obj_reply,
 				rina::cdap_rib::res_info_t& res){
 
 	res.code_ = rina::cdap_rib::CDAP_SUCCESS;
-	mad_manager::structures::ipcp_t info;
+	mad_manager::ipcp_t info;
 	info.process_id = processID_;
 	info.name = IPCManager->get_ipcp_name(processID_);
 	//TODO: Add missing stuff...
@@ -64,8 +64,8 @@ void IPCPObj::create_cb(const rina::rib::rib_handle_t rib,
 			const std::string& class_,
 			const rina::cdap_rib::filt_info_t &filt,
 			const int invoke_id,
-			const rina::cdap_rib::SerializedObject &obj_req,
-			rina::cdap_rib::SerializedObject &obj_reply,
+			const rina::cdap_rib::ser_obj_t &obj_req,
+			rina::cdap_rib::ser_obj_t &obj_reply,
 			rina::cdap_rib::res_info_t& res){
 
 	IPCPObj* ipcp;
@@ -87,8 +87,8 @@ void IPCPObj::create_cb(const rina::rib::rib_handle_t rib,
 	}
 
 
-	mad_manager::structures::ipcp_config_t object;
-	rinad::mad_manager::encoders::IPCPConfigEncoder().decode(
+	mad_manager::ipcp_config_t object;
+	rinad::mad_manager::IPCPConfigEncoder().decode(
 			obj_req, object);
 
 	//Call the IPCManager
@@ -147,7 +147,7 @@ void IPCPObj::create_cb(const rina::rib::rib_handle_t rib,
 }
 
 int IPCPObj::createIPCP(
-		rinad::mad_manager::structures::ipcp_config_t &object) {
+		rinad::mad_manager::ipcp_config_t &object) {
 
 	CreateIPCPPromise ipcp_promise;
 
@@ -168,7 +168,7 @@ int IPCPObj::createIPCP(
 }
 
 bool IPCPObj::assignToDIF(
-			rinad::mad_manager::structures::ipcp_config_t &object,
+			rinad::mad_manager::ipcp_config_t &object,
 			int ipcp_id) {
 	// ASSIGN TO DIF
 	Promise assign_promise;
@@ -207,7 +207,7 @@ bool IPCPObj::assignToDIF(
 	return true;
 }
 
-bool IPCPObj::registerAtDIFs(mad_manager::structures::ipcp_config_t &object,
+bool IPCPObj::registerAtDIFs(mad_manager::ipcp_config_t &object,
 								int ipcp_id) {
 	for(std::list<std::string>::iterator it =
 				object.difs_to_register.begin();

--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.h
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.h
@@ -14,6 +14,7 @@
 #include <librina/common.h>
 
 //Encoders and structs
+#include "structures_mad.h"
 #include "encoders_mad.h"
 
 namespace rinad{
@@ -42,7 +43,7 @@ public:
 				const std::string& class_,
 				const rina::cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				rina::cdap_rib::SerializedObject &obj_reply,
+				rina::cdap_rib::ser_obj_t &obj_reply,
 				rina::cdap_rib::res_info_t& res);
 
 
@@ -61,8 +62,8 @@ public:
 			const std::string& class_,
 			const rina::cdap_rib::filt_info_t &filt,
 			const int invoke_id,
-			const rina::cdap_rib::SerializedObject &obj_req,
-			rina::cdap_rib::SerializedObject &obj_reply,
+			const rina::cdap_rib::ser_obj_t &obj_req,
+			rina::cdap_rib::ser_obj_t &obj_reply,
 			rina::cdap_rib::res_info_t& res);
 
 
@@ -73,12 +74,12 @@ public:
 	int processID_;
 
 protected:
-	static int createIPCP(rinad::mad_manager::structures::ipcp_config_t &object);
-	static bool assignToDIF(rinad::mad_manager::structures::ipcp_config_t &object, int ipcp_id);
-	static bool registerAtDIFs(rinad::mad_manager::structures::ipcp_config_t &object, int ipcp_id);
+	static int createIPCP(rinad::mad_manager::ipcp_config_t &object);
+	static bool assignToDIF(rinad::mad_manager::ipcp_config_t &object, int ipcp_id);
+	static bool registerAtDIFs(rinad::mad_manager::ipcp_config_t &object, int ipcp_id);
 
 private:
-	mad_manager::encoders::IPCPEncoder encoder;
+	mad_manager::IPCPEncoder encoder;
 };
 
 }; //namespace rib_v1

--- a/rinad/src/ipcm/addons/ma/ribs/ribd_obj.cc
+++ b/rinad/src/ipcm/addons/ma/ribs/ribd_obj.cc
@@ -28,7 +28,7 @@ void RIBDaemonObj::read(const rina::cdap_rib::con_handle_t &con,
 				const std::string& class_,
 				const rina::cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				rina::cdap_rib::SerializedObject &obj_reply,
+				rina::cdap_rib::ser_obj_t &obj_reply,
 				rina::cdap_rib::res_info_t& res) {
 
 	QueryRIBPromise promise;
@@ -46,7 +46,7 @@ void RIBDaemonObj::read(const rina::cdap_rib::con_handle_t &con,
 	std::string trunk = promise.serialized_rib.substr(0, 1000);
 
 	//Serialize and return
-	mad_manager::encoders::StringEncoder encoder;
+	mad_manager::StringEncoder encoder;
 	encoder.encode(trunk, obj_reply);
 }
 

--- a/rinad/src/ipcm/addons/ma/ribs/ribd_obj.h
+++ b/rinad/src/ipcm/addons/ma/ribs/ribd_obj.h
@@ -35,7 +35,7 @@ public:
 				const std::string& class_,
 				const rina::cdap_rib::filt_info_t &filt,
 				const int invoke_id,
-				rina::cdap_rib::SerializedObject &obj_reply,
+				rina::cdap_rib::ser_obj_t &obj_reply,
 				rina::cdap_rib::res_info_t& res);
 
 private:

--- a/rinad/wrap/Makefile.am
+++ b/rinad/wrap/Makefile.am
@@ -1,0 +1,11 @@
+#
+# Makefile.am
+#
+# Written by: Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
+#
+
+SUBDIRS = java
+
+EXTRA_DIST =					\
+	librinad.i				\
+	stdlist.i

--- a/rinad/wrap/java/Makefile.am
+++ b/rinad/wrap/java/Makefile.am
@@ -1,0 +1,75 @@
+#
+# Makefile.am
+#
+# Written by: Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
+#
+
+if BUILD_BINDINGS_JAVA
+
+JAVA_DIR		= $(top_builddir)/../java
+SWIG_DEBUG      = -v
+SWIG_CPPFLAGS   = -I$(top_srcdir)/src/common -I$(top_srcdir)/../librina/include
+SWIG_FLAGS      = $(SWIG_DEBUG) $(SWIG_CPPFLAGS) -Wextra -Werror
+SWIG_JAVA_FLAGS = -java -package eu.irati.librinad
+
+CLEANFILES =
+
+# XXX FIXME: Prerequisites for this rule are broken ...
+wrap.stamp: $(top_srcdir)/wrap/*.i $(top_srcdir)/src/common/encoders_mad.h
+	rm -f wrap.tmp
+	touch wrap.tmp
+	rm -r -f $(JAVA_DIR)/eu/irati/librinad   &&			\
+	$(MKDIR_P) $(JAVA_DIR)/eu/irati/librinad &&			\
+	$(SWIG) $(SWIG_FLAGS) $(SWIG_JAVA_FLAGS)	\
+		-c++					\
+		-o librinad_java.cc			\
+		-outdir $(JAVA_DIR)/eu/irati/librinad		\
+		$(top_srcdir)/wrap/librinad.i || {	\
+		echo "Cannot wrap input file" ;		\
+		rm -f wrap.tmp ;			\
+		rm -r -f $(JAVA_DIR)/eu/irati/librinad ;		\
+		exit 1 ;				\
+	}
+	mv -f wrap.tmp $@
+
+CLEANFILES += wrap.stamp wrap.tmp
+CLEANFILES += librinad_java.cc
+
+librinad-java-classes: wrap.stamp
+	$(JAVAC) -cp $(JAVA_DIR) $(JAVA_DIR)/eu/irati/librinad/*.java
+
+librinad.jar: librinad-java-classes
+	cd $(JAVA_DIR) &&	\
+	$(JAR) -cvf librinad.jar eu/irati/librinad/*.class
+	mv $(JAVA_DIR)/librinad.jar $(builddir)
+
+CLEANFILES += librinad.jar
+
+pkgdata_DATA = librinad.jar
+
+clean-local:
+	rm -r -f $(JAVA_DIR)/eu/irati/librinad
+
+librinad_java.cc: wrap.stamp
+
+librinad_java_la_SOURCES  = librinad_java.cc
+librinad_java_la_LDFLAGS  = -module
+librinad_java_la_LIBADD   = $(top_builddir)/src/common/librinad.la
+librinad_java_la_CPPFLAGS = -I$(top_srcdir)/src/common $(JNI_CPPFLAGS) \
+							$(LIBRINA_CFLAGS)
+lib_LTLIBRARIES = librinad_java.la
+
+install-data-local-maven: librinad.jar
+	$(MVN) install:install-file					\
+		-Dfile=librinad.jar					\
+		-DgroupId=eu.irati					\
+		-DartifactId=eu.irati.librinad				\
+		-Dversion=$(PACKAGE_VERSION)				\
+		-Dpackaging=jar || {					\
+		echo "Cannot install librinad jar into maven ..." ;	\
+		exit 1 ;						\
+	}
+
+install-data-local: install-data-local-maven
+
+endif

--- a/rinad/wrap/librina.i
+++ b/rinad/wrap/librina.i
@@ -29,7 +29,6 @@
 SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 SWIG_JAVABODY_TYPEWRAPPER(public, public, public, SWIGTYPE)
 
-
 /**
  * void * typemaps. 
  * These are input typemaps for mapping a Java byte[] array to a C void array.
@@ -434,12 +433,11 @@ DOWNCAST_IPC_EVENT_CONSUMER(eventTimedWait);
 %rename(differs) rina::FlowInformation::operator!=(const FlowInformation &other) const;
 %rename(equals) rina::rib::RIBObjectData::operator==(const RIBObjectData &other) const;
 %rename(differs) rina::rib::RIBObjectData::operator!=(const RIBObjectData &other) const;
+
 %rename(equals) rina::Neighbor::operator==(const Neighbor &other) const;
 %rename(differs) rina::Neighbor::operator!=(const Neighbor &other) const;
-%rename(equals) rina::PsInfo::operator==(const PsInfo &other) const;
-%rename(differs) rina::PsInfo::operator!=(const PsInfo &other) const;
 
-%include "librina/exceptions.h"
+%include "../include/librina/exceptions.h"
 %include "librina/patterns.h"
 %include "librina/concurrency.h"
 %include "librina/common.h"
@@ -490,24 +488,3 @@ DOWNCAST_IPC_EVENT_CONSUMER(eventTimedWait);
   }
 }
 %enddef
-
-/* Define iterator for ApplicationProcessNamingInformation list */
-MAKE_COLLECTION_ITERABLE(ApplicationProcessNamingInformationListIterator, ApplicationProcessNamingInformation, std::list, rina::ApplicationProcessNamingInformation);
-/* Define iterator for String list */
-MAKE_COLLECTION_ITERABLE(StringListIterator, String, std::list, std::string);
-/* Define iterator for Flow Information list */
-MAKE_COLLECTION_ITERABLE(FlowInformationListIterator, FlowInformation, std::list, rina::FlowInformation);
-/* Define iterator for Unsigned int list */
-MAKE_COLLECTION_ITERABLE(UnsignedIntListIterator, Long, std::list, unsigned int);
-
-%template(DIFPropertiesVector) std::vector<rina::DIFProperties>;
-%template(FlowInformationVector) std::vector<rina::FlowInformation>;
-%template(ApplicationRegistrationVector) std::vector<rina::ApplicationRegistration *>;
-%template(ParameterList) std::list<rina::Parameter>;
-%template(ApplicationProcessNamingInformationList) std::list<rina::ApplicationProcessNamingInformation>;
-%template(IPCManagerSingleton) Singleton<rina::IPCManager>;
-%template(IPCEventProducerSingleton) Singleton<rina::IPCEventProducer>;
-%template(StringList) std::list<std::string>;
-%template(FlowInformationList) std::list<rina::FlowInformation>;
-%template(UnsignedIntList) std::list<unsigned int>;
-

--- a/rinad/wrap/librinad.i
+++ b/rinad/wrap/librinad.i
@@ -1,0 +1,163 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+
+%module rinad
+
+%include <std_string.i>
+%include "enums.swg"
+%include <stdint.i>
+%include <stl.i>
+
+%include "stdlist.i"
+%import "librina.i"
+
+#ifdef SWIGJAVA
+#endif
+
+%pragma(java) jniclassimports=%{
+import eu.irati.librina.ser_obj_t;
+%}
+
+/**
+ * void * typemaps. 
+ * These are input typemaps for mapping a Java byte[] array to a C void array.
+ * Note that as a Java array is used and thus passeed by reference, the C
+ * routine can return data to Java via the parameter.
+ *
+ * Example usage wrapping:
+ *   void foo(void *array);
+ *  
+ * Java usage:
+ *   byte b[] = new byte[20];
+ *   modulename.foo(b);
+ */
+%typemap(jni)    void * "jbyteArray"
+%typemap(jtype)  void * "byte[]"
+%typemap(jstype) void * "byte[]"
+
+%typemap(in)     void * {
+        $1 = (void *) JCALL2(GetByteArrayElements, jenv, $input, 0); 
+}
+
+%typemap(argout) void * {
+        JCALL3(ReleaseByteArrayElements, jenv, $input, (jbyte *) $1, 0); 
+}
+
+%typemap(javain) void * "$javainput"
+
+%typemap(javaout) void * {
+        return $jnicall;
+ }
+ 
+/**
+* std::string & typemaps. 
+* These are input typemaps for mapping a c++ std::string& to a Java String[].
+*/
+
+%typemap(jstype) std::string& INPUT "String[]"
+%typemap(jtype) std::string& INPUT "String[]"
+%typemap(jni) std::string& INPUT "jobjectArray"
+%typemap(javain)  std::string& INPUT "$javainput"
+%typemap(in) std::string& INPUT (std::string temp) {
+  if (!$input) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "array null");
+    return $null;
+  }
+  if (JCALL1(GetArrayLength, jenv, $input) == 0) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaIndexOutOfBoundsException, "Array must contain at least 1 element");
+  }
+  $1 = &temp;
+}
+%typemap(argout) std::string& INPUT {
+  jstring jvalue = JCALL1(NewStringUTF, jenv, temp$argnum.c_str()); 
+  JCALL3(SetObjectArrayElement, jenv, $input, 0, jvalue);
+}
+%apply  std::string& INPUT { std::string & des_obj }
+
+ 
+ 
+ 
+ 
+ 
+%typemap(javaimports) SWIGTYPE 
+%{
+import eu.irati.librina.ser_obj_t;
+%}
+
+%{
+#include "structures_mad.h"
+#include "librina/cdap_rib_structures.h"
+#include "encoders_mad.h"
+#include <string>
+%}
+
+
+%include "structures_mad.h"
+
+namespace rinad{
+namespace mad_manager{
+%template(TempStringEncoder) Encoder<std::string>;
+%template(TempIPCPConfigEncoder) Encoder<ipcp_config_t>;
+%template(TempIPCPEncoder) Encoder<ipcp_t>;
+}}
+
+%include "encoders_mad.h"
+
+/* Macro for defining collection iterators */
+%define MAKE_COLLECTION_ITERABLE( ITERATORNAME, JTYPE, CPPCOLLECTION, CPPTYPE )
+%typemap(javainterfaces) ITERATORNAME "java.util.Iterator<JTYPE>"
+%typemap(javacode) ITERATORNAME %{
+  public void remove() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  public JTYPE next() throws java.util.NoSuchElementException {
+    if (!hasNext()) {
+      throw new java.util.NoSuchElementException();
+    }
+
+    return nextImpl();
+  }
+%}
+%javamethodmodifiers ITERATORNAME::nextImpl "private";
+%inline %{
+  struct ITERATORNAME {
+    typedef CPPCOLLECTION<CPPTYPE> collection_t;
+    ITERATORNAME(const collection_t& t) : it(t.begin()), collection(t) {}
+    bool hasNext() const {
+      return it != collection.end();
+    }
+
+    const CPPTYPE& nextImpl() {
+      const CPPTYPE& type = *it++;
+      return type;
+    }
+  private:
+    collection_t::const_iterator it;
+    const collection_t& collection;    
+  };
+%}
+%typemap(javainterfaces) CPPCOLLECTION<CPPTYPE> "Iterable<JTYPE>"
+%newobject CPPCOLLECTION<CPPTYPE>::iterator() const;
+%extend CPPCOLLECTION<CPPTYPE> {
+  ITERATORNAME *iterator() const {
+    return new ITERATORNAME(*$self);
+  }
+}
+%enddef
+
+%template(StringList) std::list<std::string>;

--- a/rinad/wrap/stdlist.i
+++ b/rinad/wrap/stdlist.i
@@ -1,0 +1,50 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+
+%{
+#include <list>
+%}
+
+namespace std {
+
+    template<class T> class list {
+      public:
+        typedef size_t size_type;
+        typedef T value_type;
+        typedef const value_type& const_reference;
+        list();
+        list(size_type n);
+        size_type size() const;
+        %rename(isEmpty) empty;
+        bool empty() const;
+        void clear();
+        void reverse();
+        %rename(addFirst) push_front;
+        void push_front(const value_type& x);
+        %rename(addLast) push_back;
+        void push_back(const value_type& x);
+        %rename(getFirst) front;
+        const_reference front();
+        %rename(getLast) back;
+        const_reference back();
+        %rename(clearLast) pop_back;
+        void pop_back();
+        %rename(clearFirst) pop_front;
+        void pop_front();
+        void remove(const value_type& x);
+   };
+}


### PR DESCRIPTION
Feature that enables new wrappings in librina, adds rinad wrappings
and changes the build to repect the java package-folder relation.

Main changes are:
- SerializedObject access unified to ser_obj_t
- Added directors to the wraping config file to allow the CDAP
callbacks to be extended in java and used from the C++ code.
- Added Rinad java wrappings which have a dependency with librina
wrapped classes.
- A new wraping file tree has bee included in rinad with the same
structure than in librina.
- a new build structure which contains a java subfolder with all
the java classes in their appropiate packages (eu.irati.librina
and eu.irati.librinad)
- Movement of the encoder interface from librina to rinad.
- Spliting of encoders_mad files into structures_mad and
encoders_mad to allow a proper wrapping using SWIG
- Changes in makefiles and addition of the rinad interface file
- Changes in namespacing that require adaptation of the
manager in rina-tools.

Need ack from @edugrasa @msune @vmaffione 