### PR TITLE
rmt, sdup: match unmatched RCU critical sections

### DIFF
--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -894,8 +894,6 @@ static void send_worker(unsigned long o)
 		    n1_port->stats.plen)
 			reschedule++;
 
-		rcu_read_unlock();
-
 		n1_port->wbusy = false;
 		if (atomic_dec_and_test(&n1_port->refs_c) &&
 		    n1_port->state == N1_PORT_STATE_DEALLOCATED) {
@@ -910,6 +908,7 @@ static void send_worker(unsigned long o)
 
 	}
 	spin_unlock(&rmt->n1_ports->lock);
+	rcu_read_unlock();
 
 	if (reschedule) {
 		LOG_DBG("Sheduling policy will schedule again...");

--- a/linux/net/rina/sdup.c
+++ b/linux/net/rina/sdup.c
@@ -944,6 +944,7 @@ int sdup_update_crypto_state(struct sdup * instance,
 			return -1;
 		}
 	}
+	rcu_read_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
This was causing RCU stalls due to unbounded RCU grace periods, which
in turn used to cause OOM.
Nothing really related to KVM or XEN.

Fixes #927 

Additional examples of stack dumps, obtained with simple rina-tgen tests between two machines, normal over shim scenario.

@edugrasa @miqueltarzan

