### PR TITLE
Gracefully closing of the read mng thread

### DIFF
--- a/librina/src/ipc-process.cc
+++ b/librina/src/ipc-process.cc
@@ -23,6 +23,7 @@
 
 #include <ostream>
 #include <sstream>
+#include <errno.h>
 
 #define RINA_PREFIX "librina.ipc-process"
 
@@ -1319,8 +1320,16 @@ ReadManagementSDUResult KernelIPCProcess::readManagementSDU(void * sdu,
         int portId = 0;
         int result = syscallReadManagementSDU(ipcProcessId, sdu, &portId,
                         maxBytes);
-        if (result < 0) {
-                throw ReadSDUException();
+
+        if (result < 0)
+        {
+                switch(result) {
+                case -ESRCH:
+                        throw IPCException("the IPCP or the needed parts of the ipcp do not exist");
+                        break;
+                default:
+                        throw ReadSDUException("Unknown error");
+                }
         }
 
         readResult.setPortId(portId);

--- a/linux/net/rina/kipcm.c
+++ b/linux/net/rina/kipcm.c
@@ -2277,7 +2277,7 @@ int kipcm_mgmt_sdu_read(struct kipcm *    kipcm,
 
         if (!kipcm) {
                 LOG_ERR("Bogus kipcm instance passed, bailing out");
-                return -1;
+                return -ESRCH;
         }
 
         KIPCM_LOCK(kipcm);
@@ -2285,20 +2285,20 @@ int kipcm_mgmt_sdu_read(struct kipcm *    kipcm,
         if (!ipcp) {
                 LOG_ERR("Could not find IPC Process with id %d", id);
                 KIPCM_UNLOCK(kipcm);
-                return -1;
+                return -ESRCH;
         }
 
         if (!ipcp->ops) {
                 LOG_ERR("Bogus IPCP ops, bailing out");
                 KIPCM_UNLOCK(kipcm);
-                return -1;
+                return -ESRCH;
         }
 
         if (!ipcp->ops->mgmt_sdu_read) {
                 LOG_ERR("The IPC Process %d doesn't support this operation",
                         id);
                 KIPCM_UNLOCK(kipcm);
-                return -1;
+                return -ESRCH;
         }
         KIPCM_UNLOCK(kipcm);
 

--- a/linux/net/rina/syscalls.c
+++ b/linux/net/rina/syscalls.c
@@ -420,7 +420,7 @@ SYSCALL_DEFINE4(management_sdu_read,
 
 	if (retval) {
 		SYSCALL_DUMP_EXIT;
-		return -EFAULT;
+		return retval;
 	}
 
 	if (!sdu_wpi_is_ok(tmp)) {

--- a/rinad/src/ipcp/rib-daemon.cc
+++ b/rinad/src/ipcp/rib-daemon.cc
@@ -49,9 +49,16 @@ void * doManagementSDUReaderWork(void* arg)
 		try {
 			result = rina::kernelIPCProcess->readManagementSDU(message.message_,
 									   data->max_sdu_size_);
-		} catch (rina::Exception &e) {
-			LOG_IPCP_ERR("Problems reading management SDU: %s", e.what());
-			continue;
+		}
+		catch (rina::ReadSDUException  &e)
+		{
+		        LOG_IPCP_ERR("Problems reading management SDU: %s", e.what());
+		        continue;
+		}
+		catch(rina::IPCException &e)
+		{
+	                LOG_IPCP_ERR("Problems reading management SDU: %s", e.what());
+	                break;
 		}
 
 		message.size_ = result.bytesRead;


### PR DESCRIPTION
Fixes #825
Added error codes on the kernel side that are caught in the userspace.
When a critical error occurs on the read of the mng sdu in the kernel
it means that the kernel side of the normal IPCP is being closed.
In this case the userspace stops the thread that is polling
the kernel

Comes from https://github.com/IRATI/stack/pull/826 which closed due to an error when uploading the changes. Only need the ack from @edugrasa 