### PR TITLE
SHIM delegated did not release the lock

### DIFF
--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1574,13 +1574,13 @@ ipcm_res_t IPCManager_::delegate_ipcp_ribobj(rina::rib::DelegationObj* obj,
             LOG_ERR("Invalid IPCP id %hu", ipcp_id);
             return IPCM_FAILURE;
         }
+        //Auto release the read lock
+        rina::ReadScopedLock readlock(ipcp->rwlock, false);
         if (ipcp->get_type() != rina::NORMAL_IPC_PROCESS)
         {
         	LOG_ERR("Trying to delegate to a shim IPCP, operation not allowed");
         	return IPCM_FAILURE;
         }
-        //Auto release the read lock
-        rina::ReadScopedLock readlock(ipcp->rwlock, false);
 
         rina::cdap::CDAPMessage msg;
         msg.op_code_ = rina::cdap::cdap_m_t::M_READ;


### PR DESCRIPTION
After a read that target a SHIM, the SHIM was returning an
IPCM_ERROR (it doesn't implement the read) but was not releasing
the lock, which produced a deadlock when trying to registrate
an ipcp to the mentioned SHIM
Fixes #945 
ack @edugrasa 