### PR TITLE
kernel: sysfs: fix CLANG warning on sysfs_create_file return value

### DIFF
--- a/linux/net/rina/rds/robjects.h
+++ b/linux/net/rina/rds/robjects.h
@@ -157,7 +157,7 @@ static const struct sysfs_ops COMP_NAME##_sysfs_ops = {			\
 
 /* Adds an attribute to an existing robject */
 #define _ADD_ATTR_TO_ROBJ(ROBJ, ATTR_NAME)				\
-	sysfs_create_file(ROBJ.kobj, &ATTR_NAME##_attr.kattr.attr);
+	if (sysfs_create_file(ROBJ.kobj, &ATTR_NAME##_attr.kattr.attr));\
 
 /* Declares a new attribute and adds it to an existing kobject */
 #define RINA_DECLARE_AND_ADD_ATTRS(robj, COMP_NAME, ...)		\


### PR DESCRIPTION
The issue was reported to me by @sandervrijders. The patch has been tested and seems to remove the warning he was getting when compiling with clang (gcc was not doing that afaik).