### PR TITLE
MA stuck when closing flows

### DIFF
--- a/rinad/src/ipcm/addons/ma/flowm.cc
+++ b/rinad/src/ipcm/addons/ma/flowm.cc
@@ -515,8 +515,6 @@ FlowManager::~FlowManager()
 	it = workers.begin();
 
 	while (it != workers.end()) {
-		//Stop and join
-		//it->second->stop();
 
 		//Keep next
 		next = it;

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1817,9 +1817,6 @@ void IPCManager_::run()
     //Cleanup
     LOG_DBG("Cleaning the house...");
 
-    //Destroy all addons (stop them)
-    Addon::destroy_all();
-
     //Destroy all IPCPs
     std::vector<IPCMIPCProcess *> ipcps;
     ipcp_factory_.listIPCProcesses(ipcps);
@@ -1834,6 +1831,9 @@ void IPCManager_::run()
                      (*it)->get_id());
         }
     }
+
+    //Destroy all addons (stop them)
+    Addon::destroy_all();
 
     //Join the I/O loop thread
     keep_running = false;


### PR DESCRIPTION
Fixes #851 . The order of destroying IPCP and addons has been changed.
Now, IPCPs are destroyed before addons to avoid the MA being stuck on
the threads reading these IPCPs. Moreover, the loop of the MA reading
on the flows have been changed to allow exit from this loop.

ack @edugrasa 