### PR TITLE
plugins: lfa: align pft_find method to the null qos-id convention

### DIFF
--- a/plugins/lfa/ps.c
+++ b/plugins/lfa/ps.c
@@ -209,10 +209,12 @@ static struct pft_entry *pft_find(struct pff_ps_priv *priv,
 	ASSERT(priv_is_ok(priv));
 	ASSERT(is_address_ok(destination));
 
-	list_for_each_entry(pos, &priv->entries, next)
+	list_for_each_entry(pos, &priv->entries, next) {
 		if ((pos->destination == destination) &&
-			(pos->qos_id == qos_id))
+			(pos->qos_id == 0 || pos->qos_id == qos_id)) {
 			return pos;
+		}
+	}
 
 	return NULL;
 }


### PR DESCRIPTION
When the qos-id in a PFF entry is 0, it means it can serve requests
with any QoS ids. This patch implements this behaviour for the LFA
plugin, similarly to what is done for the PFF default plugin.
Without this patch, the LFA next-hop policy does not work correctly.