### PR TITLE
fix in ipc-api.

### DIFF
--- a/librina/src/ipc-api.cc
+++ b/librina/src/ipc-api.cc
@@ -762,7 +762,7 @@ int IPCManager::readSDU(int portId, void * sdu, int maxBytes)
 		throw ReadSDUException();
 		break;
 	case -EAGAIN:
-		return 0;
+		break;
 	default:
 		throw IPCException("Unknown error");
 	}

--- a/librina/wrap/c/src/librina-c.cc
+++ b/librina/wrap/c/src/librina-c.cc
@@ -33,7 +33,7 @@ extern "C"
 
 // TODO: Add global lock
 struct flow {
-       int              port_id;
+        int              port_id;
         FlowRequestEvent fre;
         unsigned int     seq_num;
 };


### PR DESCRIPTION
Returning 0 when there is no packet makes the C API think there is a packet with 0 length. When reading in a non-blocking way to loop over port_id's in a select() kind of way, makes the application think there is always a 0-length packet on that port_id.

This should fix ioq3 to work with multiple clients.