### PR TITLE
IPCM: fix issues with SIGCHLD handling

### DIFF
--- a/rinad/src/ipcm/main.cc
+++ b/rinad/src/ipcm/main.cc
@@ -53,7 +53,7 @@ using namespace TCLAP;
 
 void handler(int signum)
 {
-	int pid;
+	int pid, saved_errno;
 
 	switch(signum){
 		case SIGSEGV:
@@ -67,14 +67,12 @@ void handler(int signum)
 			rinad::IPCManager->stop();
 			break;
 		case SIGCHLD:
+			saved_errno = errno;
 			while (pid = waitpid(WAIT_ANY, NULL, WNOHANG), pid > 0) {
 				LOG_DBG("Child IPC Process Daemon %d died, removed from process table",
 					pid);
 			}
-
-			if (pid)
-				LOG_ERR("Waitpid returned error %d", pid);
-
+			errno = saved_errno;
 			break;
 		default:
 			LOG_CRIT("Got unknown signal %d", signum);


### PR DESCRIPTION
The second commit is a workaround. A full solution may be:
- make the SIGCHLD handler record somewhere which zombie was reaped
- temporary block the SIGCHLD handler around kill(), and only kill if not reaped

Another one may be to stop using signal handler for that.