### PR TITLE
kernel: dtp: Fix bug in dtp

### DIFF
--- a/linux/net/rina/dtcp-ps-default.c
+++ b/linux/net/rina/dtcp-ps-default.c
@@ -118,8 +118,9 @@ default_sender_ack(struct dtcp_ps * ps, seq_num_t seq_num)
 int
 default_sending_ack(struct dtcp_ps * ps, seq_num_t seq)
 {
-        struct dtp *       dtp;
-        const struct pci * pci;
+        struct dtp * dtp;
+        struct pci * pci;
+        int ret;
 
         struct dtcp * dtcp = ps->dm;
 
@@ -140,7 +141,10 @@ default_sending_ack(struct dtcp_ps * ps, seq_num_t seq)
         if (!pci)
                 return 0;
 
-        return dtcp_sv_update(ps->dm, pci);
+        ret = dtcp_sv_update(ps->dm, pci);
+        pci_destroy(pci);
+
+        return ret;
 }
 
 int

--- a/linux/net/rina/dtp.h
+++ b/linux/net/rina/dtp.h
@@ -69,7 +69,7 @@ struct rtimer * dtp_sender_inactivity_timer(struct dtp * instance);
 
 /* FIXME: temporal addition so that DTCP's sending ack can call this function
  * that was originally static */
-const struct pci * process_A_expiration(struct dtp * dtp, struct dtcp * dtcp);
+struct pci * process_A_expiration(struct dtp * dtp, struct dtcp * dtcp);
 
 int                dtp_select_policy_set(struct dtp * dtp, const string_t *path,
                                          const string_t * name);


### PR DESCRIPTION
The handler of the A-timer expiration event did not take into account
that the PCI being handed in to the DTCP could have been already
deallocated by the EFCP. Now a duplicated PCI is used.

maintainers: @lbergesio 