### PR TITLE
Pristine 1.4 Changes in RMT  to solve write problem

### DIFF
--- a/linux/net/rina/ipcps/shim-eth-vlan-core.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan-core.c
@@ -938,8 +938,6 @@ static int eth_vlan_sdu_write(struct ipcp_instance_data * data,
                 return -1;
         }
 
-        sdu_destroy(sdu);
-
         skb->dev      = data->dev;
         skb->protocol = htons(ETH_P_RINA);
 
@@ -948,12 +946,14 @@ static int eth_vlan_sdu_write(struct ipcp_instance_data * data,
         if (retval < 0) {
                 LOG_ERR("Problems in dev_hard_header (%d)", retval);
                 kfree_skb(skb);
+                sdu_destroy(sdu);
                 return -1;
         }
 
         retval = dev_queue_xmit(skb);
         if (retval == -ENETDOWN) {
         	LOG_ERR("dev_q_xmit returned device down");
+        	sdu_destroy(sdu);
         	return -1;
         }
         if (retval != NET_XMIT_SUCCESS) {
@@ -961,6 +961,7 @@ static int eth_vlan_sdu_write(struct ipcp_instance_data * data,
         	return -EAGAIN;
         }
 
+        sdu_destroy(sdu);
         LOG_DBG("Packet sent");
 
         return 0;

--- a/linux/net/rina/rmt-ps-default.c
+++ b/linux/net/rina/rmt-ps-default.c
@@ -82,7 +82,7 @@ static int rmt_queue_destroy(struct rmt_queue *q)
 	return 0;
 }
 
-int default_rmt_q_create_policy(struct rmt_ps      *ps,
+void * default_rmt_q_create_policy(struct rmt_ps      *ps,
 			        struct rmt_n1_port *n1_port)
 {
 	struct rmt_queue *queue;
@@ -90,7 +90,7 @@ int default_rmt_q_create_policy(struct rmt_ps      *ps,
 
 	if (!ps || !n1_port || !ps->priv) {
 		LOG_ERR("Wrong input parameters");
-		return -1;
+		return NULL;
 	}
 
 	data = ps->priv;
@@ -99,13 +99,11 @@ int default_rmt_q_create_policy(struct rmt_ps      *ps,
 	if (!queue) {
 		LOG_ERR("Could not create queue for n1_port %u",
 			n1_port->port_id);
-		n1_port->rmt_ps_queues = NULL;
-		return -1;
+		return NULL;
 	}
 
-	n1_port->rmt_ps_queues = queue;
 	LOG_DBG("Structures for scheduling policies created...");
-	return 0;
+	return queue;
 }
 EXPORT_SYMBOL(default_rmt_q_create_policy);
 
@@ -169,7 +167,6 @@ struct pdu *default_rmt_dequeue_policy(struct rmt_ps	  *ps,
 				       struct rmt_n1_port *n1_port)
 {
 	struct rmt_queue *q;
-	struct rmt_ps_default_data *data = ps->priv;
 	struct pdu *ret_pdu;
 
 	if (!ps || !n1_port) {

--- a/linux/net/rina/rmt-ps-default.h
+++ b/linux/net/rina/rmt-ps-default.h
@@ -38,6 +38,4 @@ int default_rmt_enqueue_policy(struct rmt_ps	 *ps,
 			       struct pdu	 *pdu);
 struct pdu *default_rmt_dequeue_policy(struct rmt_ps	 *ps,
 				       struct rmt_n1_port *n1_port);
-bool default_rmt_needs_sched_policy(struct rmt_ps *ps,
-				    struct rmt_n1_port *n1_port);
 #endif

--- a/linux/net/rina/rmt-ps-default.h
+++ b/linux/net/rina/rmt-ps-default.h
@@ -29,8 +29,8 @@
 
 struct ps_base * rmt_ps_default_create(struct rina_component *component);
 void rmt_ps_default_destroy(struct ps_base *bps);
-int default_rmt_q_create_policy(struct rmt_ps      *ps,
-				struct rmt_n1_port *n1_port);
+void *default_rmt_q_create_policy(struct rmt_ps      *ps,
+				  struct rmt_n1_port *n1_port);
 int default_rmt_q_destroy_policy(struct rmt_ps      *ps,
 				 struct rmt_n1_port *n1_port);
 int default_rmt_enqueue_policy(struct rmt_ps	 *ps,

--- a/linux/net/rina/rmt-ps.h
+++ b/linux/net/rina/rmt-ps.h
@@ -43,7 +43,7 @@ struct rmt_ps {
 	int (*rmt_enqueue_policy)(struct rmt_ps *,
 				  struct rmt_n1_port *,
 				  struct pdu *);
-	int (*rmt_q_create_policy)(struct rmt_ps *,
+	void* (*rmt_q_create_policy)(struct rmt_ps *,
 				   struct rmt_n1_port *);
 	int (*rmt_q_destroy_policy)(struct rmt_ps *,
 				    struct rmt_n1_port *);

--- a/linux/net/rina/rmt-ps.h
+++ b/linux/net/rina/rmt-ps.h
@@ -31,9 +31,8 @@
 
 /* rmt_enqueue_policy return values */
 #define RMT_PS_ENQ_SCHED 1	/* PDU enqueued and RMT needs to schedule */
-#define RMT_PS_ENQ_DSEND 2      /* Queue(s) empty, PDU written down directly */
-#define RMT_PS_ENQ_ERR   3	/* Error */
-#define RMT_PS_ENQ_DROP  4	/* PDU dropped due to queue full occupation */
+#define RMT_PS_ENQ_ERR   2	/* Error */
+#define RMT_PS_ENQ_DROP  3	/* PDU dropped due to queue full occupation */
 
 struct rmt_ps {
 	struct ps_base base;
@@ -48,8 +47,6 @@ struct rmt_ps {
 				   struct rmt_n1_port *);
 	int (*rmt_q_destroy_policy)(struct rmt_ps *,
 				    struct rmt_n1_port *);
-	bool (*rmt_needs_sched_policy)(struct rmt_ps *,
-				       struct rmt_n1_port *);
 
 	/* Reference used to access the RMT data model. */
 	struct rmt *dm;

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1079,13 +1079,13 @@ int rmt_n1port_bind(struct rmt *instance,
 		return -1;
 	}
 
-	if (ps->rmt_q_create_policy(ps, tmp)) {
-		rcu_read_unlock();
+	tmp->rmt_ps_queues = ps->rmt_q_create_policy(ps, tmp);
+	rcu_read_unlock();
+	if (!tmp->rmt_ps_queues) {
 		LOG_ERR("Cannot create structs for scheduling policy");
 		n1_port_destroy(tmp);
 		return -1;
 	}
-	rcu_read_unlock();
 
 	hash_add(instance->n1_ports->n1_ports, &tmp->hlist, id);
 	LOG_DBG("Added send queue to rmt instance %pK for port-id %d",

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -98,7 +98,7 @@ static struct rmt_n1_port *n1_port_create(port_id_t id,
 	tmp->state   = N1_PORT_STATE_ENABLED;
 
 	atomic_set(&tmp->refs_c, 0);
-	tmp->wbussy = false;
+	tmp->wbusy = false;
 	tmp->stats.plen = 0;
 	tmp->stats.pdrop = 0;
 	tmp->stats.perr = 0;
@@ -136,10 +136,10 @@ static int n1_port_destroy(struct rmt_n1_port *n1p)
 	if (n1p->sdup_port)
 		sdup_destroy_port_config(n1p->sdup_port);
 
-	if (n1p->pending_pdu)
-		pdu_destroy(n1p->pending_pdu);
+	if (n1p->pending_sdu)
+		sdu_destroy(n1p->pending_sdu);
 
-	if (n1p->wbussy)
+	if (n1p->wbusy)
 		LOG_WARN("Deleting n1_port with bussy writer... there may be something wrong...");
 
 	rkfree(n1p);
@@ -534,9 +534,46 @@ int rmt_config_set(struct rmt	     *instance,
 }
 EXPORT_SYMBOL(rmt_config_set);
 
-static int n1_port_write(struct rmt *rmt,
-			 struct rmt_n1_port *n1_port,
-			 struct pdu *pdu)
+static int n1_port_write_sdu(struct rmt *rmt,
+			     struct rmt_n1_port *n1_port,
+			     struct sdu *sdu)
+{
+	int ret;
+	unsigned long flags;
+
+	LOG_DBG("Gonna send SDU to port-id %d", port_id);
+	ret = n1_port->n1_ipcp->ops->sdu_write(n1_port->n1_ipcp->data,
+					       n1_port->port_id,
+					       sdu);
+
+	if (ret == -EAGAIN) {
+		n1_port_lock(n1_port, flags);
+		if (n1_port->pending_sdu) {
+			LOG_ERR("Already a pending SDU present for port %d",
+					n1_port->port_id);
+			sdu_destroy(n1_port->pending_sdu);
+			n1_port->stats.plen--;
+		}
+
+		n1_port->pending_sdu = sdu;
+		n1_port->stats.plen++;
+
+		if (n1_port->state == N1_PORT_STATE_DO_NOT_DISABLE) {
+			n1_port->state = N1_PORT_STATE_ENABLED;
+			tasklet_hi_schedule(&rmt->egress_tasklet);
+		} else
+			n1_port->state = N1_PORT_STATE_DISABLED;
+
+		n1_port_unlock(n1_port, flags);
+		return 0;
+	}
+
+	return ret;
+}
+
+static struct sdu * generate_sdu_from_pdu(struct rmt * rmt,
+				     	  struct rmt_n1_port *n1_port,
+				     	  struct pdu *pdu)
 {
 	struct sdu *sdu;
 	struct pdu_ser *pdu_ser;
@@ -544,8 +581,6 @@ static int n1_port_write(struct rmt *rmt,
 	struct buffer *buffer;
 	struct ipcp_instance *n1_ipcp;
 	struct pci *pci;
-	int ret;
-	unsigned long flags;
 
 	ASSERT(n1_port);
 	ASSERT(rmt);
@@ -553,7 +588,7 @@ static int n1_port_write(struct rmt *rmt,
 
 	if (!pdu) {
 		LOG_DBG("No PDU to work in this queue ...");
-		return -1;
+		return NULL;
 	}
 
 	port_id = n1_port->port_id;
@@ -562,40 +597,41 @@ static int n1_port_write(struct rmt *rmt,
 	pci = pdu_pci_get_rw(pdu);
 	if (!pci) {
 		LOG_ERR("Cannot get PCI");
-		goto error_nobuff;
+		return NULL;
 	}
 
 	pdu_ser = pdu_serialize_ni(rmt->serdes, pdu);
 	if (!pdu_ser) {
 		LOG_ERR("Error creating serialized PDU");
-		goto error_nobuff;
+		return NULL;
 	}
 
 	/* SDU Protection */
 	if (sdup_set_lifetime_limit(n1_port->sdup_port, pdu_ser, pci)){
-                LOG_ERR("Error adding a Lifetime limit to serialized PDU");
-                pdu_ser_destroy(pdu_ser);
-		goto error_nobuff;
-        }
+		LOG_ERR("Error adding a Lifetime limit to serialized PDU");
+		pdu_ser_destroy(pdu_ser);
+		return NULL;
+	}
 
 	if (sdup_protect_pdu(n1_port->sdup_port, pdu_ser)){
-                LOG_ERR("Error Protecting serialized PDU");
-                pdu_ser_destroy(pdu_ser);
-		goto error_nobuff;
-        }
+		LOG_ERR("Error Protecting serialized PDU");
+		pdu_ser_destroy(pdu_ser);
+		return NULL;
+	}
 	/* end SDU Protection */
 
 	buffer = pdu_ser_buffer(pdu_ser);
 	if (!buffer_is_ok(buffer)) {
 		LOG_ERR("Buffer is not okay");
-                pdu_ser_destroy(pdu_ser);
-		goto error_nobuff;
+		pdu_ser_destroy(pdu_ser);
+		return NULL;
 	}
 
 	if (pdu_ser_buffer_disown(pdu_ser)) {
 		LOG_ERR("Could not disown buffer");
-                pdu_ser_destroy(pdu_ser);
-		goto error_all;
+		pdu_ser_destroy(pdu_ser);
+		buffer_destroy(buffer);
+		return NULL;
 	}
 
 	pdu_ser_destroy(pdu_ser);
@@ -603,41 +639,29 @@ static int n1_port_write(struct rmt *rmt,
 	sdu = sdu_create_buffer_with_ni(buffer);
 	if (!sdu) {
 		LOG_ERR("Error creating SDU from serialized PDU");
-		goto error_all;
+		buffer_destroy(buffer);
+		return NULL;
 	}
 
-	LOG_DBG("Gonna send SDU to port-id %d", port_id);
-	ret = n1_ipcp->ops->sdu_write(n1_ipcp->data, port_id, sdu);
+	return sdu;
+}
 
-	if (ret == -EAGAIN) {
-		n1_port_lock(n1_port, flags);
-		if (n1_port->pending_pdu) {
-			LOG_ERR("Already a pending PDU present for port %d",
-				n1_port->port_id);
-			pdu_destroy(n1_port->pending_pdu);
-		}
-		/* FIXME: the serialized SDU should be kept instead of the pdu,
-		 * but we need the pdu to be sent to n1_port_write
-		 */
-		n1_port->pending_pdu = pdu;
+static int n1_port_write(struct rmt *rmt,
+			 struct rmt_n1_port *n1_port,
+			 struct pdu *pdu)
+{
+	struct sdu *sdu;
 
-		if (n1_port->state == N1_PORT_STATE_DO_NOT_DISABLE) {
-			n1_port->state = N1_PORT_STATE_ENABLED;
-		       	tasklet_hi_schedule(&rmt->egress_tasklet);
-		} else
-			n1_port->state = N1_PORT_STATE_DISABLED;
+	ASSERT(n1_port);
+	ASSERT(rmt);
+	ASSERT(rmt->serdes);
 
-		n1_port_unlock(n1_port, flags);
-		return 0;
-	}
+	sdu = generate_sdu_from_pdu(rmt, n1_port, pdu);
 	pdu_destroy(pdu);
-	return ret;
+	if (!sdu)
+		return -1;
 
-error_all:
-	buffer_destroy(buffer);
-error_nobuff:
-	pdu_destroy(pdu);
-	return -1;
+	return n1_port_write_sdu(rmt, n1_port, sdu);
 }
 
 static void send_worker(unsigned long o)
@@ -650,6 +674,7 @@ static void send_worker(unsigned long o)
 	int pdus_sent;
 	struct rmt_ps *ps;
 	struct pdu *pdu = NULL;
+	struct sdu *sdu = NULL;
 	int ret;
 
 	LOG_DBG("Send worker called");
@@ -688,7 +713,7 @@ static void send_worker(unsigned long o)
 
 		if (n1_port->state == N1_PORT_STATE_DISABLED	||
 		    !n1_port->stats.plen			||
-		    n1_port->wbussy) {
+		    n1_port->wbusy) {
 			spin_unlock(&n1_port->lock);
 			spin_lock(&rmt->n1_ports->lock);
 			LOG_DBG("Port state is DISABLED or no PDUs to send");
@@ -696,7 +721,7 @@ static void send_worker(unsigned long o)
 		}
 
 		atomic_inc(&n1_port->refs_c);
-		n1_port->wbussy = true;
+		n1_port->wbusy = true;
 
 		pdus_sent = 0;
 		ret = 0;
@@ -704,21 +729,28 @@ static void send_worker(unsigned long o)
 
 		while ((pdus_sent < MAX_PDUS_SENT_PER_CYCLE) &&
 			n1_port->stats.plen) {
-			if (n1_port->pending_pdu) {
-				pdu = n1_port->pending_pdu;
-				n1_port->pending_pdu = NULL;
-			} else
+			if (n1_port->pending_sdu) {
+				sdu = n1_port->pending_sdu;
+				n1_port->pending_sdu = NULL;
+				n1_port->stats.plen--;
+			} else {
 				pdu = ps->rmt_dequeue_policy(ps, n1_port);
-			if (!pdu) {
-				if (n1_port->stats.plen)
-					LOG_ERR("rmt_dequeue_policy returned no pdu but plen is %u",
-						n1_port->stats.plen);
-				break;
+				if (!pdu) {
+					if (n1_port->stats.plen)
+						LOG_ERR("rmt_dequeue_policy returned no pdu but plen is %u",
+								n1_port->stats.plen);
+					break;
+				}
+
+				n1_port->stats.plen--;
+				sdu = generate_sdu_from_pdu(rmt, n1_port, pdu);
+				pdu_destroy(pdu);
+				if (!sdu)
+					continue;
 			}
-			n1_port->stats.plen--;
 
 			spin_unlock(&n1_port->lock);
-			ret =  n1_port_write(rmt, n1_port, pdu);
+			ret =  n1_port_write_sdu(rmt, n1_port, sdu);
 			spin_lock(&n1_port->lock);
 
 			if (ret)
@@ -733,7 +765,7 @@ static void send_worker(unsigned long o)
 
 		rcu_read_unlock();
 
-		n1_port->wbussy = false;
+		n1_port->wbusy = false;
 		if (atomic_dec_and_test(&n1_port->refs_c) &&
 		    n1_port->state == N1_PORT_STATE_DEALLOCATED) {
 			spin_unlock(&n1_port->lock);
@@ -800,9 +832,8 @@ int rmt_send_port_id(struct rmt *instance,
 
 	n1_port_lock(n1_port, flags);
 	if (n1_port->stats.plen 				||
-		n1_port->wbussy 				||
-		n1_port->state == N1_PORT_STATE_DISABLED	||
-	        n1_port->pending_pdu) {
+		n1_port->wbusy 					||
+		n1_port->state == N1_PORT_STATE_DISABLED) {
 		ret = ps->rmt_enqueue_policy(ps, n1_port, pdu);
 		rcu_read_unlock();
 		switch (ret) {
@@ -828,13 +859,13 @@ int rmt_send_port_id(struct rmt *instance,
 		return 0;
 	}
 	rcu_read_unlock();
-	n1_port->wbussy = true;
+	n1_port->wbusy = true;
 	n1_port_unlock(n1_port, flags);
 	LOG_DBG("PDU ready to be sent, no need to enqueue");
 	ret = n1_port_write(instance, n1_port, pdu);
 	/*FIXME LB: This is just horrible, needs to be rethinked */
 	n1_port_lock(n1_port, flags);
-	n1_port->wbussy = false;
+	n1_port->wbusy = false;
 	n1_port_unlock(n1_port, flags);
 	n1pmap_release(instance, n1_port);
 	return ret;

--- a/linux/net/rina/rmt.h
+++ b/linux/net/rina/rmt.h
@@ -76,10 +76,10 @@ struct rmt_n1_port {
 	struct hlist_node	hlist;
 	enum flow_state		state;
 	atomic_t		refs_c;
-	struct pdu		*pending_pdu;
+	struct sdu		*pending_sdu;
 	struct sdup_port 	*sdup_port;
 	struct n1_port_stats	stats;
-	bool			wbussy;
+	bool			wbusy;
 };
 
 struct rmt	  *rmt_create(struct ipcp_instance *parent,

--- a/linux/net/rina/rmt.h
+++ b/linux/net/rina/rmt.h
@@ -63,6 +63,12 @@ enum flow_state {
 	N1_PORT_STATE_DEALLOCATED,
 };
 
+struct n1_port_stats {
+	unsigned int plen; /* port len, all pdus enqueued in PS queue/s */
+	unsigned int pdrop;
+	unsigned int perr;
+};
+
 struct rmt_n1_port {
 	spinlock_t		lock;
 	port_id_t		port_id;
@@ -72,6 +78,8 @@ struct rmt_n1_port {
 	atomic_t		refs_c;
 	struct pdu		*pending_pdu;
 	struct sdup_port 	*sdup_port;
+	struct n1_port_stats	stats;
+	bool			wbussy;
 };
 
 struct rmt	  *rmt_create(struct ipcp_instance *parent,

--- a/linux/net/rina/rmt.h
+++ b/linux/net/rina/rmt.h
@@ -80,6 +80,7 @@ struct rmt_n1_port {
 	struct sdup_port 	*sdup_port;
 	struct n1_port_stats	stats;
 	bool			wbusy;
+	void 			*rmt_ps_queues;
 };
 
 struct rmt	  *rmt_create(struct ipcp_instance *parent,

--- a/plugins/cong_avoidance/dtcp-ps-cas.c
+++ b/plugins/cong_avoidance/dtcp-ps-cas.c
@@ -245,7 +245,6 @@ dtcp_ps_cas_create(struct rina_component * component)
         ps->initial_rate                = NULL;
         ps->receiving_flow_control      = NULL; /* default */
         ps->update_credit               = NULL;
-        ps->reconcile_flow_conflict     = NULL;
         ps->rcvr_ack                    = NULL; /* default */
         ps->rcvr_flow_control           = cas_rcvr_flow_control;
         ps->rate_reduction              = NULL; /* default */

--- a/plugins/cong_avoidance/rmt-ps-cas.c
+++ b/plugins/cong_avoidance/rmt-ps-cas.c
@@ -247,15 +247,15 @@ static struct pdu * cas_rmt_dequeue_policy(struct rmt_ps      *ps,
 	return ret_pdu;
 }
 
-static int cas_rmt_q_create_policy(struct rmt_ps      *ps,
-				   struct rmt_n1_port *port)
+static void * cas_rmt_q_create_policy(struct rmt_ps      *ps,
+				      struct rmt_n1_port *port)
 {
         struct cas_rmt_queue *   q;
         struct cas_rmt_ps_data * data;
 
         if (!ps || !port || !ps->priv) {
                 LOG_ERR("Wrong input parms for cas_rmt_q_create_policy_tx");
-		return -1;
+		return NULL;
         }
 
         data = ps->priv;
@@ -264,8 +264,7 @@ static int cas_rmt_q_create_policy(struct rmt_ps      *ps,
         if (!q) {
                 LOG_ERR("Could not create queue for n1_port %u",
                         port->port_id);
-                port->rmt_ps_queues = NULL;
-                return -1;
+                return NULL;
         }
 
         getnstimeofday(&q->reg_cycles.prev_cycle.t_start);
@@ -275,10 +274,8 @@ static int cas_rmt_q_create_policy(struct rmt_ps      *ps,
         q->reg_cycles.prev_cycle.avg_len = 0;
         q->reg_cycles.cur_cycle = q->reg_cycles.prev_cycle;
 
-        port->rmt_ps_queues = q;
-
         LOG_DBG("Structures for scheduling policies created...");
-        return 0;
+        return q;
 }
 
 static int cas_rmt_q_destroy_policy(struct rmt_ps      *ps,

--- a/plugins/dummy/dtcp-ps-dummy.c
+++ b/plugins/dummy/dtcp-ps-dummy.c
@@ -69,7 +69,7 @@ dummy_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
 }
 
 static int
-dummy_rate_reduction(struct dtcp_ps * ps)
+dummy_rate_reduction(struct dtcp_ps * ps, const struct pci * pci)
 {
         printk("%s: called()\n", __func__);
         return 0;
@@ -107,7 +107,6 @@ dtcp_ps_dummy_create(struct rina_component * component)
         ps->initial_rate                = NULL;
         ps->receiving_flow_control      = dummy_receiving_flow_control;
         ps->update_credit               = NULL;
-        ps->reconcile_flow_conflict     = NULL;
         ps->rcvr_ack                    = dummy_rcvr_ack,
         ps->rcvr_flow_control           = dummy_rcvr_flow_control;
         ps->rate_reduction              = dummy_rate_reduction;

--- a/plugins/dummy/dtp-ps-dummy.c
+++ b/plugins/dummy/dtp-ps-dummy.c
@@ -95,10 +95,12 @@ dtp_ps_dummy_create(struct rina_component * component)
 
         ps->transmission_control        = dummy_transmission_control;
         ps->closed_window               = dummy_closed_window;
-        ps->flow_control_overrun        = dummy_flow_control_overrun;
+        ps->snd_flow_control_overrun    = dummy_flow_control_overrun;
+        ps->rcv_flow_control_overrun    = NULL;
         ps->initial_sequence_number     = dummy_initial_sequence_number;
         ps->receiver_inactivity_timer   = dummy_receiver_inactivity_timer;
         ps->sender_inactivity_timer     = dummy_sender_inactivity_timer;
+        ps->reconcile_flow_conflict     = NULL;
 
         /* Just zero here. These fields are really initialized by
          * dtp_select_policy_set. */

--- a/plugins/dummy/rmt-ps-dummy.c
+++ b/plugins/dummy/rmt-ps-dummy.c
@@ -50,7 +50,7 @@ dummy_rmt_enqueue_policy(struct rmt_ps	    *ps,
 			 struct pdu	    *pdu)
 {
         printk("%s: called()\n", __func__);
-        return RMT_PS_ENQ_DSEND;
+        return RMT_PS_ENQ_SCHED;
 }
 
 static struct pdu *
@@ -59,14 +59,6 @@ dummy_rmt_dequeue_policy(struct rmt_ps	    *ps,
 {
 	printk("%s: called()\n", __func__);
 	return NULL;
-}
-
-static bool
-dummy_rmt_needs_sched_policy(struct rmt_ps	*ps,
-			     struct rmt_n1_port *port)
-{
-        printk("%s: called()\n", __func__);
-        return false;
 }
 
 static int
@@ -103,14 +95,13 @@ rmt_ps_dummy_create(struct rina_component *component)
 		return NULL;
 	}
 
-	ps->base.set_policy_set_param = dummy_rmt_ps_set_policy_set_param;
+	ps->base.set_policy_set_param = dummy_rmt_ps_set_policy_set_param; /* default */
 	ps->dm = rmt;
 	ps->priv = NULL;
 	ps->rmt_q_create_policy = dummy_rmt_q_create_policy;
 	ps->rmt_q_destroy_policy = dummy_rmt_q_destroy_policy;
 	ps->rmt_enqueue_policy = dummy_rmt_enqueue_policy;
 	ps->rmt_dequeue_policy = dummy_rmt_dequeue_policy;
-	ps->rmt_needs_sched_policy = dummy_rmt_needs_sched_policy;
 
 	return &ps->base;
 }

--- a/plugins/dummy/rmt-ps-dummy.c
+++ b/plugins/dummy/rmt-ps-dummy.c
@@ -28,12 +28,12 @@
 #include "rds/rmem.h"
 #include "rmt-ps.h"
 
-static int
+static void *
 dummy_rmt_q_create_policy(struct rmt_ps      *ps,
 			  struct rmt_n1_port *port)
 {
         printk("%s: called()\n", __func__);
-        return 0;
+        return NULL;
 }
 
 static int

--- a/plugins/red/dtcp-ps-red.c
+++ b/plugins/red/dtcp-ps-red.c
@@ -140,7 +140,6 @@ dtcp_ps_red_create(struct rina_component * component)
         ps->initial_rate                = NULL;
         ps->receiving_flow_control      = NULL; /* default */
         ps->update_credit               = NULL;
-        ps->reconcile_flow_conflict     = NULL;
         ps->rcvr_ack                    = NULL; /* default */
         ps->rcvr_flow_control           = red_rcvr_flow_control;
         ps->rate_reduction              = NULL; /* default */

--- a/plugins/red/rmt-ps-red.c
+++ b/plugins/red/rmt-ps-red.c
@@ -230,7 +230,7 @@ exit:
         return ret;
 }
 
-static int red_rmt_q_create_policy(struct rmt_ps *      ps,
+static void * red_rmt_q_create_policy(struct rmt_ps *      ps,
                                    struct rmt_n1_port * port)
 {
         struct red_rmt_queue *   q;
@@ -239,7 +239,7 @@ static int red_rmt_q_create_policy(struct rmt_ps *      ps,
         if (!ps || !port || !ps->priv) {
                 LOG_ERR("Wrong input parameters for "
                         "red_rmt_scheduling_create_policy");
-                return -1;
+                return NULL;
         }
 
         data = ps->priv;
@@ -250,15 +250,13 @@ static int red_rmt_q_create_policy(struct rmt_ps *      ps,
         if (!q) {
                 LOG_ERR("Could not create queue for n1_port %u",
                         port->port_id);
-                port->rmt_ps_queues = NULL;
-                return -1;
+                return NULL;
         }
 
-        port->rmt_ps_queues = q;
-
         LOG_DBG("Structures for scheduling policies created...");
-        return 0;
+        return q;
 }
+
 static int red_rmt_q_destroy_policy(struct rmt_ps *      ps,
                                     struct rmt_n1_port * port)
 {


### PR DESCRIPTION
Concurrent writes are not longer allowed by means of a new boolean state variable in the n1_port. This should solve the problem with the pending_sdu being lost.

RMT PS simplified due to changes in RMT mechanism.

Some FIXMEs added, but this PR is blocking.
