### PR TITLE
Pristine 1.5 pff: fix locking and atomic modify

### DIFF
--- a/linux/net/rina/ipcp-instances.h
+++ b/linux/net/rina/ipcp-instances.h
@@ -324,6 +324,9 @@ struct ipcp_instance_ops {
 
         int (* pff_flush)(struct ipcp_instance_data * data);
 
+        int (* pff_modify)(struct ipcp_instance_data * data,
+                           struct list_head * entries);
+
         int (* query_rib)(struct ipcp_instance_data * data,
                           struct list_head *          entries,
                           const string_t *            object_class,

--- a/linux/net/rina/ipcps/normal-ipcp.c
+++ b/linux/net/rina/ipcps/normal-ipcp.c
@@ -977,6 +977,15 @@ static int normal_pff_flush(struct ipcp_instance_data * data)
         return rmt_pff_flush(data->rmt);
 }
 
+static int normal_pff_modify(struct ipcp_instance_data * data,
+                   	     struct list_head * entries)
+{
+	ASSERT(data);
+
+	return rmt_pff_modify(data->rmt,
+			      entries);
+}
+
 static const struct name * normal_ipcp_name(struct ipcp_instance_data * data)
 {
         ASSERT(data);
@@ -1222,6 +1231,7 @@ static struct ipcp_instance_ops normal_instance_ops = {
         .pff_remove                = normal_pff_remove,
         .pff_dump                  = normal_pff_dump,
         .pff_flush                 = normal_pff_flush,
+	.pff_modify		   = normal_pff_modify,
 
         .query_rib		   = NULL,
 

--- a/linux/net/rina/ipcps/shim-eth-vlan-core.c
+++ b/linux/net/rina/ipcps/shim-eth-vlan-core.c
@@ -1762,6 +1762,7 @@ static struct ipcp_instance_ops eth_vlan_instance_ops = {
         .pff_remove                = NULL,
         .pff_dump                  = NULL,
         .pff_flush                 = NULL,
+	.pff_modify		   = NULL,
 
         .query_rib		   = eth_vlan_query_rib,
 

--- a/linux/net/rina/ipcps/shim-hv-core.c
+++ b/linux/net/rina/ipcps/shim-hv-core.c
@@ -1191,6 +1191,7 @@ static struct ipcp_instance_ops shim_hv_ipcp_ops = {
         .pff_remove                = NULL,
         .pff_dump                  = NULL,
         .pff_flush                 = NULL,
+	.pff_modify		   = NULL,
 
         .query_rib		   = shim_hv_query_rib,
 

--- a/linux/net/rina/ipcps/shim-tcp-udp.c
+++ b/linux/net/rina/ipcps/shim-tcp-udp.c
@@ -2632,6 +2632,7 @@ static struct ipcp_instance_ops tcp_udp_instance_ops = {
         .pff_remove                = NULL,
         .pff_dump                  = NULL,
         .pff_flush                 = NULL,
+	.pff_modify		   = NULL,
 
         .query_rib	           = tcp_udp_query_rib,
 

--- a/linux/net/rina/kipcm.c
+++ b/linux/net/rina/kipcm.c
@@ -1124,6 +1124,7 @@ static int notify_ipcp_modify_pffe(void *             data,
         struct ipcp_instance *              ipc_process;
         ipc_process_id_t                    ipc_id;
         struct mod_pff_entry *              entry;
+        int				    result;
 
         int (* op)(struct ipcp_instance_data * data,
 		   struct mod_pff_entry      * entry);
@@ -1164,14 +1165,12 @@ static int notify_ipcp_modify_pffe(void *             data,
 
         switch(attrs->mode) {
         case 2:
-                if (ipc_process->ops->pff_flush(ipc_process->data)) {
-                        LOG_ERR("Problems flushing PFF");
-                        rnl_msg_destroy(msg);
-                        return -1;
-                }
+        	result = ipc_process->ops->pff_modify(ipc_process->data, &attrs->pff_entries);
+        	if (result)
+                        LOG_ERR("Problems modifying PFF");
 
-                op = ipc_process->ops->pff_add;
-                break;
+        	rnl_msg_destroy(msg);
+        	return result;
         case 1:
                 op = ipc_process->ops->pff_remove;
                 break;

--- a/linux/net/rina/pff-ps-default.c
+++ b/linux/net/rina/pff-ps-default.c
@@ -328,13 +328,13 @@ int default_add(struct pff_ps *        ps,
                 return -1;
         }
 
-        spin_lock(&priv->lock);
+        spin_lock_bh(&priv->lock);
 
         tmp = pft_find(priv, entry->fwd_info, entry->qos_id);
         if (!tmp) {
                 tmp = pfte_create_ni(entry->fwd_info, entry->qos_id);
                 if (!tmp) {
-                        spin_unlock(&priv->lock);
+                        spin_unlock_bh(&priv->lock);
                         return -1;
                 }
 		robject_rset_add(&tmp->robj, pff_rset(ps->dm), "%u", tmp->destination);
@@ -350,12 +350,12 @@ int default_add(struct pff_ps *        ps,
 		/* Just add the first alternative and ignore the others. */
                 if (pfte_port_add(tmp, alts->ports[0])) {
                         pfte_destroy(tmp);
-                        spin_unlock(&priv->lock);
+                        spin_unlock_bh(&priv->lock);
                         return -1;
                 }
 	}
 
-        spin_unlock(&priv->lock);
+        spin_unlock_bh(&priv->lock);
 
         return 0;
 }
@@ -385,11 +385,11 @@ int default_remove(struct pff_ps *        ps,
                 return -1;
         }
 
-        spin_lock(&priv->lock);
+        spin_lock_bh(&priv->lock);
 
         tmp = pft_find(priv, entry->fwd_info, entry->qos_id);
         if (!tmp) {
-                spin_unlock(&priv->lock);
+                spin_unlock_bh(&priv->lock);
                 return -1;
         }
 
@@ -408,7 +408,7 @@ int default_remove(struct pff_ps *        ps,
                 pfte_destroy(tmp);
         }
 
-        spin_unlock(&priv->lock);
+        spin_unlock_bh(&priv->lock);
 
         return 0;
 }
@@ -422,9 +422,9 @@ bool default_is_empty(struct pff_ps * ps)
         if (!priv_is_ok(priv))
                 return false;
 
-        spin_lock(&priv->lock);
+        spin_lock_bh(&priv->lock);
         empty = list_empty(&priv->entries);
-        spin_unlock(&priv->lock);
+        spin_unlock_bh(&priv->lock);
 
         return empty;
 }
@@ -448,11 +448,11 @@ int default_flush(struct pff_ps * ps)
         if (!priv_is_ok(priv))
                 return -1;
 
-        spin_lock(&priv->lock);
+        spin_lock_bh(&priv->lock);
 
         __pft_flush(priv);
 
-        spin_unlock(&priv->lock);
+        spin_unlock_bh(&priv->lock);
 
         return 0;
 }
@@ -554,11 +554,11 @@ int default_dump(struct pff_ps *    ps,
         if (!priv_is_ok(priv))
                 return -1;
 
-        spin_lock(&priv->lock);
+        spin_lock_bh(&priv->lock);
         list_for_each_entry(pos, &priv->entries, next) {
                 entry = rkmalloc(sizeof(*entry), GFP_ATOMIC);
                 if (!entry) {
-                        spin_unlock(&priv->lock);
+                        spin_unlock_bh(&priv->lock);
                         return -1;
                 }
 
@@ -567,13 +567,13 @@ int default_dump(struct pff_ps *    ps,
 		INIT_LIST_HEAD(&entry->port_id_altlists);
                 if (pfte_port_id_altlists_copy(pos, &entry->port_id_altlists)) {
                         rkfree(entry);
-                        spin_unlock(&priv->lock);
+                        spin_unlock_bh(&priv->lock);
                         return -1;
                 }
 
                 list_add(&entry->next, entries);
         }
-        spin_unlock(&priv->lock);
+        spin_unlock_bh(&priv->lock);
 
         return 0;
 }
@@ -627,11 +627,11 @@ void pff_ps_default_destroy(struct ps_base * bps)
                         return;
                 }
 
-                spin_lock(&priv->lock);
+                spin_lock_bh(&priv->lock);
 
                 __pft_flush(priv);
 
-                spin_unlock(&priv->lock);
+                spin_unlock_bh(&priv->lock);
 
                 rkfree(priv);
                 rkfree(ps);

--- a/linux/net/rina/pff-ps-default.h
+++ b/linux/net/rina/pff-ps-default.h
@@ -38,6 +38,8 @@ int              default_nhop(struct pff_ps * ps,
                               size_t *        count);
 int              default_dump(struct pff_ps *    ps,
                               struct list_head * entries);
+int              default_modify(struct pff_ps *    ps,
+                                struct list_head * entries);
 struct ps_base * pff_ps_default_create(struct rina_component * component);
 void             pff_ps_default_destroy(struct ps_base * bps);
 

--- a/linux/net/rina/pff-ps.h
+++ b/linux/net/rina/pff-ps.h
@@ -52,6 +52,10 @@ struct pff_ps {
         int  (* pff_dump)(struct pff_ps *    ps,
                           struct list_head * entries);
 
+        /* Dump PFF contents and add entries in an atomic operation */
+        int  (* pff_modify)(struct pff_ps *    ps,
+                            struct list_head * entries);
+
         /* Reference used to access the PFF data model. */
         struct pff * dm;
 

--- a/linux/net/rina/pff.c
+++ b/linux/net/rina/pff.c
@@ -314,6 +314,30 @@ int pff_dump(struct pff *       instance,
         return 0;
 }
 
+int pff_modify(struct pff *       instance,
+               struct list_head * entries)
+{
+        struct pff_ps * ps;
+
+        if (!__pff_is_ok(instance))
+                return -1;
+
+        rcu_read_lock();
+
+        ps = container_of(rcu_dereference(instance->base.ps),
+                          struct pff_ps, base);
+
+        ASSERT(ps->pff_modify);
+        if (ps->pff_modify(ps, entries)) {
+                rcu_read_unlock();
+                return -1;
+        }
+
+        rcu_read_unlock();
+
+        return 0;
+}
+
 int pff_select_policy_set(struct pff *     pff,
                           const string_t * path,
                           const string_t * name)

--- a/linux/net/rina/pff.h
+++ b/linux/net/rina/pff.h
@@ -55,6 +55,9 @@ int             pff_nhop(struct pff * instance,
 int             pff_dump(struct pff *       instance,
                          struct list_head * entries);
 
+int             pff_modify(struct pff *       instance,
+                           struct list_head * entries);
+
 int             pff_select_policy_set(struct pff * pff,
                                       const char * path,
                                       const char * name);

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1604,7 +1604,7 @@ int rmt_pff_flush(struct rmt *instance)
 { return is_rmt_pff_ok(instance) ? pff_flush(instance->pff) : -1; }
 EXPORT_SYMBOL(rmt_pff_flush);
 
-int rmt_pff_mnodify(struct rmt *instance,
+int rmt_pff_modify(struct rmt *instance,
 		    struct list_head *entries)
 { return is_rmt_pff_ok(instance) ? pff_modify(instance->pff, entries) : -1; }
 EXPORT_SYMBOL(rmt_pff_modify);

--- a/linux/net/rina/rmt.c
+++ b/linux/net/rina/rmt.c
@@ -1604,6 +1604,11 @@ int rmt_pff_flush(struct rmt *instance)
 { return is_rmt_pff_ok(instance) ? pff_flush(instance->pff) : -1; }
 EXPORT_SYMBOL(rmt_pff_flush);
 
+int rmt_pff_mnodify(struct rmt *instance,
+		    struct list_head *entries)
+{ return is_rmt_pff_ok(instance) ? pff_modify(instance->pff, entries) : -1; }
+EXPORT_SYMBOL(rmt_pff_modify);
+
 int rmt_ps_publish(struct ps_factory *factory)
 {
 	if (factory == NULL) {

--- a/linux/net/rina/rmt.h
+++ b/linux/net/rina/rmt.h
@@ -117,6 +117,8 @@ int		   rmt_pff_port_state_change(struct rmt *rmt,
 int		   rmt_pff_dump(struct rmt *instance,
 				struct list_head *entries);
 int		   rmt_pff_flush(struct rmt *instance);
+int		   rmt_pff_modify(struct rmt *instance,
+				  struct list_head *entries);
 int		   rmt_send(struct rmt *instance,
 			    struct pdu *pdu);
 int		   rmt_send_port_id(struct rmt *instance,

--- a/plugins/multipath/pff-ps-multipath.c
+++ b/plugins/multipath/pff-ps-multipath.c
@@ -252,7 +252,6 @@ static int __pff_add(struct pff_ps *        ps,
         if (!tmp) {
                 tmp = pfte_create_ni(entry->fwd_info, entry->qos_id);
                 if (!tmp) {
-                        spin_unlock_bh(&priv->lock);
                         return -1;
                 }
 
@@ -267,7 +266,6 @@ static int __pff_add(struct pff_ps *        ps,
 
                 if (pfte_port_add(tmp, alts->ports[0])) {
                         pfte_destroy(tmp);
-                        spin_unlock_bh(&priv->lock);
                         return -1;
                 }
 	}
@@ -279,6 +277,7 @@ static int mp_add(struct pff_ps *        ps,
                        struct mod_pff_entry * entry)
 {
         struct pff_ps_priv *     priv;
+        int result;
 
         priv = (struct pff_ps_priv *) ps->priv;
         if (!priv_is_ok(priv))
@@ -300,11 +299,11 @@ static int mp_add(struct pff_ps *        ps,
 
         spin_lock_bh(&priv->lock);
 
-        __pff_add(ps, priv, entry);
+        result = __pff_add(ps, priv, entry);
 
         spin_unlock_bh(&priv->lock);
 
-        return 0;
+        return result;
 }
 
 static int mp_remove(struct pff_ps *        ps,


### PR DESCRIPTION
Fixed locking in PFF policy implementations (default and multipath), as it is right now there can be soft lockups if the RMT queries pff->nhop while the pff is being updated.

Also added a pff_modify atomic operation, that updates all the entries in the PFF without releasing the PFF lock. As it is done right now, first all the PFF entries are removed, then lock released, then for each entry get lock, add entry and release lock. If a PDU queries the next hop in any intermediary step (getting the lock), it may be dropped because the PFF entry is still not there.

Maintainers: @sandervrijders, @vmaffione  