### PR TITLE
kernel: normal, rmt, efcp, sdup, shims: fixed bug when destroying IPCPs

### DIFF
--- a/linux/net/rina/efcp.c
+++ b/linux/net/rina/efcp.c
@@ -989,6 +989,12 @@ int efcp_enqueue(struct efcp * efcp,
                 return -1;
         }
 
+        if (!efcp->user_ipcp) {
+        	LOG_ERR("Flow is being deallocated, dropping SDU");
+        	sdu_destroy(sdu);
+        	return -1;
+        }
+
         if (efcp->user_ipcp->ops->sdu_enqueue(efcp->user_ipcp->data,
                                               port,
                                               sdu)) {

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -1442,9 +1442,9 @@ static int normal_destroy(struct ipcp_factory_data * data,
 
         robject_del(&instance->robj);
 
-        sdup_destroy(tmp->sdup);
         efcp_container_destroy(tmp->efcpc);
         rmt_destroy(tmp->rmt);
+        sdup_destroy(tmp->sdup);
         mgmt_data_destroy(tmp->mgmt_data);
 
         rkfree(tmp);

--- a/linux/net/rina/ipcps/shim-hv-core.c
+++ b/linux/net/rina/ipcps/shim-hv-core.c
@@ -886,6 +886,11 @@ shim_hv_recv_cb(void *opaque, unsigned int ch, struct vmpi_buf *vb)
         channel = priv->vmpi.channels[ch];
         port_id = channel.port_id;
 
+        if (!channel.user_ipcp){
+        	LOG_ERR("Flow is being deallocated, dropping SDU");
+        	return;
+        }
+
         ASSERT(channel.user_ipcp->ops);
         ASSERT(channel.user_ipcp->ops->sdu_enqueue);
         ret = channel.user_ipcp->ops->sdu_enqueue(channel.user_ipcp->data,

--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -865,6 +865,12 @@ tcp_udp_flow_allocate_response(struct ipcp_instance_data * data,
                         LOG_DBG("Got a new element from the fifo, "
                                 "enqueuing into user-IPCP");
 
+                        if (!flow->user_ipcp) {
+                        	LOG_ERR("Flow is being deallocated, dropping PDU");
+                        	sdu_destroy(tmp);
+                        	return -1;
+                        }
+
                         ASSERT(flow->user_ipcp->ops);
                         ASSERT(flow->user_ipcp->ops->sdu_enqueue);
                         if (flow->user_ipcp->ops->
@@ -1222,7 +1228,12 @@ static int udp_process_msg(struct ipcp_instance_data * data,
                         LOG_DBG("Port is ALLOCATED, "
                                 "queueing frame in user-IPCP");
 
-                        ASSERT(flow->user_ipcp);
+                        if (!flow->user_ipcp) {
+                        	LOG_ERR("Flow is being deallocated, dropping PDU");
+                        	sdu_destroy(du);
+                        	return -1;
+                        }
+
                         ASSERT(flow->user_ipcp->ops);
                         ASSERT(flow->user_ipcp->ops->sdu_enqueue);
 
@@ -1338,7 +1349,12 @@ static int tcp_recv_new_message(struct ipcp_instance_data * data,
                 if (flow->port_id_state == PORT_STATE_ALLOCATED) {
                         spin_unlock_irqrestore(&data->lock, flags);
 
-                        ASSERT(flow->user_ipcp);
+                        if (!flow->user_ipcp) {
+                        	LOG_ERR("Flow is being deallocated, dropping SDU");
+                        	sdu_destroy(du);
+                        	return -1;
+                        }
+
                         ASSERT(flow->user_ipcp->ops);
                         ASSERT(flow->user_ipcp->ops->sdu_enqueue);
 
@@ -1422,7 +1438,12 @@ static int tcp_recv_partial_message(struct ipcp_instance_data * data,
                 if (flow->port_id_state == PORT_STATE_ALLOCATED) {
                         spin_unlock_irqrestore(&data->lock, flags);
 
-                        ASSERT(flow->user_ipcp);
+                        if (!flow->user_ipcp) {
+                        	LOG_ERR("Flow is being deallocated, dropping SDU");
+                        	sdu_destroy(du);
+                        	return -1;
+                        }
+
                         ASSERT(flow->user_ipcp->ops);
                         ASSERT(flow->user_ipcp->ops->sdu_enqueue);
 

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -198,6 +198,7 @@ static struct rmt_n1_port *n1_port_create(port_id_t id,
 	tmp->stats.tx_bytes = 0;
 	tmp->stats.rx_pdus = 0;
 	tmp->stats.rx_bytes = 0;
+	tmp->sdup_port = 0;
 	spin_lock_init(&tmp->lock);
 
 	LOG_DBG("N-1 port %pK created successfully (port-id = %d)", tmp, id);

--- a/linux/net/rina/sdup.c
+++ b/linux/net/rina/sdup.c
@@ -313,7 +313,7 @@ static void sdup_port_destroy(struct sdup_port * instance)
 };
 
 static struct sdup_port * sdup_port_create(port_id_t port_id,
-				    struct dup_config_entry * dup_conf)
+				    	   struct dup_config_entry * dup_conf)
 {
 	struct sdup_port * tmp;
 	const string_t * crypto_ps_name;
@@ -697,6 +697,7 @@ int sdup_destroy_port_config(struct sdup_port * instance)
 	}
 
 	port_id = instance->port_id;
+
 	sdup_port_destroy(instance);
 	LOG_DBG("Destroyed SDUP configuration for port %d",
 		 port_id);


### PR DESCRIPTION
Fixed bug when destroying IPCP that is using 1 or more N-1 flows. Fixes #964 

@miqueltarzan, @vmaffione could you check you agree with modifications? Tests show the bugs are gone (Bug reported in 964 was hiding another related bug that is fixed by this PR)