### PR TITLE
rina-tools: allow servers to register to multiple DIFs

### DIFF
--- a/rina-tools/src/common/Makefile.am
+++ b/rina-tools/src/common/Makefile.am
@@ -17,4 +17,5 @@ librinaapp_la_LIBADD   =				\
 
 librinaapp_la_SOURCES  =					\
 	application.cc         application.h			\
-	server.cc	       server.h
+	server.cc	       server.h				\
+	utils.cc	       utils.h				

--- a/rina-tools/src/common/server.cc
+++ b/rina-tools/src/common/server.cc
@@ -105,10 +105,10 @@ int ServerWorkerCleaner::run()
 	return 0;
 }
 
-Server::Server(const string& dif_name,
+Server::Server(const std::list<std::string>& dif_names,
                const string& app_name,
                const string& app_instance) :
-        Application(dif_name, app_name, app_instance)
+        Application(dif_names, app_name, app_instance)
 {
 	ThreadAttributes threadAttrs;
 	threadAttrs.setJoinable();

--- a/rina-tools/src/common/server.h
+++ b/rina-tools/src/common/server.h
@@ -75,7 +75,7 @@ private:
 class Server: public Application
 {
 public:
-        Server(const std::string& dif_name,
+        Server(const std::list<std::string>& dif_names,
                const std::string& app_name,
                const std::string& app_instance);
         virtual ~Server();

--- a/rina-tools/src/common/utils.cc
+++ b/rina-tools/src/common/utils.cc
@@ -1,7 +1,7 @@
 /*
- * Echo Application
+ * Common utilities for all tools
  *
- * Addy Bombeke <addy.bombeke@ugent.be>
+ * Eduard Grasa <eduard.grasa@i2cat.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,29 +25,25 @@
  * SUCH DAMAGE.
  */
 
-#ifndef APPLICATION_HPP
-#define APPLICATION_HPP
+#define RINA_PREFIX "rina-tools-utils"
+#include <librina/logs.h>
 
-#include <string>
+#include "utils.h"
 
-class Application
+void parse_dif_names(std::list<std::string> & dif_names, const std::string& arg)
 {
-public:
-        Application(const std::list<std::string>& dif_names_,
-                    const std::string & app_name_,
-                    const std::string & app_instance_);
+	int i = 0;
+	int pos = arg.find(';');
+	if (pos == std::string::npos){
+		dif_names.push_back(arg);
+		return;
+	}
 
-        static const uint max_buffer_size;
-
-protected:
-
-        /// @param true if flows directed to this application will
-        /// have a blocking read/write behaviour, false otherwise
-        void applicationRegister();
-
-        std::list<std::string> dif_names;
-        std::string app_name;
-        std::string app_instance;
-
-};
-#endif
+	while (pos != std::string::npos) {
+		dif_names.push_back(arg.substr(i, pos-i));
+		i = ++pos;
+		pos = arg.find(';', pos);
+		if (pos == std::string::npos)
+			dif_names.push_back(arg.substr(i, arg.length()));
+	}
+}

--- a/rina-tools/src/common/utils.cc
+++ b/rina-tools/src/common/utils.cc
@@ -33,7 +33,7 @@
 void parse_dif_names(std::list<std::string> & dif_names, const std::string& arg)
 {
 	int i = 0;
-	int pos = arg.find(';');
+	int pos = arg.find(',');
 	if (pos == std::string::npos){
 		dif_names.push_back(arg);
 		return;
@@ -42,7 +42,7 @@ void parse_dif_names(std::list<std::string> & dif_names, const std::string& arg)
 	while (pos != std::string::npos) {
 		dif_names.push_back(arg.substr(i, pos-i));
 		i = ++pos;
-		pos = arg.find(';', pos);
+		pos = arg.find(',', pos);
 		if (pos == std::string::npos)
 			dif_names.push_back(arg.substr(i, arg.length()));
 	}

--- a/rina-tools/src/common/utils.h
+++ b/rina-tools/src/common/utils.h
@@ -1,7 +1,7 @@
 /*
- * Echo Application
+ * Common utilities for all tools
  *
- * Addy Bombeke <addy.bombeke@ugent.be>
+ * Eduard Grasa <eduard.grasa@i2cat.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,29 +25,12 @@
  * SUCH DAMAGE.
  */
 
-#ifndef APPLICATION_HPP
-#define APPLICATION_HPP
+#ifndef UTILS_HPP
+#define UTILS_HPP
 
 #include <string>
+#include <list>
 
-class Application
-{
-public:
-        Application(const std::list<std::string>& dif_names_,
-                    const std::string & app_name_,
-                    const std::string & app_instance_);
+void parse_dif_names(std::list<std::string> & dif_names, const std::string& arg);
 
-        static const uint max_buffer_size;
-
-protected:
-
-        /// @param true if flows directed to this application will
-        /// have a blocking read/write behaviour, false otherwise
-        void applicationRegister();
-
-        std::list<std::string> dif_names;
-        std::string app_name;
-        std::string app_instance;
-
-};
 #endif

--- a/rina-tools/src/manager/main.cc
+++ b/rina-tools/src/manager/main.cc
@@ -65,7 +65,7 @@ int wrapped_main(int argc, char** argv)
                                                        "string");
                 TCLAP::ValueArg<string> dif_arg("d",
                                 		"difs-to-register-at",
-						"The names of the DIFs to register at, separated by ';' (empty means 'any DIF')",
+						"The names of the DIFs to register at, separated by ',' (empty means 'any DIF')",
                                                 false,
                                                 "",
                                                 "string");

--- a/rina-tools/src/manager/main.cc
+++ b/rina-tools/src/manager/main.cc
@@ -39,15 +39,15 @@
 
 #include "config.h"
 #include "manager.h"
+#include "utils.h"
 
 using namespace std;
-
 
 int wrapped_main(int argc, char** argv)
 {
         string manager_apn;
         string manager_api;
-        string dif_name;
+        list<string> dif_names;
 
         try {
                 TCLAP::CmdLine cmd("manager", ' ', PACKAGE_VERSION);
@@ -64,8 +64,8 @@ int wrapped_main(int argc, char** argv)
                                                        "1",
                                                        "string");
                 TCLAP::ValueArg<string> dif_arg("d",
-                                                "dif-to-register-at",
-                                                "The name of the DIF to register at (empty means 'any DIF')",
+                                		"difs-to-register-at",
+						"The names of the DIFs to register at, separated by ';' (empty means 'any DIF')",
                                                 false,
                                                 "",
                                                 "string");
@@ -75,7 +75,7 @@ int wrapped_main(int argc, char** argv)
 
                 manager_apn = manager_apn_arg.getValue();
                 manager_api = manager_api_arg.getValue();
-                dif_name = dif_arg.getValue();
+                parse_dif_names(dif_names, dif_arg.getValue());
 
         } catch (TCLAP::ArgException &e) {
                 LOG_ERR("Error: %s for arg %d",
@@ -85,7 +85,7 @@ int wrapped_main(int argc, char** argv)
         }
 
         rina::initialize("INFO", "");
-        Manager m(dif_name, manager_apn, manager_api);
+        Manager m(dif_names, manager_apn, manager_api);
         m.run();
 
         return EXIT_SUCCESS;

--- a/rina-tools/src/manager/manager.cc
+++ b/rina-tools/src/manager/manager.cc
@@ -518,9 +518,10 @@ bool ManagerWorker::createIPCP_1(int port_id)
  cdap_prov_->process_message(message, port_id);
  }
  */
-Manager::Manager(const std::string& dif_name, const std::string& apn,
+Manager::Manager(const std::list<std::string>& dif_names,
+		 const std::string& apn,
                  const std::string& api)
-        : Server(dif_name, apn, api)
+        : Server(dif_names, apn, api)
 {
     client_app_reg_ = false;
 }

--- a/rina-tools/src/manager/manager.h
+++ b/rina-tools/src/manager/manager.h
@@ -78,7 +78,7 @@ private:
 
 class Manager : public Server {
  public:
-	Manager(const std::string& dif_name,
+	Manager(const std::list<std::string>& dif_names,
 		const std::string& apn,
 		const std::string& api);
 	~Manager() { };

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-client.cc
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-client.cc
@@ -43,12 +43,11 @@
 using namespace std;
 using namespace rina;
 
-Client::Client(const string& dif_nm, const string& apn, const string& api,
+Client::Client(const std::list<std::string>& dif_nms, const string& apn, const string& api,
                const string& server_apn, const string& server_api, bool q,
                unsigned long count, bool registration, unsigned int w, int g,
                int dw)
-        : Application(dif_nm, apn, api),
-          dif_name(dif_nm),
+        : Application(dif_nms, apn, api),
           server_name(server_apn),
           server_instance(server_api),
           quiet(q),
@@ -93,21 +92,22 @@ void Client::createFlow()
     if (gap >= 0)
         qosspec.maxAllowableGap = gap;
 
-    if (dif_name != string())
+    if (dif_names.front() != string())
     {
-        seqnum = ipcManager->requestFlowAllocationInDIF(
-                ApplicationProcessNamingInformation(app_name, app_instance),
-                ApplicationProcessNamingInformation(server_name,
-                                                    server_instance),
-                ApplicationProcessNamingInformation(dif_name, string()),
-                qosspec);
+        seqnum = ipcManager->requestFlowAllocationInDIF(ApplicationProcessNamingInformation(app_name,
+        										    app_instance),
+        						ApplicationProcessNamingInformation(server_name,
+        										    server_instance),
+						        ApplicationProcessNamingInformation(dif_names.front(),
+						        				    string()),
+						        qosspec);
     } else
     {
-        seqnum = ipcManager->requestFlowAllocation(
-                ApplicationProcessNamingInformation(app_name, app_instance),
-                ApplicationProcessNamingInformation(server_name,
-                                                    server_instance),
-                qosspec);
+        seqnum = ipcManager->requestFlowAllocation(ApplicationProcessNamingInformation(app_name,
+        									       app_instance),
+        					   ApplicationProcessNamingInformation(server_name,
+        							   	   	       server_instance),
+						   qosspec);
     }
 
     for (;;)

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-client.h
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-client.h
@@ -41,7 +41,7 @@ class Client : public Application, public rina::cdap::CDAPCallbackInterface
 {
 	friend class APPcallback;
  public:
-	Client(const std::string& dif_name, const std::string& apn,
+	Client(const std::list<std::string>& dif_names, const std::string& apn,
 	       const std::string& api, const std::string& server_apn,
 	       const std::string& server_api, bool quiet, unsigned long count,
 	       bool registration, unsigned int wait, int g, int dw);
@@ -62,7 +62,6 @@ class Client : public Application, public rina::cdap::CDAPCallbackInterface
 	void destroyFlow();
 
  private:
-	std::string dif_name;
 	std::string server_name;
 	std::string server_instance;
 	bool quiet;

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-server.cc
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-server.cc
@@ -142,11 +142,11 @@ void CDAPEchoWorker::serveEchoFlow(int port_id)
 
 const unsigned int CDAPEchoServer::max_sdu_size_in_bytes = 10000;
 
-CDAPEchoServer::CDAPEchoServer(const string& dif_name,
+CDAPEchoServer::CDAPEchoServer(const list<string>& dif_names,
 			       const string& app_name,
 			       const string& app_instance,
 			       const int dealloc_wait)
-			    : Server(dif_name, app_name, app_instance),
+			    : Server(dif_names, app_name, app_instance),
 			      dw(dealloc_wait)
 {
 }

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-server.h
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-server.h
@@ -79,10 +79,10 @@ private:
 
 class CDAPEchoServer : public Server {
 public:
-	CDAPEchoServer(const std::string& dif_name,
-			const std::string& app_name,
-			const std::string& app_instance,
-			const int dealloc_wait);
+	CDAPEchoServer(const std::list<std::string>& dif_names,
+		       const std::string& app_name,
+		       const std::string& app_instance,
+		       const int dealloc_wait);
 
 protected:
 	ServerWorker * internal_start_worker(rina::FlowInformation flow);

--- a/rina-tools/src/rina-cdap-echo/main.cc
+++ b/rina-tools/src/rina-cdap-echo/main.cc
@@ -40,6 +40,7 @@
 #include "config.h"
 #include "cdap-echo-client.h"
 #include "cdap-echo-server.h"
+#include "utils.h"
 
 using namespace std;
 
@@ -58,7 +59,7 @@ int wrapped_main(int argc, char** argv)
         string server_api;
         string client_apn;
         string client_api;
-        string dif_name;
+        list<string> dif_names;
 
         try {
                 TCLAP::CmdLine cmd("rina-cdap-echo", ' ', PACKAGE_VERSION);
@@ -111,8 +112,8 @@ int wrapped_main(int argc, char** argv)
                                                        "1",
                                                        "string");
                 TCLAP::ValueArg<string> dif_arg("d",
-                                                "dif-to-register-at",
-                                                "The name of the DIF to register at (empty means 'any DIF')",
+                                		"difs-to-register-at",
+						"The names of the DIFs to register at, separated by ';' (empty means 'any DIF')",
                                                 false,
                                                 "",
                                                 "string");
@@ -152,7 +153,7 @@ int wrapped_main(int argc, char** argv)
                 server_api = server_api_arg.getValue();
                 client_apn = client_apn_arg.getValue();
                 client_api = client_api_arg.getValue();
-                dif_name = dif_arg.getValue();
+                parse_dif_names(dif_names, dif_arg.getValue());
                 gap = gap_arg.getValue();
                 dw = dealloc_wait_arg.getValue();
 
@@ -167,11 +168,11 @@ int wrapped_main(int argc, char** argv)
 
         if (listen) {
                 // Server mode
-                CDAPEchoServer s(dif_name, server_apn, server_api, dw);
+                CDAPEchoServer s(dif_names, server_apn, server_api, dw);
                 s.run(false);
         } else {
                 // Client mode
-                Client c(dif_name, client_apn, client_api,
+                Client c(dif_names, client_apn, client_api,
                          server_apn, server_api, quiet, count,
                          registration, wait, gap, dw);
 

--- a/rina-tools/src/rina-cdap-echo/main.cc
+++ b/rina-tools/src/rina-cdap-echo/main.cc
@@ -113,7 +113,7 @@ int wrapped_main(int argc, char** argv)
                                                        "string");
                 TCLAP::ValueArg<string> dif_arg("d",
                                 		"difs-to-register-at",
-						"The names of the DIFs to register at, separated by ';' (empty means 'any DIF')",
+						"The names of the DIFs to register at, separated by ',' (empty means 'any DIF')",
                                                 false,
                                                 "",
                                                 "string");

--- a/rina-tools/src/rina-echo-time/et-client.cc
+++ b/rina-tools/src/rina-echo-time/et-client.cc
@@ -37,7 +37,7 @@
 #include <iomanip>
 #include <errno.h>
 
-#define RINA_PREFIX     "rina-echo-time"
+#define RINA_PREFIX "rina-echo-time"
 #include <librina/ipc-api.h>
 #include <librina/logs.h>
 
@@ -62,12 +62,12 @@ double time_difference_in_ms(timespec start, timespec end) {
 }
 
 Client::Client(const string& t_type,
-               const string& dif_nm, const string& apn, const string& api,
+               const list<string>& dif_nms, const string& apn, const string& api,
                const string& server_apn, const string& server_api,
                bool q, unsigned long count,
                bool registration, unsigned int size,
                int w, int g, int dw, unsigned int lw, int rt) :
-        Application(dif_nm, apn, api), test_type(t_type), dif_name(dif_nm),
+        Application(dif_nms, apn, api), test_type(t_type), dif_name(dif_nms.front()),
         server_name(server_apn), server_instance(server_api),
         quiet(q), echo_times(count),
         client_app_reg(registration), data_size(size), wait(w), gap(g),
@@ -492,22 +492,6 @@ void Client::startCancelFloodFlowTask(int port_id)
 
 Client::~Client()
 {
-        unsigned long sdus_sent;
-
-        lock.lock();
-        sdus_sent = nsdus;
-        lock.unlock();
-
-        double variance = m2/((double)sdus_received -1);
-        double stdev = sqrt(variance);
-
-        unsigned long rt = 0;
-        if (sdus_sent > 0) rt = ((sdus_sent - sdus_received)*100/sdus_sent);
-        cout << "SDUs sent: "<< sdus_sent << "; SDUs received: " << sdus_received;
-        cout << "; " << rt << "% SDU loss" <<endl;
-        cout << "Minimum RTT: " << min_rtt << " ms; Maximum RTT: " << max_rtt
-             << " ms; Average RTT:" << average_rtt
-             << " ms; Standard deviation: " << stdev<<" ms"<<endl;
 }
 
 CFloodCancelFlowTimerTask::CFloodCancelFlowTimerTask(int pid, Client * cl)

--- a/rina-tools/src/rina-echo-time/et-client.h
+++ b/rina-tools/src/rina-echo-time/et-client.h
@@ -72,7 +72,7 @@ private:
 class Client: public Application {
 public:
         Client(const std::string& test_type,
-               const std::string& dif_name,
+               const std::list<std::string>& dif_name,
                const std::string& apn,
                const std::string& api,
                const std::string& server_apn,

--- a/rina-tools/src/rina-echo-time/et-server.cc
+++ b/rina-tools/src/rina-echo-time/et-server.cc
@@ -242,12 +242,12 @@ void EchoTimeServerWorker::printPerfStats(unsigned long pkt,
 }
 
 EchoTimeServer::EchoTimeServer(const string& t_type,
-			       const string& dif_name,
+			       const std::list<std::string>& dif_names,
 			       const string& app_name,
 			       const string& app_instance,
 			       const int perf_interval,
 			       const int dealloc_wait) :
-        		Server(dif_name, app_name, app_instance),
+        		Server(dif_names, app_name, app_instance),
         test_type(t_type), interval(perf_interval), dw(dealloc_wait)
 {
 }

--- a/rina-tools/src/rina-echo-time/et-server.h
+++ b/rina-tools/src/rina-echo-time/et-server.h
@@ -63,7 +63,7 @@ class EchoTimeServer: public Server
 {
 public:
 	EchoTimeServer(const std::string& test_type,
-		       const std::string& dif_name,
+		       const std::list<std::string>& dif_names,
 		       const std::string& app_name,
 		       const std::string& app_instance,
 		       const int perf_interval,

--- a/rina-tools/src/rina-echo-time/main.cc
+++ b/rina-tools/src/rina-echo-time/main.cc
@@ -121,7 +121,7 @@ int wrapped_main(int argc, char** argv)
                                                        "string");
                 TCLAP::ValueArg<string> dif_arg("d",
                                                 "difs-to-register-at",
-                                                "The names of the DIFs to register at, separated by ';' (empty means 'any DIF')",
+                                                "The names of the DIFs to register at, separated by ',' (empty means 'any DIF')",
                                                 false,
                                                 "",
                                                 "string");

--- a/rina-tools/src/rina-echo-time/main.cc
+++ b/rina-tools/src/rina-echo-time/main.cc
@@ -39,9 +39,9 @@
 #include "config.h"
 #include "et-client.h"
 #include "et-server.h"
+#include "utils.h"
 
 using namespace std;
-
 
 int wrapped_main(int argc, char** argv)
 {
@@ -61,7 +61,7 @@ int wrapped_main(int argc, char** argv)
         string server_api;
         string client_apn;
         string client_api;
-        string dif_name;
+        list<string> dif_names;
 
         try {
                 TCLAP::CmdLine cmd("rina-echo-time", ' ', PACKAGE_VERSION);
@@ -120,8 +120,8 @@ int wrapped_main(int argc, char** argv)
                                                        "1",
                                                        "string");
                 TCLAP::ValueArg<string> dif_arg("d",
-                                                "dif-to-register-at",
-                                                "The name of the DIF to register at (empty means 'any DIF')",
+                                                "difs-to-register-at",
+                                                "The names of the DIFs to register at, separated by ';' (empty means 'any DIF')",
                                                 false,
                                                 "",
                                                 "string");
@@ -192,7 +192,7 @@ int wrapped_main(int argc, char** argv)
                 server_api = server_api_arg.getValue();
                 client_apn = client_apn_arg.getValue();
                 client_api = client_api_arg.getValue();
-                dif_name = dif_arg.getValue();
+                parse_dif_names(dif_names, dif_arg.getValue());
                 test_type = test_type_arg.getValue();
                 gap = gap_arg.getValue();
                 perf_interval = perf_interval_arg.getValue();
@@ -216,13 +216,13 @@ int wrapped_main(int argc, char** argv)
 
         if (listen) {
                 // Server mode
-                EchoTimeServer s(test_type, dif_name, server_apn, server_api,
+                EchoTimeServer s(test_type, dif_names, server_apn, server_api,
                                  perf_interval, dw);
 
                 s.run(true);
         } else {
                 // Client mode
-                Client c(test_type, dif_name, client_apn, client_api,
+                Client c(test_type, dif_names, client_apn, client_api,
                          server_apn, server_api, quiet, count,
                          registration, size, wait, gap, dw, lost_wait, rate);
 


### PR DESCRIPTION
Using the "-d" option, it is possible to specify multiple DIF names separated by ";"

    ./rina-echo-time -l -d "normal.DIF;vpn.DIF;test.DIF"

@vmaffione could you give it a go?