### PR TITLE
rinad: common: encoders: remove spurious include directive

### DIFF
--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -33,7 +33,6 @@
 #include "encoders/QoSCubeArrayMessage.pb.h"
 #include "encoders/WhatevercastNameArrayMessage.pb.h"
 #include "encoders/NeighborArrayMessage.pb.h"
-#include "encoders/IntType.pb.h"
 #include "encoders/QoSSpecification.pb.h"
 #include "encoders/FlowMessage.pb.h"
 #include "encoders/EnrollmentInformationMessage.pb.h"


### PR DESCRIPTION
This fixes #835.