### PR TITLE
neighbor lost bug fix

### DIFF
--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -1105,7 +1105,8 @@ void FlowStateObjects::deprecateObject(const std::string& fqn,
 	}
 }
 
-void FlowStateObjects::deprecateObjects(unsigned int address,
+void FlowStateObjects::deprecateObjects(unsigned int neigh_address,
+                                        unsigned int address,
 		     	     	        unsigned int max_age)
 {
 	rina::ScopedLock g(lock);
@@ -1113,7 +1114,7 @@ void FlowStateObjects::deprecateObjects(unsigned int address,
 	std::map<std::string, FlowStateObject *>::iterator it;
 	for (it = objects.begin(); it != objects.end();
 			++it) {
-		if (it->second->get_neighboraddress() == address ||
+		if (it->second->get_neighboraddress() == neigh_address &&
 				it->second->get_address() == address) {
 			it->second->deprecateObject(max_age);
 			modified_ = true;
@@ -1428,9 +1429,10 @@ void FlowStateManager::getAllFSOs(std::list<FlowStateObject>& list) const
 	fsos->getAllFSOs(list);
 }
 
-void FlowStateManager::deprecateObjectsNeighbor(unsigned int address)
+void FlowStateManager::deprecateObjectsNeighbor(unsigned int neigh_address,
+                                                unsigned int address)
 {
-	fsos->deprecateObjects(address,
+	fsos->deprecateObjects(neigh_address, address,
 			       maximum_age);
 }
 
@@ -1664,7 +1666,7 @@ void LinkStateRoutingPolicy::processFlowDeallocatedEvent(
 
 void LinkStateRoutingPolicy::processNeighborLostEvent(
 		rina::ConnectiviyToNeighborLostEvent* event) {
-	db_->deprecateObjectsNeighbor(event->neighbor_.address_);
+	db_->deprecateObjectsNeighbor(event->neighbor_.address_, ipc_process_->get_address());
 }
 
 

--- a/rinad/src/ipcp/plugins/default/routing-ps.h
+++ b/rinad/src/ipcp/plugins/default/routing-ps.h
@@ -369,7 +369,7 @@ public:
 	bool addObject(const FlowStateObject& object);
 	void deprecateObject(const std::string& fqn, 
 			     unsigned int max_age);
-	void deprecateObjects(unsigned int address,
+	void deprecateObjects(unsigned int neigh_address, unsigned int address,
 			      unsigned int max_age);
 	FlowStateObject * getObject(const std::string& fqn);
 	void getModifiedFSOs(std::list<FlowStateObject *>& result);
@@ -449,8 +449,10 @@ public:
 		       int avoid_port);
 	/// Set a FSO ready for removal
 	void deprecateObject(std::string fqn);
-	void deprecateObjectsNeighbor(unsigned int address);
-	std::map <int, std::list<FlowStateObject*> > prepareForPropagation(const std::list<rina::FlowInformation>& flows);
+	void deprecateObjectsNeighbor(unsigned int neigh_address,
+	                              unsigned int address);
+	std::map <int, std::list<FlowStateObject*> > prepareForPropagation
+	        (const std::list<rina::FlowInformation>& flows);
 	void incrementAge();
 	void updateObjects(const std::list<FlowStateObject>& newObjects,
 			   unsigned int avoidPort,


### PR DESCRIPTION
When a neighbor is lost, the routing was erasing all the FSOs
that had a realtion which such neighbor. It has only to erase
the direct link between curren IPCP and the neighbor and not
any remote link with the address of the neighbor.
Fixes #864