### PR TITLE
WIP: rinad: query an external daemon when a IPCP address can't be found

### DIFF
--- a/rinad/src/common/rina-configuration.h
+++ b/rinad/src/common/rina-configuration.h
@@ -80,6 +80,11 @@ struct KnownIPCProcessAddress {
         unsigned int address;
 
         KnownIPCProcessAddress() : address(0) { }
+
+        static unsigned int resolve(
+                const rina::ApplicationProcessNamingInformation &dif_name,
+                const std::string& process_name,
+                const std::string& process_instance);
 };
 
 /* The configuration required to create a DIF */

--- a/rinad/src/ipcm/dif-validator.cc
+++ b/rinad/src/ipcm/dif-validator.cc
@@ -223,7 +223,7 @@ bool DIFConfigValidator::knownIPCProcessAddresses()
 	std::list<rina::StaticIPCProcessAddress> staticAddress =
 			dif_info_.dif_configuration_.nsm_configuration_.
 			addressing_configuration_.static_address_;
-	bool result = staticAddress.begin() != staticAddress.end();
+	bool result = true;
 	for (std::list<rina::StaticIPCProcessAddress>::iterator it =
 			staticAddress.begin();
 	     it != staticAddress.end();

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -621,9 +621,10 @@ ipcm_res_t IPCManager_::assign_to_dif(
             nsm_config.addressing_configuration_ = address_config;
             nsm_config.policy_set_ = dif_template->nsmConfiguration.policy_set_;
 
-            bool found = dif_template->lookup_ipcp_address(ipcp->get_name(),
-                                                           address);
-            if (!found)
+            rina::ApplicationProcessNamingInformation name = ipcp->get_name();
+            if (!dif_template->lookup_ipcp_address(name, address) &&
+                !(address = KnownIPCProcessAddress::resolve(dif_name,
+                    name.processName, name.processInstance)))
             {
                 ss << "No address for IPC process "
                         << ipcp->get_name().toString() << " in DIF "

--- a/rinad/src/ipcp/plugins/default/namespace-manager-ps.cc
+++ b/rinad/src/ipcp/plugins/default/namespace-manager-ps.cc
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "ipcp/components.h"
+#include <rina-configuration.h>
 
 namespace rinad {
 
@@ -94,7 +95,8 @@ bool NamespaceManagerPs::isValidAddress(unsigned int address, const std::string&
 unsigned int NamespaceManagerPs::getValidAddress(const std::string& ipcp_name,
 		const std::string& ipcp_instance)
 {
-		rina::AddressingConfiguration configuration = nsm->ipcp->get_dif_information().
+		const rina::DIFInformation &dif_info = nsm->ipcp->get_dif_information();
+		rina::AddressingConfiguration configuration = dif_info.
 					dif_configuration_.nsm_configuration_.addressing_configuration_;
 		unsigned int candidateAddress = getIPCProcessAddress(ipcp_name,
 				ipcp_instance, configuration);
@@ -108,7 +110,7 @@ unsigned int NamespaceManagerPs::getValidAddress(const std::string& ipcp_name,
 			prefix = getAddressPrefix(ipcp_name, configuration);
 		} catch (rina::Exception &e) {
 			//We don't know the organization of the IPC Process
-			return 0;
+			goto resolve;
 		}
 
 		candidateAddress = prefix;
@@ -121,7 +123,9 @@ unsigned int NamespaceManagerPs::getValidAddress(const std::string& ipcp_name,
 			}
 		}
 
-		return 0;
+	resolve:
+		return KnownIPCProcessAddress::resolve(
+			dif_info.dif_name_, ipcp_name, ipcp_instance);
 }
 
 unsigned int NamespaceManagerPs::getIPCProcessAddress(const std::string& process_name,


### PR DESCRIPTION
This fixes the limitation that currently the only address assignment policy
is static assignment.
