### PR TITLE
kernel: rmt-ps-default: fix broken indentation

### DIFF
--- a/linux/net/rina/rmt-ps-default.c
+++ b/linux/net/rina/rmt-ps-default.c
@@ -330,9 +330,10 @@ void rmt_ps_default_destroy(struct ps_base *bps)
 	data = ps->priv;
 
 	if (bps) {
-		if (data)
+		if (data) {
 			robject_del(&data->robj);
 			rkfree(data);
+                }
 		rkfree(ps);
 	}
 }


### PR DESCRIPTION
This avois a possible kernel crash if "data" variable is NULL. It was also triggering a compiler warning.