### PR TITLE
plugins: add depmod -a instruction in install targets

### DIFF
--- a/plugins/cherish-urgency/Makefile
+++ b/plugins/cherish-urgency/Makefile
@@ -30,6 +30,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp cherish-urgency-plugin.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/cong_avoidance/Makefile
+++ b/plugins/cong_avoidance/Makefile
@@ -30,6 +30,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp cas-plugin.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/lfa/Makefile
+++ b/plugins/lfa/Makefile
@@ -30,6 +30,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp pff-lfa.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/multipath/Makefile
+++ b/plugins/multipath/Makefile
@@ -30,6 +30,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp pff-multipath.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/rdsr-ps/cdrr/Makefile
+++ b/plugins/rdsr-ps/cdrr/Makefile
@@ -31,6 +31,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp cdrr.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/rdsr-ps/ecn/Makefile
+++ b/plugins/rdsr-ps/ecn/Makefile
@@ -31,6 +31,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp ecn.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"

--- a/plugins/red/Makefile
+++ b/plugins/red/Makefile
@@ -30,6 +30,7 @@ clean:
 install:
 	$(MAKE) -C $(KDIR) M=$$PWD modules_install
 	cp red-plugin.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
 
 uninstall:
 	@echo "This target has not been implemented yet"


### PR DESCRIPTION
This makes sure modprobe works as expected after make install.

This fixes #860 

ACK:
@kewinrausch 