````
[ 4666.436232] INFO: rcu_preempt detected stalls on CPUs/tasks: {} (detected by 0, t=18002 jiffies, g=21413, c=21412, q=805)
[ 4666.436285] All QSes seen, last rcu_preempt kthread activity 0 (4296277228-4296277228), jiffies_till_next_fqs=2, root ->qsmask 0x0
[ 4666.436285] ksoftirqd/0     R  running task        0     3      2 0x00000000
[ 4666.436285]  ffff880006d21420 000000005da6fbef ffff880007a03d88 ffffffff810a51a1
[ 4666.436285]  ffff880007a16e00 ffffffff8184ba80 ffff880007a03e18 ffffffff810e069d
[ 4666.436285]  0000000000000000 ffffffff810a9b25 ffff880007a16240 ffff880007a16240
[ 4666.436285] Call Trace:
[ 4666.436285]  <IRQ>  [<ffffffff810a51a1>] sched_show_task+0xc1/0x140
[ 4666.436285]  [<ffffffff810e069d>] rcu_check_callbacks+0x98d/0x9a0
[ 4666.436285]  [<ffffffff810a9b25>] ? account_system_time+0x95/0x180
[ 4666.436285]  [<ffffffff810e5819>] update_process_times+0x39/0x60
[ 4666.436285]  [<ffffffff810f6571>] tick_sched_handle.isra.6+0x21/0x60
[ 4666.436285]  [<ffffffff810f65f9>] tick_sched_timer+0x49/0x90
[ 4666.436285]  [<ffffffff810e5eb7>] __run_hrtimer+0x77/0x2a0
[ 4666.436285]  [<ffffffff810f65b0>] ? tick_sched_handle.isra.6+0x60/0x60
[ 4666.436285]  [<ffffffff810e6b2b>] hrtimer_interrupt+0x11b/0x2a0
[ 4666.436285]  [<ffffffff810520bc>] local_apic_timer_interrupt+0x3c/0x70
[ 4666.436285]  [<ffffffff815c5981>] smp_apic_timer_interrupt+0x41/0x60
[ 4666.436285]  [<ffffffff815c3b9e>] apic_timer_interrupt+0x6e/0x80
[ 4666.436285]  <EOI>  [<ffffffff8158c64e>] ? rkfree+0xe/0x10
[ 4666.436285]  [<ffffffff812d948b>] ? __memset+0x2b/0x30
[ 4666.436285]  [<ffffffff811c2b5a>] ? __kmalloc+0x25a/0x2c0
[ 4666.436285]  [<ffffffff8158c6bf>] rkzalloc+0x1f/0x60
[ 4666.436285]  [<ffffffff81595c58>] pdu_create_ni+0x18/0x30
[ 4666.436285]  [<ffffffff8159e346>] pdu_ctrl_create_ni+0x66/0x1c0
[ 4666.436285]  [<ffffffff8159e4d4>] pdu_ctrl_generate+0x34/0x220
[ 4666.436285]  [<ffffffff815aea5a>] default_receiving_flow_control+0x2a/0x90
[ 4666.436285]  [<ffffffff8159dd71>] dtcp_sv_update+0xe1/0x180
[ 4666.436285]  [<ffffffff815a213e>] dtp_receive+0x27e/0x970
[ 4666.436285]  [<ffffffff815a338a>] efcp_container_receive+0xca/0x250
[ 4666.436285]  [<ffffffff815a6917>] rmt_receive+0x2d7/0x410
[ 4666.436285]  [<ffffffffa02f4949>] normal_sdu_enqueue+0x19/0x40 [normal_ipcp]
[ 4666.436285]  [<ffffffffa02ec46e>] eth_vlan_rcv+0x2be/0x4b0 [shim_eth_vlan]
[ 4666.436285]  [<ffffffff8148d7d3>] __netif_receive_skb_core+0x6f3/0xa60
[ 4666.436285]  [<ffffffff81490378>] __netif_receive_skb+0x18/0x60
[ 4666.436285]  [<ffffffff81490442>] netif_receive_skb_internal+0x82/0xe0
[ 4666.436285]  [<ffffffff814904bc>] netif_receive_skb_sk+0x1c/0xa0
[ 4666.436285]  [<ffffffffa02c9d39>] virtnet_receive+0x289/0x970 [virtio_net]
[ 4666.436285]  [<ffffffff810b0704>] ? update_curr+0xe4/0x1c0
[ 4666.436285]  [<ffffffffa02ca441>] virtnet_poll+0x21/0x90 [virtio_net]
[ 4666.436285]  [<ffffffff814920fe>] net_rx_action+0x20e/0x3c0
[ 4666.436285]  [<ffffffff8107cf4f>] __do_softirq+0xef/0x320
[ 4666.436285]  [<ffffffff8107d1a9>] run_ksoftirqd+0x29/0x50
[ 4666.436285]  [<ffffffff8109b18c>] smpboot_thread_fn+0x11c/0x230
[ 4666.436285]  [<ffffffff8109b070>] ? sort_range+0x30/0x30
[ 4666.436285]  [<ffffffff81097c98>] kthread+0xd8/0xf0
[ 4666.436285]  [<ffffffff81097bc0>] ? kthread_worker_fn+0x170/0x170
[ 4666.436285]  [<ffffffff815c3122>] ret_from_fork+0x42/0x70
[ 4666.436285]  [<ffffffff81097bc0>] ? kthread_worker_fn+0x170/0x170
````


