### PR TITLE
Fixes the parsing of debugging flags in CXXFLAGS

### DIFF
--- a/install-user-from-scratch
+++ b/install-user-from-scratch
@@ -10,7 +10,7 @@
 #
 PREFIX=`echo "$1"|sed -e "s,\/$,,"`
 SRCDIR=`pwd`
-FLAGS="--enable-debug"
+#FLAGS="--enable-debug"
 
 #
 # Do not touch under this line

--- a/librina/configure.ac
+++ b/librina/configure.ac
@@ -90,7 +90,7 @@ AS_IF([test "$want_debug" = "yes"],[
     AX_CHECK_COMPILE_FLAG([ -g ], [
         CXXFLAGS_EXTRA="$CXXFLAGS_EXTRA -g"
     ])
-    AS_IF([`echo $CXXFLAGS|$GREP '\\\-O2'`],[
+    AS_IF([echo "$CXXFLAGS" | "$GREP" '\-O2' > /dev/null],[
         AC_MSG_NOTICE([Patching flags])
         CXXFLAGS="`echo $CXXFLAGS | $SED -e 's|-O2||'`"
         AC_MSG_NOTICE([Flags are now '$CXXFLAGS'])

--- a/rina-tools/configure.ac
+++ b/rina-tools/configure.ac
@@ -93,7 +93,7 @@ AS_IF([test "$want_debug" = "yes"],[
     AX_CHECK_COMPILE_FLAG([ -g ], [
         CXXFLAGS_EXTRA="$CXXFLAGS_EXTRA -g"
     ])
-    AS_IF([`echo $CXXFLAGS|$GREP '\\\-O2'`],[
+    AS_IF([echo $CXXFLAGS|$GREP '\-O2' > /dev/null],[
         AC_MSG_NOTICE([Patching flags])
         CXXFLAGS="`echo $CXXFLAGS | $SED -e 's|-O2||'`"
         AC_MSG_NOTICE([Flags are now '$CXXFLAGS'])

--- a/rinad/configure.ac
+++ b/rinad/configure.ac
@@ -92,7 +92,7 @@ AS_IF([test "$want_debug" = "yes"],[
     AX_CHECK_COMPILE_FLAG([ -g ], [
         CXXFLAGS_EXTRA="$CXXFLAGS_EXTRA -g"
     ])
-    AS_IF([`echo $CXXFLAGS|$GREP '\\\-O2'`],[
+    AS_IF([echo $CXXFLAGS|$GREP '\-O2' > /dev/null],[
         AC_MSG_NOTICE([Patching flags])
         CXXFLAGS="`echo $CXXFLAGS | $SED -e 's|-O2||'`"
         AC_MSG_NOTICE([Flags are now '$CXXFLAGS'])


### PR DESCRIPTION
For librina, rinad and rina-tools
fixes #890

Be aware that this change affects the default compilation of the stack
as --enable-debug is activated by default, and from now on this will
imply -O0, so decreases in performance should be expected.

To get the former performance you should disable --enable-debug
in the configuration scripts