### PR TITLE
Replace spin_lock_irqsave per spin_lock_bh

### DIFF
--- a/linux/net/rina/dt-utils.c
+++ b/linux/net/rina/dt-utils.c
@@ -105,8 +105,6 @@ int cwq_destroy(struct cwq * queue)
 int cwq_push(struct cwq * queue,
              struct pdu * pdu)
 {
-        unsigned long flags;
-
         if (!queue)
                 return -1;
 
@@ -117,14 +115,14 @@ int cwq_push(struct cwq * queue,
 
         LOG_DBG("Pushing in the Closed Window Queue");
 
-        spin_lock_irqsave(&queue->lock, flags);
+        spin_lock_bh(&queue->lock);
         if (rqueue_tail_push_ni(queue->q, pdu)) {
                 pdu_destroy(pdu);
-                spin_unlock_irqrestore(&queue->lock, flags);
+                spin_unlock_bh(&queue->lock);
                 LOG_ERR("Failed to add PDU");
                 return -1;
         }
-        spin_unlock_irqrestore(&queue->lock, flags);
+        spin_unlock_bh(&queue->lock);
 
         return 0;
 }
@@ -189,14 +187,13 @@ EXPORT_SYMBOL(cwq_flush);
 ssize_t cwq_size(struct cwq * queue)
 {
         ssize_t       tmp;
-        unsigned long flags;
 
         if (!queue)
                 return -1;
 
-        spin_lock_irqsave(&queue->lock, flags);
+        spin_lock_bh(&queue->lock);
         tmp = rqueue_length(queue->q);
-        spin_unlock_irqrestore(&queue->lock, flags);
+        spin_unlock_bh(&queue->lock);
 
         return tmp;
 }
@@ -393,34 +390,33 @@ seq_num_t cwq_peek(struct cwq * queue)
         seq_num_t          ret;
         struct pdu *       pdu;
         const struct pci * pci;
-        unsigned long      flags;
 
         if (!queue)
                 return -1;
 
-        spin_lock_irqsave(&queue->lock, flags);
+        spin_lock_bh(&queue->lock);
         if (rqueue_is_empty(queue->q)){
-                spin_unlock_irqrestore(&queue->lock, flags);
+                spin_unlock_bh(&queue->lock);
                 return 0;
         }
         pdu = (struct pdu *) rqueue_head_pop(queue->q);
         if (!pdu) {
-                spin_unlock_irqrestore(&queue->lock, flags);
+                spin_unlock_bh(&queue->lock);
                 return -1;
         }
         pci = pdu_pci_get_ro(pdu);
         if (!pci) {
-                spin_unlock_irqrestore(&queue->lock, flags);
+                spin_unlock_bh(&queue->lock);
                 pdu_destroy(pdu);
                 return -1;
         }
         ret = pci_sequence_number_get(pci);
         if (rqueue_head_push_ni(queue->q, pdu)) {
-                spin_unlock_irqrestore(&queue->lock, flags);
+                spin_unlock_bh(&queue->lock);
                 pdu_destroy(pdu);
                 return ret;
         }
-        spin_unlock_irqrestore(&queue->lock, flags);
+        spin_unlock_bh(&queue->lock);
 
         return ret;
 }
