### PR TITLE
kernel:shim-tcp-udp: fix compilation warning

### DIFF
--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -267,6 +267,7 @@ static unsigned sockaddr_init(union address *         sa,
 		return sizeof sa->in6;
 	}
 	ASSERT(0);
+	return 0;
 }
 
 static unsigned sockaddr_copy(union address * src, union address * dst)
@@ -280,6 +281,7 @@ static unsigned sockaddr_copy(union address * src, union address * dst)
 		return sizeof dst->in6;
 	}
 	ASSERT(0);
+	return 0;
 }
 
 static ssize_t shim_tcp_udp_ipcp_attr_show(struct robject *        robj,

--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -266,8 +266,7 @@ static unsigned sockaddr_init(union address *         sa,
 		sa->in6.sin6_flowinfo = sa->in6.sin6_scope_id = 0;
 		return sizeof sa->in6;
 	}
-	ASSERT(0);
-	return 0;
+	unreachable();
 }
 
 static unsigned sockaddr_copy(union address * src, union address * dst)
@@ -280,8 +279,7 @@ static unsigned sockaddr_copy(union address * src, union address * dst)
 		dst->in6 = src->in6;
 		return sizeof dst->in6;
 	}
-	ASSERT(0);
-	return 0;
+	unreachable();
 }
 
 static ssize_t shim_tcp_udp_ipcp_attr_show(struct robject *        robj,


### PR DESCRIPTION
Just to avoid the compiler warning about a couple of

"warning: control reaches end of non-void function [-Wreturn-type]"