### PR TITLE
rebase&clean: header cleanage

### DIFF
--- a/rinad/src/common/Makefile.am
+++ b/rinad/src/common/Makefile.am
@@ -22,8 +22,7 @@ librinad_la_CPPFLAGS =				\
 	$(CPPFLAGS_EXTRA)			\
 	$(LIBRINA_CFLAGS)			\
 	$(LIBPROTOBUF_CFLAGS)			\
-	-I$(srcdir)/tclap			\
-	-I$(srcdir)/..
+	-I$(srcdir)/tclap			
 librinad_la_LIBADD   =				\
 	$(LIBRINA_LIBS)				\
 	$(LIBPROTOBUF_LIBS)			\

--- a/rinad/src/common/debug.cc
+++ b/rinad/src/common/debug.cc
@@ -18,7 +18,6 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //
 
-#include <config.h>
 #include <iostream>
 #include <cstdlib>
 

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -24,12 +24,12 @@
 
 #include <librina/logs.h>
 
-#include "common/encoder.h"
-#include "common/encoders/DataTransferConstantsMessage.pb.h"
-#include "common/encoders/DirectoryForwardingTableEntryArrayMessage.pb.h"
-#include "common/encoders/QoSCubeArrayMessage.pb.h"
-#include "common/encoders/WhatevercastNameArrayMessage.pb.h"
-#include "common/encoders/NeighborArrayMessage.pb.h"
+#include "encoder.h"
+#include "encoders/DataTransferConstantsMessage.pb.h"
+#include "encoders/DirectoryForwardingTableEntryArrayMessage.pb.h"
+#include "encoders/QoSCubeArrayMessage.pb.h"
+#include "encoders/WhatevercastNameArrayMessage.pb.h"
+#include "encoders/NeighborArrayMessage.pb.h"
 
 namespace rinad {
 


### PR DESCRIPTION
debug.cc contained config.h which was unneeded.
header inclusion in common was doing and unneeded loop (going down
in the folder structure to go up later)

Ack need from @edugrasa 