@@ -849,19 +845,17 @@ static void rtx_timer_func(void * data)
 
 int rtxq_destroy(struct rtxq * q)
 {
-        unsigned long flags;
-
         if (!q)
                 return -1;
 
-        spin_lock_irqsave(&q->lock, flags);
+        spin_lock_bh(&q->lock);
 #if RTIMER_ENABLED
         if (q->r_timer && rtimer_destroy(q->r_timer))
                 LOG_ERR("Problems destroying timer for RTXQ %pK", q->r_timer);
 #endif
         if (q->queue && rtxqueue_destroy(q->queue))
                 LOG_ERR("Problems destroying queue for RTXQ %pK", q->queue);
-        spin_unlock_irqrestore(&q->lock, flags);
+        spin_unlock_bh(&q->lock);
 
         rkfree(q);
 
@@ -942,41 +936,38 @@ struct rtxq * rtxq_create_ni(struct dt *  dt,
 
 int rtxq_size(struct rtxq * q)
 {
-        unsigned long       flags;
 	unsigned int ret;
         if (!q)
                 return -1;
 
-        spin_lock_irqsave(&q->lock, flags);
+        spin_lock_bh(&q->lock);
         ret = q->queue->len;
-        spin_unlock_irqrestore(&q->lock, flags);
+        spin_unlock_bh(&q->lock);
         return ret;
 }
 EXPORT_SYMBOL(rtxq_size);
 
 int rtxq_drop_pdus(struct rtxq * q)
 {
-        unsigned long       flags;
 	int ret;
         if (!q)
                 return -1;
 
-        spin_lock_irqsave(&q->lock, flags);
+        spin_lock_bh(&q->lock);
         ret = q->queue->drop_pdus;
-        spin_unlock_irqrestore(&q->lock, flags);
+        spin_unlock_bh(&q->lock);
         return ret;
 }
 
 struct rtxq_entry * rtxq_entry_peek(struct rtxq * q, seq_num_t sn)
 {
-        unsigned long       flags;
         struct rtxq_entry * entry;
         if (!q)
                 return NULL;
 
-        spin_lock_irqsave(&q->lock, flags);
+        spin_lock_bh(&q->lock);
         entry = rtxqueue_entry_peek(q->queue, sn);
-        spin_unlock_irqrestore(&q->lock, flags);
+        spin_unlock_bh(&q->lock);
         return entry;
 }
 EXPORT_SYMBOL(rtxq_entry_peek);
@@ -1000,18 +991,16 @@ EXPORT_SYMBOL(rtxq_entry_retries);
 int rtxq_push_ni(struct rtxq * q,
                  struct pdu *  pdu)
 {
-        unsigned long flags;
-
         if (!q || !pdu_is_ok(pdu))
                 return -1;
 
-        spin_lock_irqsave(&q->lock, flags);
+        spin_lock_bh(&q->lock);
 #if RTIMER_ENABLED
         /* is the first transmitted PDU */
         rtimer_start(q->r_timer, dt_sv_tr(q->parent));
 #endif
         rtxqueue_push_ni(q->queue, pdu);
-        spin_unlock_irqrestore(&q->lock, flags);
+        spin_unlock_bh(&q->lock);
         return 0;
 }
 
@@ -1035,17 +1024,15 @@ int rtxq_ack(struct rtxq * q,
              seq_num_t     seq_num,
              unsigned int  tr)
 {
-        unsigned long flags;
-
         if (!q)
                 return -1;
 
-        spin_lock_irqsave(&q->lock, flags);
+        spin_lock_bh(&q->lock);
         rtxqueue_entries_ack(q->queue, seq_num);
 #if RTIMER_ENABLED
         rtimer_restart(q->r_timer, tr);
 #endif
-        spin_unlock_irqrestore(&q->lock, flags);
+        spin_unlock_bh(&q->lock);
 
         return 0;
 }

--- a/linux/net/rina/dt.c
+++ b/linux/net/rina/dt.c
@@ -144,8 +144,6 @@ int dt_destroy(struct dt * dt)
 
 int dt_dtp_bind(struct dt * dt, struct dtp * dtp)
 {
-        unsigned long flags;
-
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot bind DTP");
                 return -1;
@@ -155,16 +153,16 @@ int dt_dtp_bind(struct dt * dt, struct dtp * dtp)
                 return -1;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (dt->dtp) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_ERR("A DTP instance is already bound to instance %pK, "
                         "unbind it first", dt);
                 return -1;
         }
         dt->dtp = dtp;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -172,16 +170,15 @@ int dt_dtp_bind(struct dt * dt, struct dtp * dtp)
 struct dtp * dt_dtp_unbind(struct dt * dt)
 {
         struct dtp *  tmp;
-        unsigned long flags;
 
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot unbind DTP");
                 return NULL;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (!dt->dtp) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_DBG("No DTP bound to instance %pK", dt);
                 return NULL;
@@ -189,15 +186,13 @@ struct dtp * dt_dtp_unbind(struct dt * dt)
 
         tmp     = dt->dtp;
         dt->dtp = NULL;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
 
 int dt_dtcp_bind(struct dt * dt, struct dtcp * dtcp)
 {
-        unsigned long flags;
-
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot bind DTCP");
                 return -1;
@@ -207,9 +202,9 @@ int dt_dtcp_bind(struct dt * dt, struct dtcp * dtcp)
                 return -1;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (dt->dtcp) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_ERR("A DTCP instance already bound to instance %pK, "
                         "unbind it first", dt);
@@ -217,7 +212,7 @@ int dt_dtcp_bind(struct dt * dt, struct dtcp * dtcp)
         }
 
         dt->dtcp = dtcp;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -225,16 +220,15 @@ int dt_dtcp_bind(struct dt * dt, struct dtcp * dtcp)
 struct dtcp * dt_dtcp_unbind(struct dt * dt)
 {
         struct dtcp * tmp;
-        unsigned long flags;
 
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot unbind DTCP");
                 return NULL;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (!dt->dtcp) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_DBG("No DTCP bound to instance %pK", dt);
                 return NULL;
@@ -242,15 +236,13 @@ struct dtcp * dt_dtcp_unbind(struct dt * dt)
 
         tmp      = dt->dtcp;
         dt->dtcp = NULL;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
 
 int dt_cwq_bind(struct dt * dt, struct cwq * cwq)
 {
-        unsigned long flags;
-
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot bind CWQ");
                 return -1;
@@ -261,15 +253,15 @@ int dt_cwq_bind(struct dt * dt, struct cwq * cwq)
                 return -1;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (dt->cwq) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_ERR("A CWQ already bound to instance %pK", dt);
                 return -1;
         }
         dt->cwq = cwq;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -277,16 +269,15 @@ int dt_cwq_bind(struct dt * dt, struct cwq * cwq)
 struct cwq * dt_cwq_unbind(struct dt * dt)
 {
         struct cwq *  tmp;
-        unsigned long flags;
 
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot unbind CWQ");
                 return NULL;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (!dt->cwq) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_DBG("No CWQ bound to instance %pK", dt);
                 return NULL;
@@ -294,7 +285,7 @@ struct cwq * dt_cwq_unbind(struct dt * dt)
 
         tmp     = dt->cwq;
         dt->cwq = NULL;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -302,16 +293,15 @@ struct cwq * dt_cwq_unbind(struct dt * dt)
 struct rtxq * dt_rtxq_unbind(struct dt * dt)
 {
         struct rtxq * tmp;
-        unsigned long flags;
 
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot unbind RTXQ");
                 return NULL;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (!dt->rtxq) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_DBG("No RTXQ bound to instance %pK", dt);
                 return NULL;
@@ -319,15 +309,13 @@ struct rtxq * dt_rtxq_unbind(struct dt * dt)
 
         tmp      = dt->rtxq;
         dt->rtxq = NULL;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
 
 int dt_rtxq_bind(struct dt * dt, struct rtxq * rtxq)
 {
-        unsigned long flags;
-
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot bind RTXQ");
                 return -1;
@@ -338,15 +326,15 @@ int dt_rtxq_bind(struct dt * dt, struct rtxq * rtxq)
                 return -1;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (dt->rtxq) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_ERR("A RTXQ already bound to instance %pK", dt);
                 return -1;
         }
         dt->rtxq = rtxq;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -354,31 +342,28 @@ int dt_rtxq_bind(struct dt * dt, struct rtxq * rtxq)
 struct efcp * dt_efcp_unbind(struct dt * dt)
 {
         struct efcp * tmp;
-        unsigned long flags;
 
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot unbind EFCP");
                 return NULL;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (!dt->efcp) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_ERR("No EFCP bound to instance %pK", dt);
                 return NULL;
         }
         tmp = dt->efcp;
         dt->efcp = NULL;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
 
 int dt_efcp_bind(struct dt * dt, struct efcp * efcp)
 {
-        unsigned long flags;
-
         if (!dt) {
                 LOG_ERR("Bogus instance passed, cannot bind EFCP");
                 return -1;
@@ -389,31 +374,29 @@ int dt_efcp_bind(struct dt * dt, struct efcp * efcp)
                 return -1;
         }
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         if (dt->efcp) {
-                spin_unlock_irqrestore(&dt->lock, flags);
+                spin_unlock_bh(&dt->lock);
 
                 LOG_ERR("A EFCP already bound to instance %pK", dt);
                 return -1;
         }
         dt->efcp = efcp;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
 
 struct dtp * dt_dtp(struct dt * dt)
 {
-        unsigned long flags;
-
         struct dtp * tmp;
 
         if (!dt)
                 return NULL;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->dtp;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -422,14 +405,13 @@ EXPORT_SYMBOL(dt_dtp);
 struct dtcp * dt_dtcp(struct dt * dt)
 {
         struct dtcp * tmp;
-        unsigned long flags;
 
         if (!dt)
                 return NULL;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->dtcp;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -438,14 +420,13 @@ EXPORT_SYMBOL(dt_dtcp);
 struct cwq * dt_cwq(struct dt * dt)
 {
         struct cwq *  tmp;
-        unsigned long flags;
 
         if (!dt)
                 return NULL;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->cwq;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -454,14 +435,13 @@ EXPORT_SYMBOL(dt_cwq);
 struct rtxq * dt_rtxq(struct dt * dt)
 {
         struct rtxq * tmp;
-        unsigned long flags;
 
         if (!dt)
                 return NULL;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->rtxq;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -470,14 +450,13 @@ EXPORT_SYMBOL(dt_rtxq);
 struct efcp * dt_efcp(struct dt * dt)
 {
         struct efcp * tmp;
-        unsigned long flags;
 
         if (!dt)
                 return NULL;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->efcp;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -486,14 +465,13 @@ EXPORT_SYMBOL(dt_efcp);
 uint_t dt_sv_max_pdu_size(struct dt * dt)
 {
         uint_t        tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return 0;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->max_flow_pdu_size;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -501,14 +479,13 @@ uint_t dt_sv_max_pdu_size(struct dt * dt)
 uint_t dt_sv_max_sdu_size(struct dt * dt)
 {
         uint_t        tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return 0;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->max_flow_sdu_size;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -516,14 +493,13 @@ uint_t dt_sv_max_sdu_size(struct dt * dt)
 timeout_t dt_sv_mpl(struct dt * dt)
 {
         uint_t        tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return 0;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->MPL;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -532,14 +508,13 @@ EXPORT_SYMBOL(dt_sv_mpl);
 timeout_t dt_sv_r(struct dt * dt)
 {
         uint_t        tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return 0;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->R;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -548,14 +523,13 @@ EXPORT_SYMBOL(dt_sv_r);
 timeout_t dt_sv_a(struct dt * dt)
 {
         uint_t        tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return 0;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->A;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -564,14 +538,13 @@ EXPORT_SYMBOL(dt_sv_a);
 seq_num_t dt_sv_rcv_lft_win(struct dt * dt)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return 0;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->rcv_left_window_edge;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -579,14 +552,12 @@ EXPORT_SYMBOL(dt_sv_rcv_lft_win);
 
 int dt_sv_rcv_lft_win_set(struct dt * dt, seq_num_t rcv_lft_win)
 {
-        unsigned long flags;
-
         if (!dt || !dt->sv)
                 return -1;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         dt->sv->rcv_left_window_edge = rcv_lft_win;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -595,30 +566,27 @@ EXPORT_SYMBOL(dt_sv_rcv_lft_win_set);
 bool dt_sv_window_closed(struct dt * dt)
 {
         bool          tmp;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return false;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->window_closed;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
 
 int dt_sv_window_closed_set(struct dt * dt, bool closed)
 {
-        unsigned long flags;
-
         if (!dt || !dt->sv)
                 return -1;
 
         LOG_DBG("Window set to %u (0=open, 1=closed)", closed);
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         dt->sv->window_closed = closed;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -626,15 +594,14 @@ EXPORT_SYMBOL(dt_sv_window_closed_set);
 
 timeout_t dt_sv_tr(struct dt * dt)
 {
-        unsigned long flags;
         timeout_t     tmp;
 
         ASSERT(dt);
         ASSERT(dt->sv);
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         tmp = dt->sv->tr;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return tmp;
 }
@@ -642,14 +609,13 @@ EXPORT_SYMBOL(dt_sv_tr);
 
 int dt_sv_tr_set(struct dt * dt, timeout_t tr)
 {
-        unsigned long flags;
 
         ASSERT(dt);
         ASSERT(dt->sv);
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         dt->sv->tr = tr;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return 0;
 }
@@ -658,27 +624,25 @@ EXPORT_SYMBOL(dt_sv_tr_set);
 bool dt_sv_drf_flag(struct dt * dt)
 {
         bool          flag;
-        unsigned long flags;
 
         if (!dt || !dt->sv)
                 return false;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         flag = dt->sv->drf_flag;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return flag;
 }
 
 void dt_sv_drf_flag_set(struct dt * dt, bool value)
 {
-        unsigned long flags;
         if (!dt || !dt->sv)
                 return;
 
-        spin_lock_irqsave(&dt->lock, flags);
+        spin_lock_bh(&dt->lock);
         dt->sv->drf_flag = value;
-        spin_unlock_irqrestore(&dt->lock, flags);
+        spin_unlock_bh(&dt->lock);
 
         return;
 }

--- a/linux/net/rina/dtcp.c
+++ b/linux/net/rina/dtcp.c
@@ -199,11 +199,10 @@ EXPORT_SYMBOL(dtcp_pdu_send);
 static uint_t dtcp_pdus_per_time_unit(struct dtcp * dtcp)
 {
 	uint_t ret = 0;
-	unsigned long flags;
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->pdus_per_time_unit;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -211,11 +210,10 @@ static uint_t dtcp_pdus_per_time_unit(struct dtcp * dtcp)
 static uint_t dtcp_time_unit(struct dtcp * dtcp)
 {
 	uint_t ret = 0;
-	unsigned long flags;
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->time_unit;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -223,7 +221,6 @@ static uint_t dtcp_time_unit(struct dtcp * dtcp)
 uint_t dtcp_time_frame(struct dtcp * dtcp)
 {
 	uint_t ret = 0;
-	unsigned long flags;
 
 	if (!dtcp || !dtcp->sv)
 	{
@@ -234,9 +231,9 @@ uint_t dtcp_time_frame(struct dtcp * dtcp)
 		return 0;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->time_unit;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -244,8 +241,6 @@ EXPORT_SYMBOL(dtcp_time_frame);
 
 int dtcp_time_frame_set(struct dtcp * dtcp, uint_t sec)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -255,9 +250,9 @@ int dtcp_time_frame_set(struct dtcp * dtcp, uint_t sec)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->time_unit = sec;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -265,8 +260,6 @@ EXPORT_SYMBOL(dtcp_time_frame_set);
 
 int dtcp_last_time(struct dtcp * dtcp, struct timespec * s)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -276,10 +269,10 @@ int dtcp_last_time(struct dtcp * dtcp, struct timespec * s)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	s->tv_sec = dtcp->sv->last_time.tv_sec;
 	s->tv_nsec = dtcp->sv->last_time.tv_nsec;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -287,8 +280,6 @@ EXPORT_SYMBOL(dtcp_last_time);
 
 int dtcp_last_time_set(struct dtcp * dtcp, struct timespec * s)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -298,10 +289,10 @@ int dtcp_last_time_set(struct dtcp * dtcp, struct timespec * s)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->last_time.tv_sec = s->tv_sec;
 	dtcp->sv->last_time.tv_nsec = s->tv_nsec;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -310,7 +301,6 @@ EXPORT_SYMBOL(dtcp_last_time_set);
 uint_t dtcp_sndr_rate(struct dtcp * dtcp)
 {
 	uint_t ret;
-	unsigned long flags;
 
 	if (!dtcp || !dtcp->sv)
 	{
@@ -321,9 +311,9 @@ uint_t dtcp_sndr_rate(struct dtcp * dtcp)
 		return 0;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->sndr_rate;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -331,7 +321,6 @@ EXPORT_SYMBOL(dtcp_sndr_rate);
 
 int dtcp_sndr_rate_set(struct dtcp * dtcp, uint_t rate)
 {
-	unsigned long flags;
 
 	if (!dtcp || !dtcp->sv)
 	{
@@ -342,9 +331,9 @@ int dtcp_sndr_rate_set(struct dtcp * dtcp, uint_t rate)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->sndr_rate = rate;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -353,7 +342,6 @@ EXPORT_SYMBOL(dtcp_sndr_rate_set);
 uint_t dtcp_rcvr_rate(struct dtcp * dtcp)
 {
 	uint_t ret;
-	unsigned long flags;
 
 	if (!dtcp || !dtcp->sv)
 	{
@@ -364,9 +352,9 @@ uint_t dtcp_rcvr_rate(struct dtcp * dtcp)
 		return 0;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->rcvr_rate;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -374,8 +362,6 @@ EXPORT_SYMBOL(dtcp_rcvr_rate);
 
 int dtcp_rcvr_rate_set(struct dtcp * dtcp, uint_t rate)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -385,9 +371,9 @@ int dtcp_rcvr_rate_set(struct dtcp * dtcp, uint_t rate)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->rcvr_rate = rate;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -396,7 +382,6 @@ EXPORT_SYMBOL(dtcp_rcvr_rate_set);
 uint_t dtcp_recv_itu(struct dtcp * dtcp)
 {
 	uint_t ret = 0;
-	unsigned long flags;
 
 	if (!dtcp || !dtcp->sv)
 	{
@@ -407,9 +392,9 @@ uint_t dtcp_recv_itu(struct dtcp * dtcp)
 		return 0;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->pdus_rcvd_in_time_unit;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -417,8 +402,6 @@ EXPORT_SYMBOL(dtcp_recv_itu);
 
 int dtcp_recv_itu_set(struct dtcp * dtcp, uint_t recv)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -428,9 +411,9 @@ int dtcp_recv_itu_set(struct dtcp * dtcp, uint_t recv)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->pdus_rcvd_in_time_unit = recv;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -438,8 +421,6 @@ EXPORT_SYMBOL(dtcp_recv_itu_set);
 
 int dtcp_recv_itu_inc(struct dtcp * dtcp, uint_t recv)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -449,9 +430,9 @@ int dtcp_recv_itu_inc(struct dtcp * dtcp, uint_t recv)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->pdus_rcvd_in_time_unit += recv;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -460,7 +441,6 @@ EXPORT_SYMBOL(dtcp_recv_itu_inc);
 uint_t dtcp_sent_itu(struct dtcp * dtcp)
 {
 	uint_t ret = 0;
-	unsigned long flags;
 
 	if (!dtcp || !dtcp->sv)
 	{
@@ -471,9 +451,9 @@ uint_t dtcp_sent_itu(struct dtcp * dtcp)
 		return 0;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	ret = dtcp->sv->pdus_sent_in_time_unit;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return ret;
 }
@@ -481,8 +461,6 @@ EXPORT_SYMBOL(dtcp_sent_itu);
 
 int dtcp_sent_itu_set(struct dtcp * dtcp, uint_t sent)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -492,9 +470,9 @@ int dtcp_sent_itu_set(struct dtcp * dtcp, uint_t sent)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->pdus_sent_in_time_unit = sent;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -502,8 +480,6 @@ EXPORT_SYMBOL(dtcp_sent_itu_set);
 
 int dtcp_sent_itu_inc(struct dtcp * dtcp, uint_t sent)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK.",
@@ -513,9 +489,9 @@ int dtcp_sent_itu_inc(struct dtcp * dtcp, uint_t sent)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->pdus_sent_in_time_unit += sent;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -523,8 +499,6 @@ EXPORT_SYMBOL(dtcp_sent_itu_inc);
 
 int dtcp_rate_fc_reset(struct dtcp * dtcp, struct timespec * now)
 {
-	unsigned long flags;
-
 	if (!dtcp || !dtcp->sv || !now)
 	{
 		LOG_DBG("%s, Wrong arguments; dtcp: %pK, now: %pK.",
@@ -535,12 +509,12 @@ int dtcp_rate_fc_reset(struct dtcp * dtcp, struct timespec * now)
 		return -1;
 	}
 
-	spin_lock_irqsave(&dtcp->sv->lock, flags);
+	spin_lock_bh(&dtcp->sv->lock);
 	dtcp->sv->pdus_sent_in_time_unit = 0;
 	dtcp->sv->pdus_rcvd_in_time_unit = 0;
 	dtcp->sv->last_time.tv_sec = now->tv_sec;
 	dtcp->sv->last_time.tv_nsec = now->tv_nsec;
-	spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+	spin_unlock_bh(&dtcp->sv->lock);
 
 	return 0;
 }
@@ -548,15 +522,14 @@ EXPORT_SYMBOL(dtcp_rate_fc_reset);
 
 uint_t dtcp_rtt(struct dtcp * dtcp)
 {
-        unsigned long flags;
         uint_t        tmp;
 
         if (!dtcp || !dtcp->sv)
                 return 0;
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->rtt;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -564,14 +537,12 @@ EXPORT_SYMBOL(dtcp_rtt);
 
 int dtcp_rtt_set(struct dtcp * dtcp, uint_t rtt)
 {
-        unsigned long flags;
-
         if (!dtcp || !dtcp->sv)
                 return -1;
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->rtt = rtt;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return 0;
 }
@@ -579,15 +550,14 @@ EXPORT_SYMBOL(dtcp_rtt_set);
 
 uint_t dtcp_srtt(struct dtcp * dtcp)
 {
-        unsigned long flags;
         uint_t        tmp;
 
         if (!dtcp || !dtcp->sv)
                 return 0;
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->srtt;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -595,14 +565,12 @@ EXPORT_SYMBOL(dtcp_srtt);
 
 int dtcp_srtt_set(struct dtcp * dtcp, uint_t srtt)
 {
-        unsigned long flags;
-
         if (!dtcp || !dtcp->sv)
                 return -1;
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->srtt = srtt;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return 0;
 }
@@ -610,15 +578,14 @@ EXPORT_SYMBOL(dtcp_srtt_set);
 
 uint_t dtcp_rttvar(struct dtcp * dtcp)
 {
-        unsigned long flags;
         uint_t        tmp;
 
         if (!dtcp || !dtcp->sv)
                 return 0;
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->rttvar;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -626,14 +593,12 @@ EXPORT_SYMBOL(dtcp_rttvar);
 
 int dtcp_rttvar_set(struct dtcp * dtcp, uint_t rttvar)
 {
-        unsigned long flags;
-
         if (!dtcp || !dtcp->sv)
                 return -1;
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->rtt = rttvar;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return 0;
 }
@@ -642,14 +607,12 @@ EXPORT_SYMBOL(dtcp_rttvar_set);
 static int last_rcv_ctrl_seq_set(struct dtcp * dtcp,
                                  seq_num_t     last_rcv_ctrl_seq)
 {
-        unsigned long flags;
-
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->last_rcv_ctl_seq = last_rcv_ctrl_seq;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return 0;
 }
@@ -657,14 +620,13 @@ static int last_rcv_ctrl_seq_set(struct dtcp * dtcp,
 seq_num_t last_rcv_ctrl_seq(struct dtcp * dtcp)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->last_rcv_ctl_seq;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -672,37 +634,32 @@ EXPORT_SYMBOL(last_rcv_ctrl_seq);
 
 static void flow_ctrl_inc(struct dtcp * dtcp)
 {
-        unsigned long flags;
-
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->flow_ctl++;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 }
 
 static void acks_inc(struct dtcp * dtcp)
 {
-        unsigned long flags;
-
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->acks++;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 }
 
 static int snd_rt_wind_edge_set(struct dtcp * dtcp, seq_num_t new_rt_win)
 {
-        unsigned long flags;
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->snd_rt_wind_edge = new_rt_win;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return 0;
 }
@@ -710,14 +667,13 @@ static int snd_rt_wind_edge_set(struct dtcp * dtcp, seq_num_t new_rt_win)
 seq_num_t snd_rt_wind_edge(struct dtcp * dtcp)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->snd_rt_wind_edge;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -726,14 +682,13 @@ EXPORT_SYMBOL(snd_rt_wind_edge);
 seq_num_t snd_lft_win(struct dtcp * dtcp)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->snd_lft_win;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -741,15 +696,14 @@ EXPORT_SYMBOL(snd_lft_win);
 
 seq_num_t rcvr_rt_wind_edge(struct dtcp * dtcp)
 {
-        unsigned long flags;
         seq_num_t     tmp;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->rcvr_rt_wind_edge;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -757,16 +711,14 @@ EXPORT_SYMBOL(rcvr_rt_wind_edge);
 
 int pdus_sent_in_t_unit_set(struct dtcp * dtcp, uint_t s)
 {
-        unsigned long flags;
-
         if (!dtcp || !dtcp->sv) {
                 LOG_ERR("Bogus DTCP instance");
                 return -1;
         }
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->pdus_sent_in_time_unit = s;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return 0;
 }
@@ -775,15 +727,13 @@ EXPORT_SYMBOL(pdus_sent_in_t_unit_set);
 static seq_num_t next_snd_ctl_seq(struct dtcp * dtcp)
 {
         seq_num_t     tmp;
-        unsigned long flags;
-
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = ++dtcp->sv->next_snd_ctl_seq;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -791,14 +741,13 @@ static seq_num_t next_snd_ctl_seq(struct dtcp * dtcp)
 static seq_num_t last_snd_data_ack(struct dtcp * dtcp)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->last_snd_data_ack;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
@@ -806,97 +755,87 @@ static seq_num_t last_snd_data_ack(struct dtcp * dtcp)
 static seq_num_t last_rcv_data_ack(struct dtcp * dtcp)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         tmp = dtcp->sv->last_rcv_data_ack;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 
         return tmp;
 }
 
 static void last_snd_data_ack_set(struct dtcp * dtcp, seq_num_t seq_num)
 {
-        unsigned long flags;
-
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->last_snd_data_ack = seq_num;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 }
 
 static uint_t dtcp_sndr_credit(struct dtcp * dtcp) {
-        unsigned long flags;
         seq_num_t credit;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         credit = dtcp->sv->sndr_credit;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
         return credit;
 }
 
 uint_t dtcp_rcvr_credit(struct dtcp * dtcp) {
-        unsigned long flags;
         seq_num_t credit;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         credit = dtcp->sv->rcvr_credit;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
         return credit;
 }
 EXPORT_SYMBOL(dtcp_rcvr_credit);
 
 void dtcp_rcvr_credit_set(struct dtcp * dtcp, uint_t credit)
 {
-        unsigned long flags;
-
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->rcvr_credit = credit;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 }
 EXPORT_SYMBOL(dtcp_rcvr_credit_set);
 
 void update_rt_wind_edge(struct dtcp * dtcp)
 {
         seq_num_t     seq;
-        unsigned long flags;
 
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
         seq = dt_sv_rcv_lft_win(dtcp->parent);
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         seq += dtcp->sv->rcvr_credit;
         dtcp->sv->rcvr_rt_wind_edge = seq;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 }
 EXPORT_SYMBOL(update_rt_wind_edge);
 
 void update_credit_and_rt_wind_edge(struct dtcp * dtcp, uint_t credit)
 {
-        unsigned long flags;
-
         ASSERT(dtcp);
         ASSERT(dtcp->sv);
 
-        spin_lock_irqsave(&dtcp->sv->lock, flags);
+        spin_lock_bh(&dtcp->sv->lock);
         dtcp->sv->rcvr_credit = credit;
 	/* applying the TCP rule of not shrinking the window */
 	if (dt_sv_rcv_lft_win(dtcp->parent) + credit > dtcp->sv->rcvr_rt_wind_edge)
         	dtcp->sv->rcvr_rt_wind_edge = dt_sv_rcv_lft_win(dtcp->parent) + credit;
-        spin_unlock_irqrestore(&dtcp->sv->lock, flags);
+        spin_unlock_bh(&dtcp->sv->lock);
 }
 EXPORT_SYMBOL(update_credit_and_rt_wind_edge);
 
@@ -2142,14 +2081,12 @@ seq_num_t dtcp_snd_lf_win(struct dtcp * dtcp)
 
 int dtcp_snd_lf_win_set(struct dtcp * instance, seq_num_t seq_num)
 {
-        unsigned long flags;
-
         if (!instance || !instance->sv)
                 return -1;
 
-        spin_lock_irqsave(&instance->sv->lock, flags);
+        spin_lock_bh(&instance->sv->lock);
         instance->sv->snd_lft_win = seq_num;
-        spin_unlock_irqrestore(&instance->sv->lock, flags);
+        spin_unlock_bh(&instance->sv->lock);
 
         return 0;
 }
@@ -2157,14 +2094,12 @@ EXPORT_SYMBOL(dtcp_snd_lf_win_set);
 
 int dtcp_rcv_rt_win_set(struct dtcp * instance, seq_num_t seq_num)
 {
-        unsigned long flags;
-
         if (!instance || !instance->sv)
                 return -1;
 
-        spin_lock_irqsave(&instance->sv->lock, flags);
+        spin_lock_bh(&instance->sv->lock);
         instance->sv->rcvr_rt_wind_edge = seq_num;
-        spin_unlock_irqrestore(&instance->sv->lock, flags);
+        spin_unlock_bh(&instance->sv->lock);
 
         return 0;
 }

--- a/linux/net/rina/dtp.c
+++ b/linux/net/rina/dtp.c
@@ -110,29 +110,29 @@ static struct dtp_sv default_sv = {
         .rate_fulfiled                 = false,
 };
 
-#define stats_get(name, sv, retval, flags)			\
+#define stats_get(name, sv, retval)				\
         ASSERT(sv);						\
-        spin_lock_irqsave(&sv->lock, flags);			\
+        spin_lock_bh(&sv->lock);				\
         retval = sv->stats.name;				\
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
-#define stats_inc(name, sv, flags)				\
+#define stats_inc(name, sv)					\
         ASSERT(sv);						\
-        spin_lock_irqsave(&sv->lock, flags);			\
+        spin_lock_bh(&sv->lock);				\
         sv->stats.name##_pdus++;				\
         LOG_DBG("PDUs __STRINGIFY(name) %u",			\
 		sv->stats.name##_pdus);				\
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
-#define stats_inc_bytes(name, sv, bytes, flags)			\
+#define stats_inc_bytes(name, sv, bytes)			\
         ASSERT(sv);						\
-        spin_lock_irqsave(&sv->lock, flags);			\
+        spin_lock_bh(&sv->lock);				\
         sv->stats.name##_pdus++;				\
 	sv->stats.name##_bytes += (unsigned long) bytes;	\
         LOG_DBG("PDUs __STRINGIFY(name) %u (%u)",		\
 		sv->stats.name##_pdus,				\
 		sv->stats.name##_bytes);			\
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
 static ssize_t dtp_attr_show(struct robject *		     robj,
                          	     struct robj_attribute * attr,
@@ -140,7 +140,6 @@ static ssize_t dtp_attr_show(struct robject *		     robj,
 {
 	struct dtp * instance;
 	unsigned int stats_ret;
-	unsigned long flags;
 
 	instance = container_of(robj, struct dtp, robj);
 	if (!instance || !instance->cfg || !instance->sv)
@@ -171,27 +170,27 @@ static ssize_t dtp_attr_show(struct robject *		     robj,
 			dtp_conf_seq_num_ro_th(instance->cfg));
 	}
 	if (strcmp(robject_attr_name(attr), "drop_pdus") == 0) {
-		stats_get(drop_pdus, instance->sv, stats_ret, flags);
+		stats_get(drop_pdus, instance->sv, stats_ret);
 		return sprintf(buf, "%u\n", stats_ret);
 	}
 	if (strcmp(robject_attr_name(attr), "err_pdus") == 0) {
-		stats_get(err_pdus, instance->sv, stats_ret, flags);
+		stats_get(err_pdus, instance->sv, stats_ret);
 		return sprintf(buf, "%u\n", stats_ret);
 	}
 	if (strcmp(robject_attr_name(attr), "tx_pdus") == 0) {
-		stats_get(tx_pdus, instance->sv, stats_ret, flags);
+		stats_get(tx_pdus, instance->sv, stats_ret);
 		return sprintf(buf, "%u\n", stats_ret);
 	}
 	if (strcmp(robject_attr_name(attr), "tx_bytes") == 0) {
-		stats_get(tx_bytes, instance->sv, stats_ret, flags);
+		stats_get(tx_bytes, instance->sv, stats_ret);
 		return sprintf(buf, "%u\n", stats_ret);
 	}
 	if (strcmp(robject_attr_name(attr), "rx_pdus") == 0) {
-		stats_get(rx_pdus, instance->sv, stats_ret, flags);
+		stats_get(rx_pdus, instance->sv, stats_ret);
 		return sprintf(buf, "%u\n", stats_ret);
 	}
 	if (strcmp(robject_attr_name(attr), "rx_bytes") == 0) {
-		stats_get(rx_bytes, instance->sv, stats_ret, flags);
+		stats_get(rx_bytes, instance->sv, stats_ret);
 		return sprintf(buf, "%u\n", stats_ret);
 	}
 	if (strcmp(robject_attr_name(attr), "ps_name") == 0) {
@@ -228,14 +227,12 @@ struct dtp_config * dtp_config_get(struct dtp * dtp)
 
 int nxt_seq_reset(struct dtp_sv * sv, seq_num_t sn)
 {
-        unsigned long flags;
-
         if (!sv)
                 return -1;
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         sv->seq_nr_to_send = sn;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return 0;
 }
@@ -243,13 +240,12 @@ int nxt_seq_reset(struct dtp_sv * sv, seq_num_t sn)
 static seq_num_t nxt_seq_get(struct dtp_sv * sv)
 {
         seq_num_t     tmp;
-        unsigned long flags;
 
         ASSERT(sv);
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         tmp = ++sv->seq_nr_to_send;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return tmp;
 }
@@ -258,7 +254,6 @@ seq_num_t dtp_sv_last_nxt_seq_nr(struct dtp * instance)
 {
         seq_num_t       tmp;
         struct dtp_sv * sv;
-        unsigned long   flags;
 
         if (!instance) {
                 LOG_ERR("Bogus instance passed");
@@ -267,9 +262,9 @@ seq_num_t dtp_sv_last_nxt_seq_nr(struct dtp * instance)
         sv = instance->sv;
         ASSERT(sv);
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         tmp = sv->seq_nr_to_send;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return tmp;
 }
@@ -277,7 +272,6 @@ seq_num_t dtp_sv_last_nxt_seq_nr(struct dtp * instance)
 seq_num_t dtp_sv_max_seq_nr_sent(struct dtp * instance)
 {
         seq_num_t       tmp;
-        unsigned long   flags;
         struct dtp_sv * sv;
 
         if (!instance) {
@@ -287,16 +281,15 @@ seq_num_t dtp_sv_max_seq_nr_sent(struct dtp * instance)
         sv = instance->sv;
         ASSERT(sv);
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         tmp = sv->max_seq_nr_sent;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return tmp;
 }
 
 int dtp_sv_max_seq_nr_set(struct dtp * instance, seq_num_t num)
 {
-        unsigned long   flags;
         struct dtp_sv * sv;
 
         if (!instance) {
@@ -306,22 +299,21 @@ int dtp_sv_max_seq_nr_set(struct dtp * instance, seq_num_t num)
         sv = instance->sv;
         ASSERT(sv);
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         if (sv->max_seq_nr_sent < num)
                 sv->max_seq_nr_sent = num;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return 0;
 }
 
 static bool sv_rate_fulfiled(struct dtp_sv * sv)
 {
-        unsigned long flags;
         bool          tmp;
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         tmp = sv->rate_fulfiled;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return tmp;
 }
@@ -342,7 +334,6 @@ bool dtp_sv_rate_fulfiled(struct dtp * instance)
 
 int dtp_sv_rate_fulfiled_set(struct dtp * instance, bool fulfiled)
 {
-        unsigned long   flags;
         struct dtp_sv * sv;
 
         if (!instance) {
@@ -354,9 +345,9 @@ int dtp_sv_rate_fulfiled_set(struct dtp * instance, bool fulfiled)
 
         LOG_DBG("rbfc Rate set to %u (0=some more, 1=consumed)", fulfiled);
 
-        spin_lock_irqsave(&sv->lock, flags);
+        spin_lock_bh(&sv->lock);
         sv->rate_fulfiled = fulfiled;
-        spin_unlock_irqrestore(&sv->lock, flags);
+        spin_unlock_bh(&sv->lock);
 
         return 0;
 }
@@ -715,7 +706,6 @@ struct pci * process_A_expiration(struct dtp * dtp, struct dtcp * dtcp)
         struct seq_queue_entry * pos, * n;
         struct dtp_ps *          ps;
         struct dtcp_ps *         dtcp_ps;
-        unsigned long            flags;
         struct rqueue *          to_post;
         struct pci *             pci, * pci_ret = NULL;
 
@@ -754,7 +744,7 @@ struct pci * process_A_expiration(struct dtp * dtp, struct dtcp * dtcp)
                 return NULL;
         }
 
-        spin_lock_irqsave(&seqq->lock, flags);
+        spin_lock_bh(&seqq->lock);
         LWE = dt_sv_rcv_lft_win(dt);
         LOG_DBG("LWEU: Original LWE = %u", LWE);
         LOG_DBG("LWEU: MAX GAPS     = %u", max_sdu_gap);
@@ -762,7 +752,7 @@ struct pci * process_A_expiration(struct dtp * dtp, struct dtcp * dtcp)
         list_for_each_entry_safe(pos, n, &seqq->queue->head, next) {
                 pdu = pos->pdu;
                 if (!pdu_is_ok(pdu)) {
-                        spin_unlock_irqrestore(&seqq->lock, flags);
+                        spin_unlock_bh(&seqq->lock);
 
                         LOG_ERR("Bogus data, bailing out");
                         return NULL;
@@ -829,8 +819,8 @@ struct pci * process_A_expiration(struct dtp * dtp, struct dtcp * dtcp)
 
         }
 finish:
-	pci_ret = pci_dup_ni(pci_ret);
-        spin_unlock_irqrestore(&seqq->lock, flags);
+        pci_ret = pci_dup_ni(pci_ret);
+        spin_unlock_bh(&seqq->lock);
 
         while (!rqueue_is_empty(to_post)) {
                 pdu = (struct pdu *) rqueue_head_pop(to_post);
@@ -1348,7 +1338,6 @@ int dtp_write(struct dtp * instance,
         struct dtp_ps *         ps;
         seq_num_t               sn, csn;
         struct efcp *           efcp;
-	unsigned long           flags;
         int			sbytes;
         uint_t                  sc;
 
@@ -1511,7 +1500,7 @@ int dtp_write(struct dtp * instance,
                 }
 
                 rcu_read_unlock();
-		stats_inc_bytes(tx, sv, sbytes, flags);
+		stats_inc_bytes(tx, sv, sbytes);
 #if DTP_INACTIVITY_TIMERS_ENABLE
                 /* Start SenderInactivityTimer */
                 if (rtimer_restart(instance->timers.sender_inactivity,
@@ -1530,7 +1519,7 @@ int dtp_write(struct dtp * instance,
                         instance->rmt,
                         pdu))
 		return -1;
-	stats_inc_bytes(tx, sv, sbytes, flags);
+	stats_inc_bytes(tx, sv, sbytes);
 	return 0;
 
 pci_err_exit:
@@ -1544,7 +1533,7 @@ pdu_err_exit:
 stats_err_exit:
         rcu_read_unlock();
 stats_nounlock_err_exit:
-	stats_inc(err, sv, flags);
+	stats_inc(err, sv);
 	return -1;
 }
 
@@ -1554,11 +1543,9 @@ void dtp_drf_required_set(struct dtp * dtp)
 /*
 static bool is_drf_required(struct dtp * dtp)
 {
-        unsigned long flags;
-
-        spin_lock_irqsave(&dtp->sv->lock, flags);
+        spin_lock_bh(&dtp->sv->lock);
         ret = dtp->sv->drf_required;
-        spin_unlock_irqrestore(&dtp->sv->lock, flags);
+        spin_unlock_bh(&dtp->sv->lock);
         return ret;
 }
 */
@@ -1626,7 +1613,6 @@ int dtp_receive(struct dtp * instance,
         bool             in_order;
         bool             rtx_ctrl = false;
         seq_num_t        max_sdu_gap;
-        unsigned long    flags;
         struct rqueue *  to_post;
 	int              sbytes;
 	struct efcp *		efcp = 0;
@@ -1704,10 +1690,10 @@ int dtp_receive(struct dtp * instance,
 #endif
                 if ((pci_flags_get(pci) & PDU_FLAGS_DATA_RUN)) {
                         instance->sv->drf_required = false;
-                        spin_lock_irqsave(&instance->seqq->lock, flags);
+                        spin_lock_bh(&instance->seqq->lock);
                         dtp_squeue_flush(instance);
                         dt_sv_rcv_lft_win_set(dt, seq_num);
-                        spin_unlock_irqrestore(&instance->seqq->lock, flags);
+                        spin_unlock_bh(&instance->seqq->lock);
                         if (dtcp) {
                                 if (dtcp_sv_update(dtcp, pci)) {
                                         LOG_ERR("Failed to update dtcp sv");
@@ -1715,13 +1701,13 @@ int dtp_receive(struct dtp * instance,
                                 }
                         }
                         pdu_post(instance, pdu);
-			stats_inc_bytes(rx, sv, sbytes, flags);
+			stats_inc_bytes(rx, sv, sbytes);
                         LOG_DBG("Data run flag DRF");
                         return 0;
                 }
                 LOG_ERR("Expecting DRF but not present, dropping PDU %d...",
                         seq_num);
-		stats_inc(drop, sv, flags);
+		stats_inc(drop, sv);
                 pdu_destroy(pdu);
                 return 0;
         }
@@ -1734,7 +1720,7 @@ int dtp_receive(struct dtp * instance,
         if ((seq_num <= LWE) || (is_fc_overrun(dt, dtcp, seq_num, sbytes)))
         {
                 pdu_destroy(pdu);
-                stats_inc(drop, sv, flags);
+                stats_inc(drop, sv);
 
                 /*FIXME: Rtimer should not be restarted here, to be deleted */
 #if DTP_INACTIVITY_TIMERS_ENABLE
@@ -1813,7 +1799,7 @@ int dtp_receive(struct dtp * instance,
                 if (pdu_post(instance, pdu))
                         return -1;
 
-		stats_inc_bytes(rx, sv, sbytes, flags);
+		stats_inc_bytes(rx, sv, sbytes);
                 return 0;
 
         fail:
@@ -1821,7 +1807,8 @@ int dtp_receive(struct dtp * instance,
                 return -1;
         }
 
-        spin_lock_irqsave(&instance->seqq->lock, flags);
+        spin_lock_bh(&instance->seqq->lock);
+	/* FIXME we must avoid allocating memory here */
         to_post = rqueue_create_ni();
         if (!to_post) {
                 LOG_ERR("Could not create to_post queue");
@@ -1848,7 +1835,7 @@ int dtp_receive(struct dtp * instance,
                 dt_sv_rcv_lft_win_set(dt, seq_num);
                 rqueue_tail_push_ni(to_post, pdu);
         }
-        spin_unlock_irqrestore(&instance->seqq->lock, flags);
+        spin_unlock_bh(&instance->seqq->lock);
 
         if (list_empty(&instance->seqq->queue->head))
                 rtimer_stop(instance->timers.a);
@@ -1865,8 +1852,8 @@ int dtp_receive(struct dtp * instance,
                 if (pdu) {
                 	sbytes = buffer_length(pdu_buffer_get_ro(pdu));
                         pdu_post(instance, pdu);
-			stats_inc_bytes(rx, sv, sbytes, flags);
-                }
+			stats_inc_bytes(rx, sv, sbytes);
+		}
         }
         rqueue_destroy(to_post, (void (*)(void *)) pdu_destroy);
 

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -199,8 +199,6 @@ static int kfa_flow_deallocate_worker(void *data)
 	port_id_t	     id;
 	struct flowdel_data *wqdata;
 
-	IRQ_BARRIER;
-
 	wqdata = (struct flowdel_data *) data;
 	if (!wqdata) {
 		LOG_ERR("Bogus ipcp data passed, bailing out");
@@ -425,8 +423,6 @@ int kfa_flow_sdu_write(struct ipcp_instance_data *data,
 	struct kfa           *instance;
 	int		      retval = 0;
 
-	IRQ_BARRIER;
-
 	if (!data) {
 		LOG_ERR("Bogus ipcp data passed, bailing out");
 		sdu_destroy(sdu);
@@ -608,8 +604,6 @@ int kfa_flow_sdu_read(struct kfa  *instance,
 {
 	struct ipcp_flow *flow;
 	int		  retval = 0;
-
-	IRQ_BARRIER;
 
 	if (!instance) {
 		LOG_ERR("Bogus instance passed, bailing out");
@@ -834,8 +828,6 @@ int kfa_flow_create(struct kfa           *instance,
 {
 	struct ipcp_flow *flow;
 
-	IRQ_BARRIER;
-
 	if (!instance) {
 		LOG_ERR("Bogus kfa instance passed, bailing out");
 		return -1;
@@ -890,7 +882,6 @@ static int kfa_flow_ipcp_bind(struct ipcp_instance_data *data,
 	struct ipcp_flow *flow;
 	struct kfa       *instance;
 
-	IRQ_BARRIER;
 	LOG_DBG("Binding IPCP %pK to flow on port %d", ipcp, pid);
 
 	if (!ipcp) {
@@ -1053,8 +1044,6 @@ int kfa_flow_opts_set(struct kfa *instance,
 {
 	struct ipcp_flow *flow;
 
-	IRQ_BARRIER;
-
 	if (!instance) {
 		LOG_ERR("Bogus instance passed, bailing out");
 		return -EINVAL;
@@ -1086,8 +1075,6 @@ flow_opts_t kfa_flow_opts(struct kfa *instance,
 			  port_id_t   pid)
 {
 	struct ipcp_flow *flow;
-
-	IRQ_BARRIER;
 
 	if (!instance) {
 		LOG_ERR("Bogus instance passed, bailing out");

--- a/linux/net/rina/pff-ps-default.c
+++ b/linux/net/rina/pff-ps-default.c
@@ -466,7 +466,6 @@ int default_nhop(struct pff_ps * ps,
         address_t            destination;
         qos_id_t             qos_id;
         struct pft_entry *   tmp;
-        unsigned long        flags;
 
         priv = (struct pff_ps_priv *) ps->priv;
         if (!priv_is_ok(priv)) {
@@ -494,22 +493,22 @@ int default_nhop(struct pff_ps * ps,
          * Taking the lock here since otherwise priv might be deleted when
          * copying the ports
          */
-        spin_lock_irqsave(&priv->lock, flags);
+        spin_lock_bh(&priv->lock);
 
         tmp = pft_find(priv, destination, qos_id);
         if (!tmp) {
                 LOG_ERR("Could not find any entry for dest address: %u and "
                         "qos_id %d", destination, qos_id);
-                spin_unlock_irqrestore(&priv->lock, flags);
+                spin_unlock_bh(&priv->lock);
                 return -1;
         }
 
         if (pfte_ports_copy(tmp, ports, count)) {
-                spin_unlock_irqrestore(&priv->lock, flags);
+                spin_unlock_bh(&priv->lock);
                 return -1;
         }
 
-        spin_unlock_irqrestore(&priv->lock, flags);
+        spin_unlock_bh(&priv->lock);
 
         return 0;
 }

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1092,7 +1092,7 @@ int rmt_enable_port_id(struct rmt *instance,
 	/* incs refs_c */
 	n1_port = n1pmap_find(instance, id);
 	if (!n1_port) {
-		LOG_ERR("No queue for this port-id or already deallocated, %d",
+		LOG_WARN("No queue for N-1 port-id %d or already deallocated",
 			id);
 		return -1;
 	}


### PR DESCRIPTION
This commit is actually a backport from Arcfire needed to fix a bad behaviour in EFCP.

spin_lock_irqsave/irqrestore has been replaced in all the kernel code by spin_lock_bh. In this way HW interrupts are NOT disabled and the NIC can still receive packets from the wire and allocate them in its buffer, while bottom halves (soft IRQs including  net_rx_softirq) are properly disabled.

99% of changes are these replacements. Nevertheless KFA has a sensitive change by removing present IRQ_BARRIER s, although they should not be needed anymore it deserves proper checking.

Mainteiners:
@sandervrijders 
	linux/net/rina/ipcps/shim-eth-vlan-core.c
	linux/net/rina/ipcps/shim-tcp-udp.c
	linux/net/rina/pff-ps-default.c
	linux/net/rina/rinarp/arp826-tables.c
@miqueltarzan 	linux/net/rina/ipcps/normal-ipcp.c
	linux/net/rina/kfa.c
	linux/net/rina/rmt.c
@lbergesio ==> @vmaffione 
	linux/net/rina/dt-utils.c
	linux/net/rina/dt.c
	linux/net/rina/dtcp.c
	linux/net/rina/dtp.c
	linux/net/rina/efcp.c
