### PR TITLE
rina-echo-time: do not use all CPU while reading a SDU with a timeout

### DIFF
--- a/librina/src/ipc-api.cc
+++ b/librina/src/ipc-api.cc
@@ -762,6 +762,7 @@ int IPCManager::readSDU(int portId, void * sdu, int maxBytes)
 		throw ReadSDUException();
 		break;
 	case -EAGAIN:
+	case -EINTR:
 		break;
 	default:
 		throw IPCException("Unknown error");
@@ -798,6 +799,8 @@ int IPCManager::writeSDU(int portId, void * sdu, int size)
 		break;
 	case -EAGAIN:
 		return 0;
+	case -EINTR:
+		break;
 	default:
 		throw IPCException("Unknown error");
 	}

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -481,7 +481,6 @@ int kfa_flow_sdu_write(struct ipcp_instance_data *data,
 			LOG_DBG("Write woken up (%d)", retval);
 
 			if (retval < 0) {
-				LOG_DBG("Wait-event interrupted (%d)", retval);
 				if (signal_pending(current)) {
 					LOG_DBG("A signal is pending");
 #if 0
@@ -651,11 +650,10 @@ int kfa_flow_sdu_read(struct kfa  *instance,
 			LOG_DBG("Read woken up (%d)", retval);
 
 			if (retval < 0) {
-				LOG_ERR("Wait-event interrupted (%d)", retval);
 				if (signal_pending(current)) {
-					LOG_ERR("A signal is pending");
+					LOG_DBG("A signal is pending");
 #if 0
-					LOG_ERR("Pending signal (0x%08zx%08zx)",
+					LOG_DBG("Pending signal (0x%08zx%08zx)",
 						current->pending.signal.sig[0],
 						current->pending.signal.sig[1]);
 #endif


### PR DESCRIPTION
This implements what I suggested in #1003, waiting that SDU can be read/written with posix API (like select).
This was quick enough to do, and the use of all CPU annoyed me too much, in particular in VMs.