### PR TITLE
Delegation of objects various bugs fixed

### DIFF
--- a/librina/include/librina/cdap_v2.h
+++ b/librina/include/librina/cdap_v2.h
@@ -222,6 +222,7 @@ class CDAPCallbackInterface
 	virtual void read_request(const cdap_rib::con_handle_t &con,
 				  const cdap_rib::obj_info_t &obj,
 				  const cdap_rib::filt_info_t &filt,
+				  const cdap_rib::flags_t &flags,
 				  const int invoke_id);
 	virtual void cancel_read_request(const cdap_rib::con_handle_t &con,
 					 const cdap_rib::obj_info_t &obj,

--- a/librina/include/librina/rib_v2.h
+++ b/librina/include/librina/rib_v2.h
@@ -476,19 +476,29 @@ class DelegationObj : public RIBObj{
 
 public:
 	/// Constructor
-	DelegationObj(const std::string &class_name) : RIBObj(class_name) {
-		delegates = true;
-	};
+	DelegationObj(const std::string &class_name);
 
 	//Destructor
-	~DelegationObj(void){};
+	~DelegationObj(void);
 
 	virtual void forward_object(const rina::cdap_rib::con_handle_t& con,
-	                            const rina::cdap_rib::obj_info_t &obj,
+	                            const std::string obj_name,
+	                            const std::string obj_class,
 	                            const rina::cdap_rib::flags_t &flags,
 	                            const rina::cdap_rib::filt_info_t &filt,
 	                            int invoke_id) = 0;
-	virtual void forwarded_object_response(rina::cdap::cdap_m_t *msg) = 0;
+	void forwarded_object_response(int port, int invoke_id,
+			rina::cdap::cdap_m_t *msg);
+	bool is_processing_delegation();
+	void set_last(bool state);
+	rina::Lockable lock;
+protected:
+	void set_processing_delegation(bool state);
+private:
+	/// indicates if the delegated object is being operated remotely
+	bool processing_delegation;
+	/// indicates if the delegated object is the last object to be sent
+	bool last;
 };
 
 ///

--- a/librina/src/rib_v2.cc
+++ b/librina/src/rib_v2.cc
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <map>
@@ -378,6 +379,7 @@ protected:
 	void read_request(const cdap_rib::con_handle_t &con,
 			  const cdap_rib::obj_info_t &obj,
 			  const cdap_rib::filt_info_t &filt,
+			  const cdap_rib::flags_t &flags,
 			  const int invoke_id);
 	void cancel_read_request(const cdap_rib::con_handle_t &con,
 			const cdap_rib::obj_info_t &obj,
@@ -424,10 +426,25 @@ private:
 	//Number of objects that delegate
 	unsigned int num_of_deleg;
 
+        //CDAP Provider
+        cdap::CDAPProviderInterface *cdap_provider;
+
+        //rwlock
+        ReadWriteLockable rwlock;
+
+        //Cache rwlock
+        ReadWriteLockable cache_rwlock;
+
+
+        //RIB handle (id)
+        const rib_handle_t handle;
+
+
 	void get_objects_to_operate(const int64_t object_id,
 				    int scope,
 				    char* filter,
-				    std::list<RIBObj*>& objects);
+				    std::list<std::pair<int, RIBObj*> >
+	                            &objects);
 
 	//@internal only; must be called with the rwlock acquired
 	RIBObj* get_obj(int64_t inst_id);
@@ -451,19 +468,7 @@ private:
 	//must be called with the wlock acquired
 	int64_t get_new_inst_id(void);
 
-	//CDAP Provider
-	cdap::CDAPProviderInterface *cdap_provider;
-
-	//rwlock
-	ReadWriteLockable rwlock;
-
-	//Cache rwlock
-	ReadWriteLockable cache_rwlock;
-
-
-	//RIB handle (id)
-	const rib_handle_t handle;
-
+	int compareString(std::string a, std::string b);
 	//RIBDaemon to access operations callbacks
 	friend class RIBDaemon;
 };
@@ -677,15 +682,24 @@ void RIB::delete_request(const cdap_rib::con_handle_t &con,
 	}
 }
 
