### PR TITLE
rinad: fix segfault when enrollment fails, fix #872

### DIFF
--- a/rinad/src/ipcp/enrollment-task.h
+++ b/rinad/src/ipcp/enrollment-task.h
@@ -237,6 +237,24 @@ public:
 	std::string reason_;
 };
 
+class AbortEnrollmentTimerTask: public rina::TimerTask {
+public:
+	AbortEnrollmentTimerTask(rina::IEnrollmentTask * enr_task,
+				 const rina::ApplicationProcessNamingInformation& remotePeerNamingInfo,
+				 int portId,
+				 const std::string& reason,
+				 bool sendReleaseMessage);
+	~AbortEnrollmentTimerTask() throw() {};
+	void run();
+
+private:
+	rina::IEnrollmentTask * etask;
+	rina::ApplicationProcessNamingInformation peer_name;
+	int port_id;
+	std::string reason;
+	bool send_message;
+};
+
 class EnrollmentTask: public IPCPEnrollmentTask, public rina::InternalEventListener {
 public:
 	static const std::string ENROLL_TIMEOUT_IN_MS;


### PR DESCRIPTION
@jmuchemb could you give it a try? I've tested the case when the member IPCP doesn't know the address of the IPCP that joins (in enrollment) and works for me