### PR TITLE
Update default.dif to last DIF validation algorithms

### DIFF
--- a/tests/conf/default.dif
+++ b/tests/conf/default.dif
@@ -6,7 +6,10 @@
     	"lengthLength" : 2,
     	"portIdLength" : 2,
     	"qosIdLength" : 2,
+        "rateLength" : 4,
+        "frameLength" : 4,
     	"sequenceNumberLength" : 4,
+        "ctrlSequenceNumberLength" : 4,
     	"maxPduSize" : 10000,
     	"maxPduLifetime" : 60000
     },


### PR DESCRIPTION
Before this patch, using default.dif leads to failures due to
invalid (incomplete) data transfer constants.

MAINTAINERS: @edugrasa 