+int RIB::compareString(std::string a, std::string b)
+{
+        int r = a.compare(b);
+        if (r < 0)
+                return -1;
+        if (r > 0)
+                return 1;
+        return 0;
+}
+
 void RIB::read_request(const cdap_rib::con_handle_t &con,
 		       const cdap_rib::obj_info_t &obj,
 		       const cdap_rib::filt_info_t &filt,
+		       const cdap_rib::flags_t &flags,
 		       const int invoke_id)
 {
-	// FIXME add res and flags
-	cdap_rib::flags_t flags;
-	flags.flags_ = cdap_rib::flags_t::NONE_FLAGS;
-
+	cdap_rib::flags flags_r;
+	flags_r.flags_= cdap_rib::flags_t::NONE_FLAGS;
 	//Reply object set to empty
 	cdap_rib::obj_info_t obj_reply;
 	obj_reply.name_ = obj.name_;
@@ -695,24 +709,16 @@ void RIB::read_request(const cdap_rib::con_handle_t &con,
 	obj_reply.value_.message_ = NULL;
 
 	cdap_rib::res_info_t res;
-	std::list<RIBObj*> objects;
+	std::list<std::pair <int, RIBObj*> > objects;
         RIBObj* rib_obj = NULL;
 
 	/* RAII scope for RIB scoped lock (read) */
 	{
 		//Mutual exclusion
 		ReadScopedLock rlock(rwlock);
-
 		int64_t id = get_obj_inst_id(obj.name_);
 		// Check if we have to delegate the call
 		rib_obj = get_obj(id);
-		if(id >0 && rib_obj->delegates &&
-		   obj.name_.compare(rib_obj->fqn) != 0)
-		{
-		        DelegationObj *del_obj = (DelegationObj*)rib_obj;
-		        del_obj->forward_object(con, obj, flags, filt, invoke_id);
-		        return;
-		}
 
 		//Get all objects affected by the operation
 		get_objects_to_operate(id,
@@ -728,7 +734,7 @@ void RIB::read_request(const cdap_rib::con_handle_t &con,
 			try {
 				cdap_provider->send_read_result(con,
 								obj_reply,
-								flags,
+								flags_r,
 								res,
 								invoke_id);
 			} catch (Exception &e) {
@@ -740,42 +746,99 @@ void RIB::read_request(const cdap_rib::con_handle_t &con,
 		return;
 	}
 
-	std::list<RIBObj*>::iterator it;
+	std::list<std::pair<int, RIBObj*> >::iterator it;
+	std::list<DelegationObj*> delegated_objs;
 	unsigned int count = 0;
 	for (it = objects.begin(); it != objects.end(); ++it) {
-		rib_obj = *it;
-		count++;
+			rib_obj = it->second;
+			count++;
+			LOG_DBG("Processing read over object %s", rib_obj->fqn.c_str());
+			//Mutual exclusion
+			ReadScopedLock rlock(rib_obj->rwlock, false);
 
-		//Mutual exclusion
-		ReadScopedLock rlock(rib_obj->rwlock, false);
+			rib_obj->read(con, obj.name_, obj.class_, filt, invoke_id,
+					obj_reply, res);
 
-		rib_obj->read(con,
-			      obj.name_,
-			      obj.class_,
-			      filt,
-			      invoke_id,
-			      obj_reply,
-			      res);
+			if (res.code_ == cdap_rib::CDAP_PENDING ||
+							invoke_id == 0)
+					continue;
 
-		if (res.code_ == cdap_rib::CDAP_PENDING ||
-				invoke_id == 0)
-			continue;
+		// If the object is delegated
+        int delegate = false;
+		if(rib_obj->delegates)
+		{
+		        int rem_scope = filt.scope_ - it->first;
+		        delegate = true;
+		        std::string delegated_name;
+		        //check if the request is for the delegated object or
+		        //for its childs
+		        switch(compareString(obj.name_,rib_obj->fqn))
+		        {
+		                // original name is equal to rib_obj name
+		                case 0:
+		                // original name is shorter to rib_obj name
+		                case -1: if (rem_scope == 0)
+                                        delegate = false;
+                                else
+                                        delegated_name = rib_obj->fqn + "/";
+                                break;
+		                        break;
+		                // original name is longer to rib_obj name
+		                case 1: delegated_name = obj.name_;
+		                        break;
 
-		try {
-			if (count == objects.size())
-				flags.flags_ = cdap_rib::flags_t::NONE_FLAGS;
-			else
-				flags.flags_ = cdap_rib::flags_t::F_RD_INCOMPLETE;
-			obj_reply.class_ = rib_obj->class_name;
-			obj_reply.name_ = rib_obj->fqn;
-			cdap_provider->send_read_result(con,
-							obj_reply,
-							flags,
-							res,
+		        }
+		        if (delegate)
+		        {
+		                rina::cdap_rib::filt_info_t deleg_filt;
+		                deleg_filt.scope_ = rem_scope;
+		                deleg_filt.filter_ = filt.filter_;
+						DelegationObj *del_obj =
+										(DelegationObj*)rib_obj;
+						del_obj->forward_object(con, delegated_name,
+								rib_obj->class_name, flags, deleg_filt,
+								invoke_id);
+		        }
+		}
+        if(!delegate)
+        {
+				if (count == objects.size())
+				{
+						for(std::list<DelegationObj*>::iterator it =
+								delegated_objs.begin();
+								it!= delegated_objs.end(); ++it)
+						{
+								while((*it)->is_processing_delegation())
+								{
+									usleep(1000);
+								}
+						}
+						flags_r.flags_ = cdap_rib::flags_t::NONE_FLAGS;
+				}
+				else
+						flags_r.flags_ = cdap_rib::flags_t::F_RD_INCOMPLETE;
+				obj_reply.class_ = rib_obj->class_name;
+				obj_reply.name_ = rib_obj->fqn;
+				try {
+						LOG_DBG("Sending read result for object %s with "
+								"flags %d",	obj_reply.name_.c_str(),
+								flags_r.flags_);
+						cdap_provider->send_read_result(con, obj_reply,
+								flags_r, res, invoke_id);
+				} catch (Exception &e) {
+					LOG_ERR("Unable to send response for invoke id %d",
 							invoke_id);
-		} catch (Exception &e) {
-			LOG_ERR("Unable to send response for invoke id %d",
-					invoke_id);
+				}
+		}
+		else
+		{
+				// Control the last message to be sent to the manager
+				if (count == objects.size())
+				{
+						((DelegationObj*) rib_obj)->set_last(true);
+				}
+				else
+						delegated_objs.push_back((DelegationObj*) rib_obj);
 		}
 	}
 }
@@ -1018,10 +1081,11 @@ void RIB::stop_request(const cdap_rib::con_handle_t &con,
 void RIB::get_objects_to_operate(const int64_t object_id,
 			         int scope,
 			         char * filter,
-			         std::list<RIBObj*>& objects)
+			         std::list<std::pair<int, RIBObj*> >
+			         &objects)
 {
 	std::list<int64_t> *child_list = NULL;
-	RIBObj * rib_obj = NULL;
+	RIBObj *rib_obj = NULL;
 
 	rib_obj = get_obj(object_id);
 	if (!rib_obj)
@@ -1031,7 +1095,8 @@ void RIB::get_objects_to_operate(const int64_t object_id,
 	//Acquire the read lock over the object (make sure it is not
 	//deleted while we process the operation)
 	rib_obj->rwlock.readlock();
-	objects.push_back(rib_obj);
+	std::pair<int, RIBObj*> pair (scope, rib_obj);
+	objects.push_back(pair);
 
 	if (scope == 0)
 		return;
@@ -1683,6 +1748,7 @@ protected:
 	void read_request(const cdap_rib::con_handle_t &con,
 			  const cdap_rib::obj_info_t &obj,
 			  const cdap_rib::filt_info_t &filt,
+			  const cdap_rib::flags_t &flags,
 			  const int invoke_id);
 	void cancel_read_request(const cdap_rib::con_handle_t &con,
 				 const cdap_rib::obj_info_t &obj,
@@ -2686,6 +2752,7 @@ void RIBDaemon::delete_request(const cdap_rib::con_handle_t &con,
 void RIBDaemon::read_request(const cdap_rib::con_handle_t &con,
 			     const cdap_rib::obj_info_t &obj,
 			     const cdap_rib::filt_info_t &filt,
+			     const cdap_rib::flags_t &flags,
 			     const int invoke_id)
 {
 	//TODO this is not safe if RIB instances can be deleted
@@ -2708,7 +2775,7 @@ void RIBDaemon::read_request(const cdap_rib::con_handle_t &con,
 	}
 
 	//Invoke
-	rib->read_request(con, obj, filt, invoke_id);
+	rib->read_request(con, obj, filt, flags, invoke_id);
 }
 void RIBDaemon::cancel_read_request(const cdap_rib::con_handle_t &con,
 				    const cdap_rib::obj_info_t &obj,
@@ -2909,10 +2976,53 @@ void RIBObj::stop(const cdap_rib::con_handle_t &con,
 }
 
 void RIBObj::operation_not_supported(cdap_rib::res_info_t& res) {
+	LOG_INFO("Operation over a RIB object not supported");
 	res.code_ = cdap_rib::CDAP_OP_NOT_SUPPORTED;
 }
 
+// DelegationObj
 
+DelegationObj::DelegationObj(const std::string &class_name):
+		RIBObj(class_name) {
+	delegates = true;
+	processing_delegation = false;
+	last = false;
+}
+
+DelegationObj::~DelegationObj(void)
+{}
+
+void DelegationObj::forwarded_object_response(int port, int invoke_id,
+		rina::cdap::cdap_m_t *msg)
+{
+		rina::cdap_rib::con_handle_t con;
+		con.port_id = port;
+		msg->invoke_id_ = invoke_id;
+		if (msg->flags_ != rina::cdap_rib::flags_t::F_RD_INCOMPLETE &&
+				!last)
+		{
+			msg->flags_ = rina::cdap_rib::flags_t::F_RD_INCOMPLETE;
+			set_processing_delegation(false);
+		}
+		rina::cdap::getProvider()->send_cdap_result(con,  msg);
+}
+
+bool DelegationObj::is_processing_delegation()
+{
+    rina::ScopedLock scop(lock);
+    return processing_delegation;
+}
+
+void DelegationObj::set_processing_delegation(bool state)
+{
+    rina::ScopedLock scop(lock);
+    processing_delegation = state;
+}
+
+void DelegationObj::set_last(bool state)
+{
+    last = state;
+}
 //Single RIBDaemon instance
 static RIBDaemon* ribd = NULL;
 

--- a/librina/test/test-rib_v2.cc
+++ b/librina/test/test-rib_v2.cc
@@ -357,10 +357,11 @@ public:
 	virtual ~MyDelegationObj(){};
 
         void forward_object(const rina::cdap_rib::con_handle_t& con,
-                                    const rina::cdap_rib::obj_info_t &obj,
-                                    const rina::cdap_rib::flags_t &flags,
-                                    const rina::cdap_rib::filt_info_t &filt,
-                                    int invoke_id) {};
+                            const std::string obj_name,
+                            const std::string obj_class,
+                            const rina::cdap_rib::flags_t &flags,
+                            const rina::cdap_rib::filt_info_t &filt,
+                            int invoke_id) {};
         void forwarded_object_response(rina::cdap::cdap_m_t *msg){};
 
 	const std::string& get_class() const{

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -985,7 +985,7 @@ void FlowEncoder::encode(const configs::Flow &obj, rina::ser_obj_t& serobj)
         gpb.set_allocated_dtpconfig(
                         cube_helpers::get_dtpConfig_t(
                                         obj.getActiveConnection()->getDTPConfig()));
-        //optional dtpConfig_t dtpConfig
+        //optional dtcpConfig_t dtpConfig
         gpb.set_allocated_dtcpconfig(
                         cube_helpers::get_dtcpConfig_t(
                                         obj.getActiveConnection()->getDTCPConfig()));

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -932,13 +932,10 @@ int IPCMConsole::read_ipcp_ribobj(std::vector<std::string>& args)
 	// CAREFUL, DELEGATION OBJECT SET TO NULL, this function is only
 	// for testing, return result is not being processed.
 	if (IPCManager->delegate_ipcp_ribobj(NULL,
-					 &promise,
-					 ipcp_id,
-					 args[2],
-					 args[3],
-					 scope) == IPCM_FAILURE ||
-					 promise.wait() != IPCM_SUCCESS) {
-		outstream << "Error occured while forwarding CDAP message to IPCP" << endl;
+			ipcp_id, args[2], args[3], scope, 1, 0)
+			== IPCM_FAILURE || promise.wait() != IPCM_SUCCESS) {
+		outstream << "Error occured while forwarding CDAP message to IPCP"
+				<< endl;
 	} else {
 		outstream << "Successfully sent M_READ request "
 			  << "with object class = " << args[2]

--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
@@ -61,38 +61,32 @@ bool IPCPObj::delete_(const rina::cdap_rib::con_handle_t &con,
 }
 
 void IPCPObj::forward_object(const rina::cdap_rib::con_handle_t& con,
-                const rina::cdap_rib::obj_info_t &obj,
-                const rina::cdap_rib::flags_t &flags,
-                const rina::cdap_rib::filt_info_t &filt,
-                const int invoke_id)
+                        const std::string obj_name,
+                        const std::string obj_class,
+                        const rina::cdap_rib::flags_t &flags,
+                        const rina::cdap_rib::filt_info_t &filt,
+                        const int invoke_id)
 {
-       Promise promise;
-       params.con =  con;
-       params.flags = flags;
-       params.obj = obj;
-       params.invoke_id = invoke_id;
+       // TODO: This has to be stored in a list in case of more than
+       // one consecutive request
 
-       int pos = obj.name_.rfind("ipcProcessID");
-       std::string object_name = obj.name_.substr(pos);
-       pos = object_name.find("/");
-       object_name = object_name.substr(pos);
-
-       IPCManager->delegate_ipcp_ribobj(this, &promise, processID_ , obj.class_, object_name, filt.scope_);
-}
-
-void IPCPObj::forwarded_object_response(rina::cdap::cdap_m_t *msg)
-{
-        /*
-        void remote_read_result(const cdap_rib::con_handle_t& con,
-                               const cdap_rib::obj_info_t &obj,
-                               const cdap_rib::flags_t &flags,
-                               const cdap_rib::res_info_t &res,
-                               int invoke_id);
-        */
-
-		msg->flags_ = params.flags.flags_;
-		msg->invoke_id_ = params.invoke_id;
-		rina::cdap::getProvider()->send_cdap_result(params.con,  msg);
+       int pos = obj_name.rfind("ipcProcessID");
+       if (pos != std::string::npos)
+       {
+                std::string object_sub_name = obj_name.substr(pos);
+                pos = object_sub_name.find("/");
+                if (pos != std::string::npos)
+                {
+                   object_sub_name = object_sub_name.substr(pos);
+                   ipcm_res_t res = IPCManager->delegate_ipcp_ribobj(this,
+                		   processID_, obj_class, object_sub_name, filt.scope_,
+                           invoke_id, con.port_id);
+                   if (res != IPCM_FAILURE)
+                	   set_processing_delegation(true);
+                }
+       }
+       else
+    	   LOG_ERR("This object is not an IPC process");
 }
 
 void IPCPObj::create_cb(const rina::rib::rib_handle_t rib,
@@ -116,7 +110,8 @@ void IPCPObj::create_cb(const rina::rib::rib_handle_t rib,
 
         if (class_ != IPCPObj::class_name)
         {
-                LOG_ERR("Create operation failed: received an invalid class name '%s' during create operation in '%s'",
+                LOG_ERR("Create operation failed: received an invalid class "
+                		"name '%s' during create operation in '%s'",
                         class_.c_str(), fqn.c_str());
                 res.code_ = rina::cdap_rib::CDAP_INVALID_OBJ_CLASS;
                 return;

--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.h
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.h
@@ -54,12 +54,12 @@ public:
 				rina::cdap_rib::res_info_t& res);
 
 	void forward_object(const rina::cdap_rib::con_handle_t& con,
-	                    const rina::cdap_rib::obj_info_t &obj,
-	                    const rina::cdap_rib::flags_t &flags,
-	                    const rina::cdap_rib::filt_info_t &filt,
-	                    int invoke_id);
+    			const std::string obj_name,
+				const std::string obj_class,
+				const rina::cdap_rib::flags_t &flags,
+				const rina::cdap_rib::filt_info_t &filt,
+				const int invoke_id);
 
-	void forwarded_object_response(rina::cdap::cdap_m_t *msg);
 	//Create callback
 	static void create_cb(const rina::rib::rib_handle_t rib,
 			const rina::cdap_rib::con_handle_t &con,
@@ -88,7 +88,6 @@ protected:
                 rina::cdap_rib::flags_t flags;
                 int invoke_id;
 	};
-	Params params;
 };
 
 }; //namespace rib_v1

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -87,9 +87,7 @@ IPCManager_::IPCManager_()
           io_thread(NULL),
           dif_template_manager(NULL),
           dif_allocator(NULL)
-{
-        forwarded_calls_lock = new rina::Lockable();
-}
+{}
 
 IPCManager_::~IPCManager_()
 {
@@ -103,7 +101,6 @@ IPCManager_::~IPCManager_()
         delete dif_allocator;
     }
     forwarded_calls.clear();
-    delete forwarded_calls_lock;
 
     for (std::map<int, TransactionState*>::iterator
     		it = pend_transactions.begin(); it != pend_transactions.end(); ++it)
@@ -1265,17 +1262,21 @@ ipcm_res_t IPCManager_::set_policy_set_param(Addon* callee, Promise* promise,
     return IPCM_PENDING;
 }
 
-int IPCManager_::reserve_invoke_id(rina::rib::DelegationObj* obj)
+int IPCManager_::store_delegated_obj(int port, int invoke_id,
+		rina::rib::DelegationObj* obj)
 {
-       int invoke_id = 0;
-       rina::ScopedLock(*forwarded_calls_lock);
+       rina::ScopedLock scope(forwarded_calls_lock);
+       int key = 0;
        do
        {
-               invoke_id++;
-       }while(forwarded_calls.find(invoke_id) != forwarded_calls.end());
-       forwarded_calls[invoke_id] = obj;
-
-       return invoke_id;
+               key++;
+       }while(forwarded_calls.find(key) != forwarded_calls.end());
+       delegated_stored_t *del_sto = new delegated_stored_t;
+       del_sto->obj = obj;
+       del_sto->invoke_id = invoke_id;
+       del_sto->port = port;
+       forwarded_calls[key] = del_sto;
+       return key;
 }
 
 
@@ -1555,11 +1556,10 @@ ipcm_res_t IPCManager_::update_catalog(Addon* callee)
 }
 
 ipcm_res_t IPCManager_::delegate_ipcp_ribobj(rina::rib::DelegationObj* obj,
-                                         Promise* promise,
                                          const unsigned short ipcp_id,
                                          const std::string& object_class,
                                          const std::string& object_name,
-                                         int scope)
+                                         int scope, int invoke_id, int port)
 {
     IPCMIPCProcess * ipcp;
    // TransactionState* trans;
@@ -1586,26 +1586,11 @@ ipcm_res_t IPCManager_::delegate_ipcp_ribobj(rina::rib::DelegationObj* obj,
         msg.op_code_ = rina::cdap::cdap_m_t::M_READ;
         msg.obj_class_ = object_class;
         msg.obj_name_ = object_name;
-        msg.invoke_id_ = reserve_invoke_id(obj);
         msg.scope_ = scope;
-/*
-        trans = new TransactionState(NULL, promise);
-        if (!trans)
-        {
-            ss
-                    << "Unable to allocate memory for the transaction object. Out of memory! ";
-            FLUSH_LOG(ERR, ss);
-            throw rina::Exception();
-        }
 
-        //Store transaction
-        if (add_transaction_state(trans) < 0)
-        {
-            ss << "Unable to add transaction; out of memory? ";
-            FLUSH_LOG(ERR, ss);
-            throw rina::Exception();
-        }
-*/
+        // Generate a unique id to recover the delegated object
+        msg.invoke_id_ = store_delegated_obj(port, invoke_id, obj);
+
         ipcp->forwardCDAPMessage(msg, 0);
 
         ss << "Forwarded CDAPMessage to IPC process "
@@ -1902,18 +1887,22 @@ void IPCManager_::run()
     google::protobuf::ShutdownProtobufLibrary();
 }
 
-rina::rib::DelegationObj* IPCManager_::get_forwarded_object(int invoke_id)
+delegated_stored_t* IPCManager_::get_forwarded_object(int invoke_id,
+                                                            bool remove)
 {
-        rina::ScopedLock(*forwarded_calls_lock);
-        rina::rib::DelegationObj* obj;
-        std::map<int, rina::rib::DelegationObj*>::iterator it =
+        rina::ScopedLock scope(forwarded_calls_lock);
+        delegated_stored_t* obj;
+        std::map<int, delegated_stored_t*>::iterator it =
                         forwarded_calls.find(invoke_id);
         if (it == forwarded_calls.end())
                 return NULL;
         else
         {
                 obj = it->second;
-                forwarded_calls.erase(it);
+                if (remove)
+                {
+                        forwarded_calls.erase(it);
+                }
                 return obj;
         }
 }

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -247,6 +247,13 @@ public:
 // @brief The IPCManager class is in charge of managing the IPC processes
 // life-cycle.
 //
+
+typedef struct DelegatedStored{
+	int invoke_id;
+	int port;
+	rina::rib::DelegationObj* obj;
+}delegated_stored_t;
+
 class IPCManager_ {
 
 public:
@@ -496,11 +503,10 @@ public:
         // @ret IPCM_PENDING if the NL message could be sent to the IPCP,
         // IPCM_FAILURE otherwise
 	ipcm_res_t delegate_ipcp_ribobj(rina::rib::DelegationObj* obj,
-				    Promise* promise,
 			      	    const unsigned short ipcp_id,
 			      	    const std::string& object_class,
 			      	    const std::string& object_name,
-			      	    int scope);
+			      	    int scope, int invoke_id, int port);
 
 	//
 	// Update policy-set catalog, with the plugins stored in
@@ -545,11 +551,12 @@ public:
 		req_to_stop = true;
 	}
 
-	/// returns the forwarded object sent with invoke_id and
-	/// removes it from the map
-	/// @param invoke_id
-	/// @return rina::rib::DelegationObj*
-        rina::rib::DelegationObj* get_forwarded_object(int invoke_id);
+		/// returns the forwarded object sent with invoke_id and
+		/// removes it from the map
+		/// @param invoke_id
+		/// @return rina::rib::DelegationObj*
+		delegated_stored_t* get_forwarded_object(int invoke_id,
+												 bool remove);
 
         //Generator of opaque identifiers
         rina::ConsecutiveUnsignedIntegerGenerator __tid_gen;
@@ -866,11 +873,12 @@ private:
 			const unsigned short ipcp_id, IPCMIPCProcess*& ipcp);
 	void assign_to_dif(Addon* callee, Promise *promise,
 			rina::DIFInformation dif_info, IPCMIPCProcess* ipcp);
-	// Obtain and reserva an invoke_id
-	int reserve_invoke_id(rina::rib::DelegationObj* obj);
+	// Store a delegated object waiting for the response
+	int store_delegated_obj(int port, int invoke_id,
+			rina::rib::DelegationObj* obj);
 
-	rina::Lockable* forwarded_calls_lock;
-	std::map<int, rina::rib::DelegationObj*> forwarded_calls;
+	rina::Lockable forwarded_calls_lock;
+	std::map<int, delegated_stored_t*> forwarded_calls;
 };
 
 

--- a/rinad/src/ipcp/rib-daemon.cc
+++ b/rinad/src/ipcp/rib-daemon.cc
@@ -334,6 +334,7 @@ void IPCPCDAPIOHandler::invoke_callback(const rina::cdap_rib::con_handle_t& con_
 			callback_->read_request(con_handle,
 						obj,
 						filt,
+						flags,
 						invoke_id);
 			break;
 		case rina::cdap::cdap_m_t::M_CANCELREAD:


### PR DESCRIPTION
Flags where not being encoded as expected. Delegation objects are now
being sent to the manager controling the invoke_id used as response and
also the port of the conexion (which was not being stored, and hence,
not allowing multiple managers).
Fixes #932 
Ack @vmaffione @edugrasa 