````
1] INFO: rcu_preempt detected stalls on CPUs/tasks: { P0 P348 P23576 P3} (detected by 0, t=18002 jiffies, g=21475, c=21474, q=3825)
[ 4837.579622] swapper/0       R  running task        0     0      0 0x00000000
[ 4837.579622]  ffffffff818124c0 5c8e4e33c4d24392 ffff880007a03d58 ffffffff810a51a1
[ 4837.579622]  ffffffff818124c0 ffffffff8184ba80 ffff880007a03d88 ffffffff815bc5f4
[ 4837.579622]  ffff880007a16e00 ffffffff8184ba80 0000000000000000 0000000000000ef1
[ 4837.579622] Call Trace:
[ 4837.579622]  <IRQ>  [<ffffffff810a51a1>] sched_show_task+0xc1/0x140
[ 4837.579622]  [<ffffffff815bc5f4>] rcu_print_detail_task_stall_rnp+0x48/0x6c
[ 4837.579622]  [<ffffffff810e056d>] rcu_check_callbacks+0x85d/0x9a0
[ 4837.579622]  [<ffffffff810e5819>] update_process_times+0x39/0x60
[ 4837.579622]  [<ffffffff810f6571>] tick_sched_handle.isra.6+0x21/0x60
[ 4837.579622]  [<ffffffff810f65f9>] tick_sched_timer+0x49/0x90
[ 4837.579622]  [<ffffffff810e5eb7>] __run_hrtimer+0x77/0x2a0
[ 4837.579622]  [<ffffffff810f65b0>] ? tick_sched_handle.isra.6+0x60/0x60
[ 4837.579622]  [<ffffffff810e6b2b>] hrtimer_interrupt+0x11b/0x2a0
[ 4837.579622]  [<ffffffff810520bc>] local_apic_timer_interrupt+0x3c/0x70
[ 4837.579622]  [<ffffffff815c5981>] smp_apic_timer_interrupt+0x41/0x60
[ 4837.579622]  [<ffffffff815c3b9e>] apic_timer_interrupt+0x6e/0x80
[ 4837.579622]  <EOI>  [<ffffffff810a9728>] ? sched_clock_cpu+0x98/0xe0
[ 4837.579622]  [<ffffffff8105fa16>] ? native_safe_halt+0x6/0x10
[ 4837.579622]  [<ffffffff81020f9e>] default_idle+0x1e/0x130
[ 4837.579622]  [<ffffffff81021c6f>] arch_cpu_idle+0xf/0x20
[ 4837.579622]  [<ffffffff810bc618>] cpu_startup_entry+0x3e8/0x460
[ 4837.579622]  [<ffffffff815b389a>] rest_init+0x8a/0x90
[ 4837.579622]  [<ffffffff818ff021>] start_kernel+0x48e/0x4af
[ 4837.579622]  [<ffffffff818fe120>] ? early_idt_handler_array+0x120/0x120
[ 4837.579622]  [<ffffffff818fe339>] x86_64_start_reservations+0x2a/0x2c
[ 4837.579622]  [<ffffffff818fe485>] x86_64_start_kernel+0x14a/0x16d
[ 4837.579622] ipcp            S ffff8800057e3e38     0   348    339 0x00000000
[ 4837.579622]  ffff8800057e3e38 ffff880006d26eb0 ffff880005b14670 ffff8800057e3f18
[ 4837.579622]  ffff8800057e4000 ffff8800060df3c0 ffff8800060df3c8 ffff8800060df3e0
[ 4837.579622]  ffff8800057e3e90 ffff8800057e3e58 ffffffff815bf0b7 ffff8800057e3e58
[ 4837.579622] Call Trace:
[ 4837.579622]  [<ffffffff815bf0b7>] schedule+0x37/0x90
[ 4837.579622]  [<ffffffffa02e75ee>] normal_mgmt_sdu_read+0xce/0x290 [normal_ipcp]
[ 4837.579622]  [<ffffffff810bbf50>] ? wake_atomic_t_function+0x60/0x60
[ 4837.579622]  [<ffffffff815ac3d4>] kipcm_mgmt_sdu_read+0x84/0x100
[ 4837.579622]  [<ffffffff815b1b47>] SyS_management_sdu_read+0x47/0x180
[ 4837.579622]  [<ffffffff815c2d2e>] system_call_fastpath+0x12/0x71
[ 4837.579622] ipcp            x ffff88000331be98     0 23576      0 0x00000000
[ 4837.579622]  ffff88000331be98 ffff880006d26eb0 ffff8800032664a0 0000000000000000
[ 4837.579622]  ffff88000331c000 ffff880003266c20 ffff88000331ba50 ffff880006135c68
[ 4837.579622]  00007fc748875e58 ffff88000331beb8 ffffffff815bf0b7 ffff880006135c68
[ 4837.579622] Call Trace:
[ 4837.579622]  [<ffffffff815bf0b7>] schedule+0x37/0x90
[ 4837.579622]  [<ffffffff8107bcf4>] do_exit+0x8c4/0xbd0
[ 4837.579622]  [<ffffffff8107c047>] SyS_exit+0x17/0x20
[ 4837.579622]  [<ffffffff815c2d2e>] system_call_fastpath+0x12/0x71
[ 4837.579622] ksoftirqd/0     S ffff880006d3fe58     0     3      2 0x00000000
[ 4837.579622]  ffff880006d3fe58 ffff880000013250 ffff880006d21420 000001000000000a
[ 4837.579622]  ffff880006d40000 ffff880006c021d0 ffffffff8183a440 0000000000000000
[ 4837.579622]  0000000000000000 ffff880006d3fe78 ffffffff815bf0b7 ffff880006d3fe78
[ 4837.579622] Call Trace:
[ 4837.579622]  [<ffffffff815bf0b7>] schedule+0x37/0x90
[ 4837.579622]  [<ffffffff8109b224>] smpboot_thread_fn+0x1b4/0x230
[ 4837.579622]  [<ffffffff8109b070>] ? sort_range+0x30/0x30
[ 4837.579622]  [<ffffffff81097c98>] kthread+0xd8/0xf0
[ 4837.579622]  [<ffffffff81097bc0>] ? kthread_worker_fn+0x170/0x170
[ 4837.579622]  [<ffffffff815c3122>] ret_from_fork+0x42/0x70
[ 4837.579622]  [<ffffffff81097bc0>] ? kthread_worker_fn+0x170/0x170
[ 4837.579622] swapper/0       R  running task        0     0      0 0x00000000
[ 4837.579622]  ffffffff818124c0 5c8e4e33c4d24392 ffff880007a03d58 ffffffff810a51a1
[ 4837.579622]  ffffffff818124c0 ffffffff8184ba80 ffff880007a03d88 ffffffff815bc5f4
[ 4837.579622]  ffff880007a16e00 ffffffff8184ba80 0000000000000000 ffffffff8184bb40
[ 4837.579622] Call Trace:
[ 4837.579622]  <IRQ>  [<ffffffff810a51a1>] sched_show_task+0xc1/0x140
[ 4837.579622]  [<ffffffff815bc5f4>] rcu_print_detail_task_stall_rnp+0x48/0x6c
[ 4837.579622]  [<ffffffff810e05a9>] rcu_check_callbacks+0x899/0x9a0
[ 4837.579622]  [<ffffffff810e5819>] update_process_times+0x39/0x60
[ 4837.579622]  [<ffffffff810f6571>] tick_sched_handle.isra.6+0x21/0x60
[ 4837.579622]  [<ffffffff810f65f9>] tick_sched_timer+0x49/0x90
[ 4837.579622]  [<ffffffff810e5eb7>] __run_hrtimer+0x77/0x2a0
[ 4837.579622]  [<ffffffff810f65b0>] ? tick_sched_handle.isra.6+0x60/0x60
[ 4837.579622]  [<ffffffff810e6b2b>] hrtimer_interrupt+0x11b/0x2a0
[ 4837.579622]  [<ffffffff810520bc>] local_apic_timer_interrupt+0x3c/0x70
[ 4837.579622]  [<ffffffff815c5981>] smp_apic_timer_interrupt+0x41/0x60
[ 4837.579622]  [<ffffffff815c3b9e>] apic_timer_interrupt+0x6e/0x80
[ 4837.579622]  <EOI>  [<ffffffff810a9728>] ? sched_clock_cpu+0x98/0xe0
[ 4837.579622]  [<ffffffff8105fa16>] ? native_safe_halt+0x6/0x10
[ 4837.579622]  [<ffffffff81020f9e>] default_idle+0x1e/0x130
[ 4837.579622]  [<ffffffff81021c6f>] arch_cpu_idle+0xf/0x20
[ 4837.579622]  [<ffffffff810bc618>] cpu_startup_entry+0x3e8/0x460
[ 4837.579622]  [<ffffffff815b389a>] rest_init+0x8a/0x90
[ 4837.579622]  [<ffffffff818ff021>] start_kernel+0x48e/0x4af
[ 4837.579622]  [<ffffffff818fe120>] ? early_idt_handler_array+0x120/0x120
[ 4837.579622]  [<ffffffff818fe339>] x86_64_start_reservations+0x2a/0x2c
[ 4837.579622]  [<ffffffff818fe485>] x86_64_start_kernel+0x14a/0x16d
[ 4837.579622] ipcp            S ffff8800057e3e38     0   348    339 0x00000000
[ 4837.579622]  ffff8800057e3e38 ffff880006d26eb0 ffff880005b14670 ffff8800057e3f18
[ 4837.579622]  ffff8800057e4000 ffff8800060df3c0 ffff8800060df3c8 ffff8800060df3e0
[ 4837.579622]  ffff8800057e3e90 ffff8800057e3e58 ffffffff815bf0b7 ffff8800057e3e58
[ 4837.579622] Call Trace:
[ 4837.579622]  [<ffffffff815bf0b7>] schedule+0x37/0x90
[ 4837.579622]  [<ffffffffa02e75ee>] normal_mgmt_sdu_read+0xce/0x290 [normal_ipcp]
[ 4837.579622]  [<ffffffff810bbf50>] ? wake_atomic_t_function+0x60/0x60
[ 4837.579622]  [<ffffffff815ac3d4>] kipcm_mgmt_sdu_read+0x84/0x100
[ 4837.579622]  [<ffffffff815b1b47>] SyS_management_sdu_read+0x47/0x180
[ 4837.579622]  [<ffffffff815c2d2e>] system_call_fastpath+0x12/0x71
[ 4837.579622] ipcp            x ffff88000331be98     0 23576      0 0x00000000
[ 4837.579622]  ffff88000331be98 ffff880006d26eb0 ffff8800032664a0 0000000000000000
[ 4837.579622]  ffff88000331c000 ffff880003266c20 ffff88000331ba50 ffff880006135c68
[ 4837.579622]  00007fc748875e58 ffff88000331beb8 ffffffff815bf0b7 ffff880006135c68
[ 4837.579622] Call Trace:
[ 4837.579622]  [<ffffffff815bf0b7>] schedule+0x37/0x90
[ 4837.579622]  [<ffffffff8107bcf4>] do_exit+0x8c4/0xbd0
[ 4837.579622]  [<ffffffff8107c047>] SyS_exit+0x17/0x20
[ 4837.579622]  [<ffffffff815c2d2e>] system_call_fastpath+0x12/0x71
[ 4837.579622] ksoftirqd/0     S ffff880006d3fe58     0     3      2 0x00000000
[ 4837.579622]  ffff880006d3fe58 ffff880000013250 ffff880006d21420 000001000000000a
[ 4837.579622]  ffff880006d40000 ffff880006c021d0 ffffffff8183a440 0000000000000000
[ 4837.579622]  0000000000000000 ffff880006d3fe78 ffffffff815bf0b7 ffff880006d3fe78
[ 4837.579622] Call Trace:
[ 4837.579622]  [<ffffffff815bf0b7>] schedule+0x37/0x90
[ 4837.579622]  [<ffffffff8109b224>] smpboot_thread_fn+0x1b4/0x230
[ 4837.579622]  [<ffffffff8109b070>] ? sort_range+0x30/0x30
[ 4837.579622]  [<ffffffff81097c98>] kthread+0xd8/0xf0
[ 4837.579622]  [<ffffffff81097bc0>] ? kthread_worker_fn+0x170/0x170
[ 4837.579622]  [<ffffffff815c3122>] ret_from_fork+0x42/0x70
[ 4837.579622]  [<ffffffff81097bc0>] ? kthread_worker_fn+0x170/0x170

````