### PR TITLE
Plugin build system

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -161,6 +161,10 @@ M: Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
 F: plugins/dummy/*
 F: plugins/red/*
 
+Plugins build system
+M: Vincenzo Maffione <v.maffione (at) nextworks.it>
+F: plugins/Makefile
+
 Jain's Congestion Avoidance plugin:
 M: Leonardo Bergesio <leonardo.bergesio (at) i2cat.net>
 F: plugins/cong_avoidance/*

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,22 +1,31 @@
 directories=$(shell ls)
 
+ifndef INSTALLDIR
+$(error "INSTALLDIR is not set")
+endif
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../linux
+endif
+
 all:
-	for i in $(directories); do 			\
-		cd $$i || continue; 			\
-		INSTALLDIR=$(INSTALLDIR) make; 		\
-		cd ..; 					\
+	for i in $(directories); do 					\
+		cd $$i || continue; 					\
+		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make; 		\
+		cd ..; 							\
 	done
 
 clean:
-	for i in $(directories); do 			\
-		cd $$i || continue; 			\
-		INSTALLDIR=$(INSTALLDIR) make clean; 	\
-		cd ..; 					\
+	for i in $(directories); do 					\
+		cd $$i || continue; 					\
+		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make clean; 	\
+		cd ..; 							\
 	done
 
 install:
-	for i in $(directories); do 			\
-		cd $$i || continue; 			\
-		INSTALLDIR=$(INSTALLDIR) make install; 	\
-		cd ..; 					\
+	for i in $(directories); do 					\
+		cd $$i || continue; 					\
+		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make install; 	\
+		cd ..; 							\
 	done

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,0 +1,22 @@
+directories=$(shell ls)
+
+all:
+	for i in $(directories); do 			\
+		cd $$i || continue; 			\
+		INSTALLDIR=$(INSTALLDIR) make; 		\
+		cd ..; 					\
+	done
+
+clean:
+	for i in $(directories); do 			\
+		cd $$i || continue; 			\
+		INSTALLDIR=$(INSTALLDIR) make clean; 	\
+		cd ..; 					\
+	done
+
+install:
+	for i in $(directories); do 			\
+		cd $$i || continue; 			\
+		INSTALLDIR=$(INSTALLDIR) make install; 	\
+		cd ..; 					\
+	done

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -6,26 +6,28 @@ endif
 
 ifndef KDIR
 $(warning "KDIR will be set to the linux directory of the repository")
-KDIR=../linux
+KDIR=$(shell echo `pwd`/../linux)
 endif
 
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+
 all:
-	for i in $(directories); do 					\
-		cd $$i || continue; 					\
-		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make; 		\
-		cd ..; 							\
+	for i in $(directories); do 						\
+		cd $$i || continue; 						\
+		make KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) KREL=$(KREL); 	\
+		cd ..; 								\
 	done
 
 clean:
-	for i in $(directories); do 					\
-		cd $$i || continue; 					\
-		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make clean; 	\
-		cd ..; 							\
+	for i in $(directories); do 						\
+		cd $$i || continue; 						\
+		make KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) KREL=$(KREL) clean; 	\
+		cd ..; 								\
 	done
 
 install:
-	for i in $(directories); do 					\
-		cd $$i || continue; 					\
-		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make install; 	\
-		cd ..; 							\
+	for i in $(directories); do 						\
+		cd $$i || continue; 						\
+		make KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) KREL=$(KREL) install;\
+		cd ..; 								\
 	done

--- a/plugins/cherish-urgency/Makefile
+++ b/plugins/cherish-urgency/Makefile
@@ -2,9 +2,6 @@
 # Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
 #
 
-KDIR=../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
-
 ifneq ($(KERNELRELEASE),)
 
 ccflags-y = -Wtype-limits -Inet/rina
@@ -14,6 +11,15 @@ obj-m := cherish-urgency-plugin.o
 cherish-urgency-plugin-y := cherish-urgency.o
 
 else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
+
+ifndef KREL
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
 
 all:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/plugins/cherish-urgency/Makefile
+++ b/plugins/cherish-urgency/Makefile
@@ -3,7 +3,7 @@
 #
 
 KDIR=../../linux
-KREL=`uname -r`
+KREL=$(shell cd $(KDIR) && make kernelrelease)
 
 ifneq ($(KERNELRELEASE),)
 

--- a/plugins/cong_avoidance/Makefile
+++ b/plugins/cong_avoidance/Makefile
@@ -3,7 +3,7 @@
 #
 
 KDIR=../../linux
-KREL=`uname -r`
+KREL=$(shell cd $(KDIR) && make kernelrelease)
 
 ifneq ($(KERNELRELEASE),)
 

--- a/plugins/cong_avoidance/Makefile
+++ b/plugins/cong_avoidance/Makefile
@@ -2,9 +2,6 @@
 # Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
 #
 
-KDIR=../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
-
 ifneq ($(KERNELRELEASE),)
 
 ccflags-y = -Wtype-limits -Inet/rina
@@ -14,6 +11,15 @@ obj-m := cas-plugin.o
 cas-plugin-y := cas-plugin-ps.o rmt-ps-cas.o dtcp-ps-cas.o 
 
 else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
+
+ifndef KREL
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
 
 all:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/plugins/dummy/Makefile
+++ b/plugins/dummy/Makefile
@@ -2,8 +2,6 @@
 # Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
 #
 
-KDIR=../../linux
-
 ifneq ($(KERNELRELEASE),)
 
 ccflags-y = -Wtype-limits -Inet/rina
@@ -13,6 +11,11 @@ obj-m := dummy-plugin.o
 dummy-plugin-y := dummy-plugin-ps.o rmt-ps-dummy.o dtcp-ps-dummy.o dtp-ps-dummy.o pft-ps-dummy.o
 
 else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
 
 all:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/plugins/example-sm-plugin/Makefile
+++ b/plugins/example-sm-plugin/Makefile
@@ -34,7 +34,7 @@ $(PLUGIN_NAME).so: $(OBJECTS)
 	$(CXX) -c $(CXXFLAGS) $< -o $@
 
 clean:
-	rm -f $(OBJECTS)
+	rm -f $(OBJECTS) $(PLUGIN_NAME).so
 
 install:
 	install $(PLUGIN_NAME).so $(INSTALLDIR)/lib/rinad/ipcp

--- a/plugins/lfa/Makefile
+++ b/plugins/lfa/Makefile
@@ -3,7 +3,7 @@
 #
 
 KDIR=../../linux
-KREL=`uname -r`
+KREL=$(shell cd $(KDIR) && make kernelrelease)
 
 ifneq ($(KERNELRELEASE),)
 

--- a/plugins/lfa/Makefile
+++ b/plugins/lfa/Makefile
@@ -2,9 +2,6 @@
 # Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
 #
 
-KDIR=../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
-
 ifneq ($(KERNELRELEASE),)
 
 ccflags-y = -Wtype-limits -Inet/rina
@@ -14,6 +11,15 @@ obj-m := pff-lfa.o
 pff-lfa-y := ps.o
 
 else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
+
+ifndef KREL
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
 
 all:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/plugins/multipath/Makefile
+++ b/plugins/multipath/Makefile
@@ -3,7 +3,7 @@
 #
 
 KDIR=../../linux
-KREL=`uname -r`
+KREL=$(shell cd $(KDIR) && make kernelrelease)
 
 ifneq ($(KERNELRELEASE),)
 

--- a/plugins/multipath/Makefile
+++ b/plugins/multipath/Makefile
@@ -2,9 +2,6 @@
 # Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
 #
 
-KDIR=../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
-
 ifneq ($(KERNELRELEASE),)
 
 ccflags-y = -Wtype-limits -Inet/rina
@@ -14,6 +11,15 @@ obj-m := pff-multipath.o
 pff-multipath-y := mp-plugin-ps.o pff-ps-multipath.o
 
 else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
+
+ifndef
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
 
 all:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/plugins/rdsr-ps/Makefile
+++ b/plugins/rdsr-ps/Makefile
@@ -1,22 +1,30 @@
 directories=$(shell ls)
 
+ifndef INSTALLDIR
+$(error "INSTALLDIR is not set")
+endif
+
+ifndef KDIR
+$(error "KDIR is not set")
+endif
+
 all:
-	for i in $(directories); do 			\
-		cd $$i || continue; 			\
-		INSTALLDIR=$(INSTALLDIR) make; 		\
-		cd ..; 					\
+	for i in $(directories); do 					\
+		cd $$i || continue; 					\
+		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make; 		\
+		cd ..; 							\
 	done
 
 clean:
-	for i in $(directories); do 			\
-		cd $$i || continue; 			\
-		INSTALLDIR=$(INSTALLDIR) make clean; 	\
-		cd ..; 					\
+	for i in $(directories); do 					\
+		cd $$i || continue; 					\
+		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make clean; 	\
+		cd ..; 							\
 	done
 
 install:
-	for i in $(directories); do 			\
-		cd $$i || continue; 			\
-		INSTALLDIR=$(INSTALLDIR) make install; 	\
-		cd ..; 					\
+	for i in $(directories); do 					\
+		cd $$i || continue; 					\
+		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make install; 	\
+		cd ..; 							\
 	done

--- a/plugins/rdsr-ps/Makefile
+++ b/plugins/rdsr-ps/Makefile
@@ -8,23 +8,27 @@ ifndef KDIR
 $(error "KDIR is not set")
 endif
 
+ifndef KREL
+$(error "KREL is not set")
+endif
+
 all:
-	for i in $(directories); do 					\
-		cd $$i || continue; 					\
-		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make; 		\
-		cd ..; 							\
+	for i in $(directories); do 						\
+		cd $$i || continue; 						\
+		make KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) KREL=$(KREL); 	\
+		cd ..; 								\
 	done
 
 clean:
-	for i in $(directories); do 					\
-		cd $$i || continue; 					\
-		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make clean; 	\
-		cd ..; 							\
+	for i in $(directories); do 						\
+		cd $$i || continue; 						\
+		make KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) KREL=$(KREL) clean; 	\
+		cd ..; 								\
 	done
 
 install:
-	for i in $(directories); do 					\
-		cd $$i || continue; 					\
-		KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) make install; 	\
-		cd ..; 							\
+	for i in $(directories); do 						\
+		cd $$i || continue; 						\
+		make KDIR=$(KDIR) INSTALLDIR=$(INSTALLDIR) KREL=$(KREL) install;\
+		cd ..; 								\
 	done

--- a/plugins/rdsr-ps/Makefile
+++ b/plugins/rdsr-ps/Makefile
@@ -1,0 +1,22 @@
+directories=$(shell ls)
+
+all:
+	for i in $(directories); do 			\
+		cd $$i || continue; 			\
+		INSTALLDIR=$(INSTALLDIR) make; 		\
+		cd ..; 					\
+	done
+
+clean:
+	for i in $(directories); do 			\
+		cd $$i || continue; 			\
+		INSTALLDIR=$(INSTALLDIR) make clean; 	\
+		cd ..; 					\
+	done
+
+install:
+	for i in $(directories); do 			\
+		cd $$i || continue; 			\
+		INSTALLDIR=$(INSTALLDIR) make install; 	\
+		cd ..; 					\
+	done

--- a/plugins/rdsr-ps/cdrr/Makefile
+++ b/plugins/rdsr-ps/cdrr/Makefile
@@ -4,6 +4,8 @@
 # Author: Kewin Rausch <kewin.rausch@create-net.org>
 #
 
+KDIR=../../../linux
+KREL=$(shell cd $(KDIR) && make kernelrelease)
 
 EXTRA_CFLAGS=-Wtype-limits -Inet/rina/
 
@@ -11,11 +13,11 @@ obj-m	+= cdrr.o
 cdrr-y	:= dtcp-ps-cdrr.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd)
+	$(MAKE) -C $(KDIR) M=$(shell pwd)
 	
 install:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules_install
-	cp cdrr.manifest /lib/modules/$(shell uname -r)/extra/
+	$(MAKE) -C $(KDIR) M=$(shell pwd) modules_install
+	cp cdrr.manifest /lib/modules/$(KREL)/extra/
 	
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
+	$(MAKE) -C $(KDIR) M=$(shell pwd) clean

--- a/plugins/rdsr-ps/cdrr/Makefile
+++ b/plugins/rdsr-ps/cdrr/Makefile
@@ -4,20 +4,36 @@
 # Author: Kewin Rausch <kewin.rausch@create-net.org>
 #
 
-KDIR=../../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
+ifneq ($(KERNELRELEASE),)
 
-EXTRA_CFLAGS=-Wtype-limits -Inet/rina/
+ccflags-y = -Wtype-limits -Inet/rina
 
 obj-m	+= cdrr.o
 cdrr-y	:= dtcp-ps-cdrr.o
 
+else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../../linux
+endif
+
+ifndef
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
+
 all:
-	$(MAKE) -C $(KDIR) M=$(shell pwd)
-	
-install:
-	$(MAKE) -C $(KDIR) M=$(shell pwd) modules_install
-	cp cdrr.manifest /lib/modules/$(KREL)/extra/
-	
+	$(MAKE) -C $(KDIR) M=$$PWD
+
 clean:
-	$(MAKE) -C $(KDIR) M=$(shell pwd) clean
+	rm -r -f *.o *.ko *.mod.c *.mod.o Module.symvers .*.cmd .tmp_versions modules.order
+
+install:
+	$(MAKE) -C $(KDIR) M=$$PWD modules_install
+	cp cdrr.manifest /lib/modules/$(KREL)/extra/
+
+uninstall:
+	@echo "This target has not been implemented yet"
+	@exit 1
+
+endif

--- a/plugins/rdsr-ps/ecn/Makefile
+++ b/plugins/rdsr-ps/ecn/Makefile
@@ -4,17 +4,20 @@
 # Author: Kewin Rausch <kewin.rausch@create-net.org>
 #
 
+KDIR=../../../linux
+KREL=$(shell cd $(KDIR) && make kernelrelease)
+
 EXTRA_CFLAGS=-Wtype-limits -Inet/rina/
 
 obj-m	+= ecn.o
 ecn-y	:= rmt-ps-ecn.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd)
+	$(MAKE) -C $(KDIR) M=$(shell pwd)
 
 install:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules_install
-	cp ecn.manifest /lib/modules/$(shell uname -r)/extra/
+	$(MAKE) -C $(KDIR) M=$(shell pwd) modules_install
+	cp ecn.manifest /lib/modules/$(KREL)/extra/
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
+	$(MAKE) -C $(KDIR) M=$(shell pwd) clean

--- a/plugins/rdsr-ps/ecn/Makefile
+++ b/plugins/rdsr-ps/ecn/Makefile
@@ -4,20 +4,36 @@
 # Author: Kewin Rausch <kewin.rausch@create-net.org>
 #
 
-KDIR=../../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
+ifneq ($(KERNELRELEASE),)
 
-EXTRA_CFLAGS=-Wtype-limits -Inet/rina/
+ccflags-y = -Wtype-limits -Inet/rina
 
 obj-m	+= ecn.o
 ecn-y	:= rmt-ps-ecn.o
 
-all:
-	$(MAKE) -C $(KDIR) M=$(shell pwd)
+else
 
-install:
-	$(MAKE) -C $(KDIR) M=$(shell pwd) modules_install
-	cp ecn.manifest /lib/modules/$(KREL)/extra/
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../../linux
+endif
+
+ifndef
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
+
+all:
+	$(MAKE) -C $(KDIR) M=$$PWD
 
 clean:
-	$(MAKE) -C $(KDIR) M=$(shell pwd) clean
+	rm -r -f *.o *.ko *.mod.c *.mod.o Module.symvers .*.cmd .tmp_versions modules.order
+
+install:
+	$(MAKE) -C $(KDIR) M=$$PWD modules_install
+	cp ecn.manifest /lib/modules/$(KREL)/extra/
+
+uninstall:
+	@echo "This target has not been implemented yet"
+	@exit 1
+
+endif

--- a/plugins/rdsr-ps/fare/Makefile
+++ b/plugins/rdsr-ps/fare/Makefile
@@ -28,7 +28,7 @@ $(PLUGIN_NAME).so: $(OBJECTS)
 	$(CXX) -c $(CXXFLAGS) $< -o $@
 
 clean:
-	rm -f $(OBJECTS)
+	rm -f $(OBJECTS) $(PLUGIN_NAME).so
 
 install:
 	install $(PLUGIN_NAME).so $(INSTALLDIR)/lib/rinad/ipcp

--- a/plugins/red/Makefile
+++ b/plugins/red/Makefile
@@ -3,7 +3,7 @@
 #
 
 KDIR=../../linux
-KREL=`uname -r`
+KREL=$(shell cd $(KDIR) && make kernelrelease)
 
 ifneq ($(KERNELRELEASE),)
 

--- a/plugins/red/Makefile
+++ b/plugins/red/Makefile
@@ -2,9 +2,6 @@
 # Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
 #
 
-KDIR=../../linux
-KREL=$(shell cd $(KDIR) && make kernelrelease)
-
 ifneq ($(KERNELRELEASE),)
 
 ccflags-y = -Wtype-limits -Inet/rina
@@ -14,6 +11,15 @@ obj-m := red-plugin.o
 red-plugin-y := rmt-ps-debug.o dtcp-ps-debug.o red-ps.o rmt-ps-red.o dtcp-ps-red.o
 
 else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
+
+ifndef
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
 
 all:
 	$(MAKE) -C $(KDIR) M=$$PWD


### PR DESCRIPTION
Add a build system for the out-of-tree plugins.

In the plugin/ directory, it is possible to start the compilation and installation of all the plugins at once

````
$ make INSTALLDIR=/path/to/irati/install/dir/
$ sudo make INSTALLDIR=/path/to/irati/install/dir/ install
````

If the KDIR directory is not specified, the linux/ directory in the repository will be used as default. This could be used to address some concerns related to #823 .

Need ACK from:
@edugrasa @kewinrausch @lbergesio @miqueltarzan @sandervrijders 