### PR TITLE
Pristine 1.4 fix valgrind closure

### DIFF
--- a/librina/include/librina/application.h
+++ b/librina/include/librina/application.h
@@ -201,6 +201,7 @@ class AppPolicyManager {
 public:
 	AppPolicyManager() { };
 	virtual ~AppPolicyManager();
+	virtual void clear();
 	virtual std::vector<PsFactory>::iterator
                   psFactoryLookup(const PsInfo& ps_info);
 	virtual int psFactoryPublish(const PsFactory& factory,
@@ -212,12 +213,10 @@ public:
 	virtual int psDestroy(const std::string& ae_name,
                               const std::string& name,
                               IPolicySet * instance);
-
 protected:
 	int plugin_load(const std::string& plugin_dir,
 			const std::string& name);
 	int plugin_unload(const std::string& name);
-
 private:
 	std::vector<rina::PsFactory> ae_policy_factories;
 	std::map< std::string, void * > plugins_handles;

--- a/librina/include/librina/timer.h
+++ b/librina/include/librina/timer.h
@@ -69,9 +69,8 @@ public:
 	~Timer();
 	void scheduleTask(TimerTask* task, long delay_ms);
 	void cancelTask(TimerTask *task);
-	void clear();
 	TaskScheduler* get_task_scheduler() const;
-	bool is_continue();
+	bool execute_tasks();
 private:
 	void cancel();
 	Thread *thread_;

--- a/librina/src/core.cc
+++ b/librina/src/core.cc
@@ -103,14 +103,20 @@ void RINANetlinkEndpoint::setApplicationProcessName(
 
 /* CLASS NETLINK PORT ID MAP */
 NetlinkPortIdMap::~NetlinkPortIdMap(){
-  std::map<std::string, RINANetlinkEndpoint*>::iterator iterator;
-
-  for (iterator = applicationNameMappings.begin();
-      iterator != applicationNameMappings.end(); ++iterator) {
-    if (iterator->second) {
-      delete iterator->second;
-    }
-  }
+        for (std::map<unsigned short, RINANetlinkEndpoint *>::iterator iterator
+                        = ipcProcessIdMappings.begin();
+                        iterator != ipcProcessIdMappings.end(); ++iterator) {
+                if (iterator->second) {
+                        delete iterator->second;
+                }
+        }
+        for (std::map<std::string, RINANetlinkEndpoint*>::iterator iterator
+                  = applicationNameMappings.begin();
+                  iterator != applicationNameMappings.end(); ++iterator) {
+                if (iterator->second) {
+                        delete iterator->second;
+                }
+        }
 }
 
 void NetlinkPortIdMap::putIPCProcessIdToNelinkPortIdMapping(
@@ -426,6 +432,7 @@ IPCEvent * NetlinkPortIdMap::osProcessFinalized(unsigned int nl_portid)
     if (iterator->second->getNetlinkPortId() == nl_portid) {
       apNamingInfo = iterator->second->getApplicationProcessName();
       foundAppName = true;
+      delete iterator->second;
       applicationNameMappings.erase(iterator);
       break;
     }
@@ -440,6 +447,7 @@ IPCEvent * NetlinkPortIdMap::osProcessFinalized(unsigned int nl_portid)
       iterator2 != ipcProcessIdMappings.end(); ++iterator2) {
     if (iterator2->second->getNetlinkPortId() == nl_portid) {
       ipcProcessId = iterator2->first;
+      delete iterator2->second;
       ipcProcessIdMappings.erase(iterator2);
       break;
     }

--- a/librina/src/ipc-manager.cc
+++ b/librina/src/ipc-manager.cc
@@ -618,7 +618,12 @@ void IPCProcessFactory::destroy(IPCProcessProxy* ipcp)
 	resultKernel = syscallDestroyIPCProcess(ipcp->id);
 
 	if (ipcp->getType().compare(NORMAL_IPC_PROCESS) == 0)
+	{
+		resultUserSpace = kill(ipcp->getPid(), SIGINT);
+		// TODO: Change magic number
+		usleep(1000000);
 		resultUserSpace = kill(ipcp->getPid(), SIGKILL);
+	}
 #endif
 
 	delete ipcp;

--- a/librina/src/timer.cc
+++ b/librina/src/timer.cc
@@ -154,9 +154,8 @@ unlock();
 void* doWorkTimer(void *arg) {
 	Timer *timer = (Timer*) arg;
 	Sleep sleep;
-	while (timer->is_continue()) {
-		sleep.sleepForMili(500);
-		timer->get_task_scheduler()->runTasks();
+	while (timer->execute_tasks()) {
+                sleep.sleepForMili(500);
 	}
 	return (void *) 0;
 }
@@ -212,10 +211,13 @@ void Timer::cancel() {
 TaskScheduler* Timer::get_task_scheduler() const {
 	return task_scheduler;
 }
-bool Timer::is_continue() {
-	bool result;
+bool Timer::execute_tasks() {
 	continue_lock_.lock();
-	result = continue_;
+        bool result = continue_;
+	if (result)
+	{
+	        get_task_scheduler()->runTasks();
+	}
 	continue_lock_.unlock();
 	return result;
 }

--- a/rinad/src/common/encoders/IntType.proto
+++ b/rinad/src/common/encoders/IntType.proto
@@ -1,6 +1,0 @@
-package rina.messages;
-option optimize_for = LITE_RUNTIME;
-
-message int_t {  //information to identify an int
-	required uint32 value = 1; 				//value of the integer
-}

--- a/rinad/src/common/encoders/Makefile.inc
+++ b/rinad/src/common/encoders/Makefile.inc
@@ -331,39 +331,6 @@ EXTRA_DIST +=                                   \
 protoSOURCES += FlowStateMessage.pb.cc FlowStateMessage.pb.h
 
 
-IntType.stamp: IntType.proto
-	rm -f IntType.tmp
-	touch IntType.tmp
-	$(PROTOC) -I$(builddir) -I$(srcdir)	\
-		--cpp_out=$(builddir)		\
-		$(srcdir)/IntType.proto
-	mv -f IntType.tmp $@
-
-IntType.pb.h IntType.pb.cc: IntType.stamp
-	if test -f $@; then :; else \
-	  trap 'rm -rf IntType.lock IntType.stamp' 1 2 13 15; \
-	  if mkdir IntType.lock 2>/dev/null; then \
-	    rm -f IntType.stamp; \
-	    $(MAKE) $(AM_MAKEFLAGS) IntType.stamp; \
-	    result=$$?; rm -rf IntType.lock; exit $$result; \
-	  else \
-	    while test -d IntType.lock; do sleep 1; done; \
-	    test -f IntType.stamp; \
-	  fi; \
-	fi
-
-DISTCLEANFILES +=                               \
-        IntType.pb.h IntType.pb.cc IntType.stamp
-
-MOSTLYCLEANFILES +=                             \
-        IntType.tmp
-
-EXTRA_DIST +=                                   \
-        IntType.proto
-
-protoSOURCES += IntType.pb.cc IntType.pb.h
-
-
 MA-IPCP.stamp: MA-IPCP.proto
 	rm -f MA-IPCP.tmp
 	touch MA-IPCP.tmp
@@ -595,6 +562,39 @@ EXTRA_DIST +=                                   \
 protoSOURCES += QoSSpecification.pb.cc QoSSpecification.pb.h
 
 
+RoutingForwarding.stamp: RoutingForwarding.proto
+	rm -f RoutingForwarding.tmp
+	touch RoutingForwarding.tmp
+	$(PROTOC) -I$(builddir) -I$(srcdir)	\
+		--cpp_out=$(builddir)		\
+		$(srcdir)/RoutingForwarding.proto
+	mv -f RoutingForwarding.tmp $@
+
+RoutingForwarding.pb.h RoutingForwarding.pb.cc: RoutingForwarding.stamp
+	if test -f $@; then :; else \
+	  trap 'rm -rf RoutingForwarding.lock RoutingForwarding.stamp' 1 2 13 15; \
+	  if mkdir RoutingForwarding.lock 2>/dev/null; then \
+	    rm -f RoutingForwarding.stamp; \
+	    $(MAKE) $(AM_MAKEFLAGS) RoutingForwarding.stamp; \
+	    result=$$?; rm -rf RoutingForwarding.lock; exit $$result; \
+	  else \
+	    while test -d RoutingForwarding.lock; do sleep 1; done; \
+	    test -f RoutingForwarding.stamp; \
+	  fi; \
+	fi
+
+DISTCLEANFILES +=                               \
+        RoutingForwarding.pb.h RoutingForwarding.pb.cc RoutingForwarding.stamp
+
+MOSTLYCLEANFILES +=                             \
+        RoutingForwarding.tmp
+
+EXTRA_DIST +=                                   \
+        RoutingForwarding.proto
+
+protoSOURCES += RoutingForwarding.pb.cc RoutingForwarding.pb.h
+
+
 WhatevercastNameArrayMessage.stamp: WhatevercastNameArrayMessage.proto
 	rm -f WhatevercastNameArrayMessage.tmp
 	touch WhatevercastNameArrayMessage.tmp
@@ -659,38 +659,5 @@ EXTRA_DIST +=                                   \
         WhatevercastNameMessage.proto
 
 protoSOURCES += WhatevercastNameMessage.pb.cc WhatevercastNameMessage.pb.h
-
-
-RoutingForwarding.stamp: RoutingForwarding.proto
-	rm -f RoutingForwarding.tmp
-	touch RoutingForwarding.tmp
-	$(PROTOC) -I$(builddir) -I$(srcdir)	\
-		--cpp_out=$(builddir)		\
-		$(srcdir)/RoutingForwarding.proto
-	mv -f RoutingForwarding.tmp $@
-
-RoutingForwarding.pb.h RoutingForwarding.pb.cc: RoutingForwarding.stamp
-	if test -f $@; then :; else \
-	  trap 'rm -rf RoutingForwarding.lock RoutingForwarding.stamp' 1 2 13 15; \
-	  if mkdir RoutingForwarding.lock 2>/dev/null; then \
-	    rm -f RoutingForwarding.stamp; \
-	    $(MAKE) $(AM_MAKEFLAGS) RoutingForwarding.stamp; \
-	    result=$$?; rm -rf RoutingForwarding.lock; exit $$result; \
-	  else \
-	    while test -d RoutingForwarding.lock; do sleep 1; done; \
-	    test -f RoutingForwarding.stamp; \
-	  fi; \
-	fi
-
-DISTCLEANFILES +=                               \
-        RoutingForwarding.pb.h RoutingForwarding.pb.cc RoutingForwarding.stamp
-
-MOSTLYCLEANFILES +=                             \
-        RoutingForwarding.tmp
-
-EXTRA_DIST +=                                   \
-        RoutingForwarding.proto
-
-protoSOURCES += RoutingForwarding.pb.cc RoutingForwarding.pb.h
 
 

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -55,6 +55,7 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
                 std::stringstream ss;
                 ss << IPCP_LOG_IPCP_FILE_PREFIX << "-" << id;
                 rina::initialize(log_level, log_file);
+                LOG_DBG("IPCProcessImpl");
                 rina::extendedIPCManager->ipcManagerPort = ipc_manager_port;
                 rina::extendedIPCManager->ipcProcessId = id;
                 rina::kernelIPCProcess->ipcProcessId = id;
@@ -81,12 +82,12 @@ IPCProcessImpl::IPCProcessImpl(const rina::ApplicationProcessNamingInformation& 
         add_entity(internal_event_manager_);
         add_entity(rib_daemon_);
         add_entity(enrollment_task_);
+        add_entity(routing_component_);
         add_entity(resource_allocator_->get_n_minus_one_flow_manager());
         add_entity(resource_allocator_);
         add_entity(namespace_manager_);
         add_entity(flow_allocator_);
         add_entity(security_manager_);
-        add_entity(routing_component_);
 
         try {
                 rina::ApplicationProcessNamingInformation naming_info(name_, instance_);
@@ -109,73 +110,6 @@ IPCProcessImpl::~IPCProcessImpl() {
 
 	if (delimiter_) {
 		delete delimiter_;
-	}
-
-	if (internal_event_manager_) {
-		delete internal_event_manager_;
-	}
-
-	if (enrollment_task_) {
-		if (enrollment_task_->ps) {
-			psDestroy(rina::ApplicationEntity::ENROLLMENT_TASK_AE_NAME,
-				  enrollment_task_->selected_ps_name,
-				  enrollment_task_->ps);
-		}
-		delete enrollment_task_;
-	}
-
-	if (flow_allocator_) {
-		if (flow_allocator_->ps) {
-			psDestroy(IFlowAllocator::FLOW_ALLOCATOR_AE_NAME,
-				  flow_allocator_->selected_ps_name,
-				  flow_allocator_->ps);
-		}
-		delete flow_allocator_;
-	}
-
-	if (namespace_manager_) {
-		if (namespace_manager_->ps) {
-			psDestroy(INamespaceManager::NAMESPACE_MANAGER_AE_NAME,
-				  namespace_manager_->selected_ps_name,
-				  namespace_manager_->ps);
-		}
-		delete namespace_manager_;
-	}
-
-	if (resource_allocator_) {
-		if (resource_allocator_->ps) {
-			psDestroy(IResourceAllocator::RESOURCE_ALLOCATOR_AE_NAME,
-				  resource_allocator_->selected_ps_name,
-				  resource_allocator_->ps);
-		}
-		delete resource_allocator_;
-	}
-
-	if (security_manager_) {
-		if (security_manager_->ps) {
-			psDestroy(rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME,
-				  security_manager_->selected_ps_name,
-				  security_manager_->ps);
-		}
-		delete security_manager_;
-	}
-
-	if (routing_component_) {
-		if (routing_component_->ps) {
-			psDestroy(IRoutingComponent::ROUTING_COMPONENT_AE_NAME,
-				  routing_component_->selected_ps_name,
-				  routing_component_->ps);
-		}
-		delete routing_component_;
-	}
-
-	if (rib_daemon_) {
-		if (rib_daemon_->ps) {
-			psDestroy(IPCPRIBDaemon::RIB_DAEMON_AE_NAME,
-				  rib_daemon_->selected_ps_name,
-				  rib_daemon_->ps);
-		}
-		delete rib_daemon_;
 	}
 }
 
@@ -608,7 +542,7 @@ void IPCProcessImpl::event_loop(void){
 
 	rina::IPCEvent *e;
 
-	bool keep_running = true;
+	keep_running = true;
 
 	LOG_DBG("Starting main I/O loop...");
 

--- a/rinad/src/ipcp/ipc-process.h
+++ b/rinad/src/ipcp/ipc-process.h
@@ -69,6 +69,7 @@ public:
 	//Event loop (run)
 	void event_loop(void);
 
+	bool keep_running;
 private:
         IPCProcessImpl(const rina::ApplicationProcessNamingInformation& name,
                         unsigned short id, unsigned int ipc_manager_port,

--- a/rinad/src/ipcp/resource-allocator.cc
+++ b/rinad/src/ipcp/resource-allocator.cc
@@ -364,9 +364,6 @@ ResourceAllocator::ResourceAllocator() : IResourceAllocator() {
 }
 
 ResourceAllocator::~ResourceAllocator() {
-	if (n_minus_one_flow_manager_) {
-		delete n_minus_one_flow_manager_;
-	}
 }
 
 void ResourceAllocator::set_application_process(rina::ApplicationProcess * ap)


### PR DESCRIPTION
Fixed 2 errors:
1. A protobuffer closure problem that was introducing memory leaks when closing the ipcm
2. The capture of the SIGINT signal by the IPCP and the closure of the IPCP without segfaults.

Need ack from @vmaffione and @edugrasa 