### PR TITLE
Introduced prioritization of layer mgmt. PDUs in RMT default policy

### DIFF
--- a/linux/net/rina/rmt-ps-default.c
+++ b/linux/net/rina/rmt-ps-default.c
@@ -40,8 +40,9 @@
 #define rmap_hash(T, K) hash_min(K, HASH_BITS(T))
 
 struct rmt_queue {
-	struct rfifo	 *queue;
-	port_id_t	  pid;
+	struct rfifo *dt_queue;
+	struct rfifo *mgt_queue;
+	port_id_t    pid;
 };
 
 struct rmt_ps_default_data {
@@ -56,8 +57,15 @@ static struct rmt_queue *rmt_queue_create(port_id_t port)
 	if (!tmp)
 		return NULL;
 
-	tmp->queue = rfifo_create_ni();
-	if (!tmp->queue) {
+	tmp->dt_queue = rfifo_create_ni();
+	if (!tmp->dt_queue) {
+		rkfree(tmp);
+		return NULL;
+	}
+
+	tmp->mgt_queue = rfifo_create_ni();
+	if (!tmp->mgt_queue) {
+		rfifo_destroy(tmp->dt_queue, (void (*)(void *)) pdu_destroy);
 		rkfree(tmp);
 		return NULL;
 	}
@@ -74,8 +82,11 @@ static int rmt_queue_destroy(struct rmt_queue *q)
 		return -1;
 	}
 
-	if (q->queue)
-		rfifo_destroy(q->queue, (void (*)(void *)) pdu_destroy);
+	if (q->dt_queue)
+		rfifo_destroy(q->dt_queue, (void (*)(void *)) pdu_destroy);
+
+	if (q->mgt_queue)
+		rfifo_destroy(q->mgt_queue, (void (*)(void *)) pdu_destroy);
 
 	rkfree(q);
 
@@ -139,6 +150,7 @@ int default_rmt_enqueue_policy(struct rmt_ps	  *ps,
 {
 	struct rmt_queue *q;
 	struct rmt_ps_default_data *data = ps->priv;
+	pdu_type_t pdu_type;
 
 	if (!ps || !n1_port || !pdu) {
 		LOG_ERR("Wrong input parameters");
@@ -153,12 +165,18 @@ int default_rmt_enqueue_policy(struct rmt_ps	  *ps,
 		return RMT_PS_ENQ_ERR;
 	}
 
-	if (rfifo_length(q->queue) >= data->q_max) {
+	pdu_type = pci_type(pdu_pci_get_ro(pdu));
+	if (pdu_type == PDU_TYPE_MGMT) {
+		rfifo_push_ni(q->mgt_queue, pdu);
+		return RMT_PS_ENQ_SCHED;
+	}
+
+	if (rfifo_length(q->dt_queue) >= data->q_max) {
 		pdu_destroy(pdu);
 		return RMT_PS_ENQ_DROP;
 	}
 
-	rfifo_push_ni(q->queue, pdu);
+	rfifo_push_ni(q->dt_queue, pdu);
 	return RMT_PS_ENQ_SCHED;
 }
 EXPORT_SYMBOL(default_rmt_enqueue_policy);
@@ -181,7 +199,11 @@ struct pdu *default_rmt_dequeue_policy(struct rmt_ps	  *ps,
 		return NULL;
 	}
 
-	ret_pdu = rfifo_pop(q->queue);
+	if (!rfifo_is_empty(q->mgt_queue))
+		ret_pdu = rfifo_pop(q->mgt_queue);
+	else
+		ret_pdu = rfifo_pop(q->dt_queue);
+
 	if (!ret_pdu) {
 		LOG_ERR("Could not dequeue scheduled pdu");
 		return NULL;


### PR DESCRIPTION
Now layer mgmgt PDUs are put in a dedicated queue (with no max size) and dequeued first always.
It doesn't completely solve the problem for multiple layers, but we can't do better until we have separate layer management and data transfer flows.

Maintainers: @lbergesio 