### PR TITLE
mad: Produce IPCProcess ID

### DIFF
--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
@@ -175,8 +175,7 @@ void IPCPObj::create_cb(const rina::rib::rib_handle_t rib,
         try
         {
         	std::stringstream ss;
-        	std::string partial_name = fqn.substr(0, fqn.find_last_of("="));
-        	ss << partial_name << ipcp_id;
+        	ss << fqn << "=" << ipcp_id;
                 RIBFactory::getProxy()->addObjRIB(rib, ss.str(), &ipcp);
         } catch (...)
         {


### PR DESCRIPTION
The id of the ipcprocess was being sent by the manager, which is a
wrong behaviour. This characteristic produced also some problems
when erasing the created IPCP etc... Now the original message is a
CREATE(".../IPCProcessID") instead of CREATE(".../IPCProcessID=x").
Now the MAD is able to remove the rib objects when IPCProces dies.

Fixes #952

ack @edugrasa 