### PR TITLE
rinad: ipcm: fixed bug when unregistering apps

### DIFF
--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1601,7 +1601,6 @@ ipcm_res_t IPCManager_::unregister_app_from_ipcp(
             ss
                     << "Unable to allocate memory for the transaction object. Out of memory! ";
             FLUSH_LOG(ERR, ss);
-            delete trans;
             throw rina::Exception();
         }
 
@@ -1610,7 +1609,6 @@ ipcm_res_t IPCManager_::unregister_app_from_ipcp(
         {
             ss << "Unable to add transaction; out of memory? ";
             FLUSH_LOG(ERR, ss);
-            delete trans;
             throw rina::Exception();
         }
 
@@ -1621,7 +1619,6 @@ ipcm_res_t IPCManager_::unregister_app_from_ipcp(
                         "process " << slave_ipcp->get_name().toString()
                 << std::endl;
         FLUSH_LOG(INFO, ss);
-        delete trans;
     } catch (rina::ConcurrentException& e)
     {
         ss << ": Error while unregistering application "
@@ -1629,7 +1626,7 @@ ipcm_res_t IPCManager_::unregister_app_from_ipcp(
                         "process " << slave_ipcp->get_name().toString()
                 << ". Operation timedout." << std::endl;
         FLUSH_LOG(ERR, ss);
-        delete trans;
+        remove_transaction_state(trans->tid);
         return IPCM_FAILURE;
     } catch (rina::IpcmUnregisterApplicationException& e)
     {
@@ -1637,14 +1634,14 @@ ipcm_res_t IPCManager_::unregister_app_from_ipcp(
                 << req_event.applicationName.toString() << " from IPC "
                         "process " << slave_ipcp->get_name().toString()
                 << std::endl;
-        delete trans;
+        remove_transaction_state(trans->tid);
         FLUSH_LOG(ERR, ss);
         return IPCM_FAILURE;
     } catch (rina::Exception& e)
     {
         ss << ": Unknown error while unregistering application " << std::endl;
         FLUSH_LOG(ERR, ss);
-        delete trans;
+        remove_transaction_state(trans->tid);
         return IPCM_FAILURE;
     }
     return IPCM_PENDING;

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1609,6 +1609,7 @@ ipcm_res_t IPCManager_::unregister_app_from_ipcp(
         {
             ss << "Unable to add transaction; out of memory? ";
             FLUSH_LOG(ERR, ss);
+            delete trans;
             throw rina::Exception();
         }
 


### PR DESCRIPTION
Wrong handling of transactions code in IPCM caused it to terminate when an application was unregistered.

@vmaffione could you test it? It's quick, just register and unregister an application several times and make sure IPCM is still alive.