### PR TITLE
rinad: enrollment: fixed wrong inheritance by WatchdogRIBObject

### DIFF
--- a/rinad/src/ipcp/enrollment-task.cc
+++ b/rinad/src/ipcp/enrollment-task.cc
@@ -197,7 +197,7 @@ void WatchdogRIBObject::read(const rina::cdap_rib::con_handle_t &con,
 			     const std::string& class_,
 			     const rina::cdap_rib::filt_info_t &filt,
 			     const int invoke_id,
-			     rina::ser_obj_t &obj_reply,
+			     rina::cdap_rib::obj_info_t &obj_reply,
 			     rina::cdap_rib::res_info_t& res)
 {
 	rina::ScopedLock g(*lock_);
@@ -217,7 +217,7 @@ void WatchdogRIBObject::read(const rina::cdap_rib::con_handle_t &con,
 
 	//2 Prepare response (RIBDaemon will send it)
 	rina::cdap::IntEncoder encoder;
-	encoder.encode(ipc_process_->get_address(), obj_reply);
+	encoder.encode(ipc_process_->get_address(), obj_reply.value_);
 	res.code_ = rina::cdap_rib::CDAP_SUCCESS;
 }
 

--- a/rinad/src/ipcp/enrollment-task.h
+++ b/rinad/src/ipcp/enrollment-task.h
@@ -91,7 +91,7 @@ private:
 	int delay_;
 };
 
-class WatchdogRIBObject: public IPCPRIBObj, rina::rib::RIBOpsRespHandler {
+class WatchdogRIBObject: public IPCPRIBObj, public rina::rib::RIBOpsRespHandler {
 public:
 	WatchdogRIBObject(IPCProcess * ipc_process,
 			  int wdog_period_ms,
@@ -107,7 +107,7 @@ public:
 		  const std::string& class_,
 		  const rina::cdap_rib::filt_info_t &filt,
 		  const int invoke_id,
-		  rina::ser_obj_t &obj_reply,
+		  rina::cdap_rib::obj_info_t &obj_reply,
 		  rina::cdap_rib::res_info_t& res);
 
 	/// Send watchdog messages to the IPC processes that are our neighbors and we're enrolled to


### PR DESCRIPTION
Fixed wrong parameter type in read object api that prevented the method in the derived class from being called.