### PR TITLE
rina-tools, rinad: use size_t for string::find() result

### DIFF
--- a/rina-tools/src/common/utils.cc
+++ b/rina-tools/src/common/utils.cc
@@ -33,7 +33,7 @@
 void parse_dif_names(std::list<std::string> & dif_names, const std::string& arg)
 {
 	int i = 0;
-	unsigned int pos = arg.find(',');
+	size_t pos = arg.find(',');
 	if (pos == std::string::npos){
 		dif_names.push_back(arg);
 		return;

--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
@@ -70,7 +70,7 @@ void IPCPObj::forward_object(const rina::cdap_rib::con_handle_t& con,
        // TODO: This has to be stored in a list in case of more than
        // one consecutive request
 
-       int pos = obj_name.rfind("ipcProcessID");
+       std::size_t pos = obj_name.rfind("ipcProcessID");
        if (pos != std::string::npos)
        {
                 std::string object_sub_name = obj_name.substr(pos);


### PR DESCRIPTION
This patch fixes a bug that was causing an OOM crash in parse_dif_names(),
when the second argument was an empty string. OOM was due to the
condition (pos == std::string::npos) failing due to type mismatch,
even if it was expected to succeed.

@edugrasa 