### PR TITLE
query-rib: filtering by object class/name

### DIFF
--- a/librina/include/librina/rib_v2.h
+++ b/librina/include/librina/rib_v2.h
@@ -790,13 +790,21 @@ public:
                          const std::string fqdn);
 
         ///
-        /// Get the list of all the objects in the RIB
+        /// Get the list of all the objects in the RIB, filtered by class/name.
         ///
         /// @param handle The handle of the RIB
+        /// @param class_ Optional parameter. When defined (!=""), only objects
+        /// of this class_ are returned.
+        /// @param name Optional parameter. When defined (!=""), only objects
+        /// of this name are returned, including child object if the parameter
+        /// ends with '/'.
         ///
         /// @throws eRIBNotFound, eObjDoesNotExist
         ///
-        std::list<RIBObjectData> get_rib_objects_data(const rib_handle_t& handle);
+        std::list<RIBObjectData> get_rib_objects_data(
+                const rib_handle_t& handle,
+                const std::string& class_="",
+                const std::string& name="");
 
         int set_security_manager(ApplicationEntity * sec_man);
 

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -123,7 +123,8 @@ IPCMConsole::IPCMConsole(const std::string& socket_path_) :
 				"<neighbor-process-instance>");
 	commands_map["query-rib"] =
 			ConsoleCmdInfo(&IPCMConsole::query_rib,
-				"USAGE: query-rib <ipcp-id>");
+				"USAGE: query-rib <ipcp-id> "
+				"[(<object-class>|-) [<object-name>]]");
 	commands_map["select-policy-set"] =
 			ConsoleCmdInfo(&IPCMConsole::select_policy_set,
 				"USAGE: select-policy-set <ipcp-id> "
@@ -574,6 +575,7 @@ IPCMConsole::query_rib(std::vector<string>& args)
 {
 	int ipcp_id;
 	QueryRIBPromise promise;
+	string objectClass, objectName;
 
 	if (args.size() < 2) {
 		outstream << commands_map[args[0]].usage << endl;
@@ -590,7 +592,15 @@ IPCMConsole::query_rib(std::vector<string>& args)
 		return CMDRETCONT;
 	}
 
-	if (IPCManager->query_rib(this, &promise, ipcp_id) == IPCM_FAILURE ||
+	if (args.size() > 2) {
+		if (args[2] != "-")
+			objectClass = args[2];
+		if (args.size() > 3)
+			objectName = args[3];
+	}
+
+	if (IPCManager->query_rib(this, &promise, ipcp_id,
+				  objectClass, objectName) == IPCM_FAILURE ||
 			promise.wait() != IPCM_SUCCESS) {
 		outstream << "Query RIB operation failed" << endl;
 		return CMDRETCONT;

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1195,7 +1195,7 @@ ipcm_res_t IPCManager_::query_rib(Addon* callee, QueryRIBPromise* promise,
 
         ss << "Requested query RIB of IPC process "
                 << ipcp->get_name().toString() << std::endl;
-        FLUSH_LOG(INFO, ss);
+        FLUSH_LOG(DBG, ss);
     } catch (rina::ConcurrentException& e)
     {
         ss << "Error while querying RIB of IPC Process "

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -1152,7 +1152,9 @@ ipcm_res_t IPCManager_::update_dif_configuration(
 }
 
 ipcm_res_t IPCManager_::query_rib(Addon* callee, QueryRIBPromise* promise,
-                                  const unsigned short ipcp_id)
+                                  const unsigned short ipcp_id,
+                                  const std::string& objectClass,
+                                  const std::string& objectName)
 {
     std::ostringstream ss;
     IPCMIPCProcess *ipcp;
@@ -1189,7 +1191,7 @@ ipcm_res_t IPCManager_::query_rib(Addon* callee, QueryRIBPromise* promise,
             throw rina::Exception();
         }
 
-        ipcp->queryRIB("", "", 0, 0, "", trans->tid);
+        ipcp->queryRIB(objectClass, objectName, 0, 0, "", trans->tid);
 
         ss << "Requested query RIB of IPC process "
                 << ipcp->get_name().toString() << std::endl;

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -440,7 +440,9 @@ public:
 	//
 	// @ret IPCM_FAILURE on failure, otherwise the IPCM_PENDING
 	ipcm_res_t query_rib(Addon* callee, QueryRIBPromise* promise,
-						const unsigned short ipcp_id);
+				const unsigned short ipcp_id,
+				const std::string& objectClass="",
+				const std::string& objectName="");
 
 	//
 	// Select a policy set

--- a/rinad/src/ipcm/misc-handlers.cc
+++ b/rinad/src/ipcm/misc-handlers.cc
@@ -81,7 +81,7 @@ void IPCManager_::query_rib_response_event_handler(rina::QueryRIBResponseEvent *
 
 	ss << "Query RIB operation completed for IPC "
 		<< "process " << ipcp->get_name().toString() << endl;
-	FLUSH_LOG(INFO, ss);
+	FLUSH_LOG(DBG, ss);
 
 	for (lit = e->ribObjects.begin(); lit != e->ribObjects.end();
 			++lit) {

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -325,7 +325,7 @@ void IPCProcessImpl::logPDUFTE(const rina::DumpFTResponseEvent& event) {
 		ss << std::endl;
 	}
 
-	LOG_IPCP_INFO("%s", ss.str().c_str());
+	LOG_IPCP_DBG("%s", ss.str().c_str());
 }
 
 static void parse_path(const std::string& path, std::string& component,

--- a/rinad/src/ipcp/rib-daemon.cc
+++ b/rinad/src/ipcp/rib-daemon.cc
@@ -575,8 +575,10 @@ void IPCPRIBDaemonImpl::nMinusOneFlowAllocated(rina::NMinusOneFlowAllocatedEvent
 
 void IPCPRIBDaemonImpl::processQueryRIBRequestEvent(const rina::QueryRIBRequestEvent& event)
 {
-	std::list<rina::rib::RIBObjectData> result =
-			ribd->get_rib_objects_data(rib);
+	std::list<rina::rib::RIBObjectData> result = ribd->get_rib_objects_data(
+		rib,
+		event.getObjectClass(),
+		event.getObjectName());
 
 	try {
 		rina::extendedIPCManager->queryRIBResponse(event,


### PR DESCRIPTION
The netlink message already carried objectClass/objectName fields, but they were neither filled nor processed. 2 things in particular about the implementation:
- If *objectName* does not end with `/`, then *query-rib* returns information for this exact object. Otherwise, it also returns all information from child objects.
- Since the console does not provide any escaping mechanism that could be used to pass an empty token, `-` can be passed to *class* if one only wants to only filter by *name*.