### PR TITLE
kernel:rmt:fixed wrong return in n1_port_write_sdu

### DIFF
--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -678,6 +678,8 @@ static int n1_port_write_sdu(struct rmt *rmt,
 	ret = n1_port->n1_ipcp->ops->sdu_write(n1_port->n1_ipcp->data,
 					       n1_port->port_id,
 					       sdu);
+	if (!ret)
+		return (int) bytes;
 
 	if (ret == -EAGAIN) {
 		n1_port_lock(n1_port, flags);
@@ -698,10 +700,8 @@ static int n1_port_write_sdu(struct rmt *rmt,
 			n1_port->state = N1_PORT_STATE_DISABLED;
 
 		n1_port_unlock(n1_port, flags);
-		return ret;
 	}
-
-	return (int) bytes;
+	return ret;
 }
 
 static struct sdu * generate_sdu_from_pdu(struct rmt * rmt,


### PR DESCRIPTION
n1_port_write_sdu only considered a -EAGAIN coming from the sdu_write ops as
only possible error. If -1 was returned by the op, n1_port_write_sdu was
obviating this and returning the bytes of the sdu supposedly written.