### PR TITLE
Pristine 1.5 authssh

### DIFF
--- a/librina/src/security-manager.cc
+++ b/librina/src/security-manager.cc
@@ -874,7 +874,7 @@ int AuthSSH2PolicySet::load_authentication_keys(SSH2SecurityContext * sc)
 
 	//TODO fix problems with reading private keys from encrypted repos
 	//we should use sc->keystore_pass.c_str() as the last argument
-	sc->auth_peer_pub_key = PEM_read_bio_RSAPublicKey(keystore, NULL, 0, NULL);
+	sc->auth_peer_pub_key = PEM_read_bio_RSA_PUBKEY(keystore, NULL, 0, NULL);
 	BIO_free(keystore);
 
 	if (!sc->auth_peer_pub_key) {
@@ -895,7 +895,7 @@ int AuthSSH2PolicySet::load_authentication_keys(SSH2SecurityContext * sc)
 	//maximum length of the data to be encrypted must be less than RSA_size(rsa) - 41
 	sc->challenge.length = rsa_size - 42;
 
-	LOG_DBG("Read RSA key pair from keystore");
+	LOG_DBG("Read RSA keys from keystore");
 	return 0;
 }
 

--- a/rina-tools/src/util-scripts/rmt-port-monitor.sh
+++ b/rina-tools/src/util-scripts/rmt-port-monitor.sh
@@ -18,7 +18,7 @@ do
         rx_pdus=$(head -n 1 "/sys/rina/ipcps/$1/rmt/n1_ports/$2/rx_pdus")
 	tx_pdus=$(head -n 1 "/sys/rina/ipcps/$1/rmt/n1_ports/$2/tx_pdus")
 	q_pdus=$(head -n 1 "/sys/rina/ipcps/$1/rmt/n1_ports/$2/queued_pdus")
-	drop_pdus=$(head -n 1 "/sys/rina/ipcps/$1/rmt/n1_ports/$2/dropped_pdus")
+	drop_pdus=$(head -n 1 "/sys/rina/ipcps/$1/rmt/n1_ports/$2/drop_pdus")
 
 	echo "$time  $rx_pdus  $tx_pdus  $q_pdus  $drop_pdus" >> $3
         counter=$((counter+1))

--- a/rinad/src/ipcp/plugins/default/enrollment-task-ps.cc
+++ b/rinad/src/ipcp/plugins/default/enrollment-task-ps.cc
@@ -338,8 +338,6 @@ void EnrolleeStateMachine::initiateEnrollment(const rina::EnrollmentRequest& enr
 		rina::cdap_rib::ep_info_t src_ep;
 		rina::cdap_rib::ep_info_t dest_ep;
 		rina::cdap_rib::vers_info_t vers;
-		rina::cdap_rib::auth_policy_t auth = auth_ps_->get_auth_policy(portId,
-									       profile);
 
 		src_ep.ap_name_ = ipc_process_->get_name();
 		src_ep.ap_inst_ = ipc_process_->get_instance();
@@ -348,6 +346,10 @@ void EnrolleeStateMachine::initiateEnrollment(const rina::EnrollmentRequest& enr
 		dest_ep.ap_name_ = remote_peer_.name_.processName;
 		dest_ep.ap_inst_ = remote_peer_.name_.processInstance;
 		dest_ep.ae_name_ = IPCProcess::MANAGEMENT_AE;
+
+		rina::cdap_rib::auth_policy_t auth = auth_ps_->get_auth_policy(portId,
+									       dest_ep,
+									       profile);
 
 		vers.version_ = 0x01;
 
@@ -957,6 +959,7 @@ void EnrollerStateMachine::connect(const rina::cdap::CDAPMessage& message,
 	rina::IAuthPolicySet::AuthStatus auth_status =
 			auth_ps_->initiate_authentication(message.auth_policy_,
 							  profile,
+							  con_handle.dest_,
 							  con.port_id);
 	if (auth_status == rina::IAuthPolicySet::FAILED) {
 		lock_.unlock();


### PR DESCRIPTION
Fixed an issue identified by Sarah from Thales: the policy was using a single RSA key pair for both authenticating parties, which doesn't make a lot of sense and is not how SSH operates.  Now is updated so that each IPCP has its own RSA key pair. Therefore, each IPCP needs to know the public keys of the IPCPs it wants to establish an application connection to.

The code is slightly changed, as well as the configuration of this policy. Now the "keystore_path" configuration parameter expects a path to a folder (terminating without "/"). The contents of the folder should be the following files:

* **key** : The RSA private key of the IPCP in PEM format (generated for example with _openssl genrsa -out key 2048_)
* **public_key**: The RSA public key of the IPCP in PEM format (extracted from the private key file, for example with _openssl rsa -in key -pubout > mykey.pub_)
* For each IPCP whose public key is known, a file containing his public key in PEM format. The file *must be named* with the IPC Process application process name. For example, imagine the IPCP has 3 neighbors, then there would be 3 files, each one containing the public key
    * B.IRATI
    * C.IRATI
    * D.IRATI