### PR TITLE
Data Center TCP-like policy

### DIFF
--- a/plugins/dctcp/Makefile
+++ b/plugins/dctcp/Makefile
@@ -1,0 +1,39 @@
+#
+# Written by Francesco Salvestrini <f.salvestrini@nextworks.it>
+#
+
+ifneq ($(KERNELRELEASE),)
+
+ccflags-y = -Wtype-limits -Inet/rina
+
+obj-m := dctcp-plugin.o
+
+dctcp-plugin-y := dctcp-plugin-ps.o rmt-ps-dctcp.o dtcp-ps-dctcp.o
+
+else
+
+ifndef KDIR
+$(warning "KDIR will be set to the linux directory of the repository")
+KDIR=../../linux
+endif
+
+ifndef
+KREL=$(shell make -s -C $(KDIR) kernelrelease)
+endif
+
+all:
+	$(MAKE) -C $(KDIR) M=$$PWD
+
+clean:
+	rm -r -f *.o *.ko *.mod.c *.mod.o Module.symvers .*.cmd .tmp_versions modules.order
+
+install:
+	$(MAKE) -C $(KDIR) M=$$PWD modules_install
+	cp dctcp-plugin.manifest /lib/modules/$(KREL)/extra/
+	depmod -a
+
+uninstall:
+	@echo "This target has not been implemented yet"
+	@exit 1
+
+endif

--- a/plugins/dctcp/README.md
+++ b/plugins/dctcp/README.md
@@ -1,0 +1,38 @@
+## Data Center TCP-like policy
+
+The goal of DCTCP is to achieve high burst tolerance, low latency, and high throughput, 
+with commodity shallow buffered switches. DCTCP achieves these goals primarily by reacting 
+to congestion in proportion to the extent of congestion. DCTCP requires active queue 
+management scheme at switches.
+
+Data Center TCP-like behavior in RINA can be achieved by altering RMT and DTCP policies.
+
+### RMT DCTCP policy
+
+The DCTCP policy for RMT is simple. It is possible to configure a queue size and a threshold. 
+If queue size exceedes the threshold, the RMT starts to mark PDUs with explicit congestion 
+flag (ECN). 
+
+**Parameters that can be set:**
+You can use the following parameters to alter policy behavior.
+
+- `q_threshold:` Sets the queue threshold. If the queue size is exceeded, PDUs will be marked
+with ECN flag.
+- `q_max:` Maximal size of the queue. If exceeded, the PDU is dropped.
+
+### DTCP DCTCP policy
+The DCTCP policy for DTCP maintains an estimate of the fraction of packets that are marked 
+with ECN flag. This value is updated with every PDU according the following formula:
+
+`α ← (1−g) × α + g × F`
+
+The DCTCP policy reacts to PDUs with ECN flag set by reducing the sender’s credit size using
+the following formula:
+
+`new_credit ← new_credit × (1−α/2)`
+
+**Parameters that can be set:**
+You can use the following parameter to alter policy behavior.
+
+- `shift_g:` According the DCTCP paper, the g value should be small enough and all experiments 
+in the paper use `g = 0.0625 (1/16)`. Thus, the `shift_g = 4` is `2^4 = 16`. 

--- a/plugins/dctcp/dctcp-plugin-ps.c
+++ b/plugins/dctcp/dctcp-plugin-ps.c
@@ -1,0 +1,88 @@
+/*
+ * Data Center TCP-like plugin policy sets (RMT, DTCP)
+ *
+ *    Matej Gregr <igregr@fit.vutbr.cz>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/export.h>
+#include <linux/module.h>
+#include <linux/string.h>
+
+#define RINA_PREFIX "dctcp-plugin"
+#define RINA_DCTCP_PS_NAME "dctcp-ps"
+
+#include "logs.h"
+#include "rds/rmem.h"
+#include "rmt-ps.h"
+#include "dtcp-ps.h"
+
+extern struct ps_factory rmt_factory;
+extern struct ps_factory dtcp_factory;
+
+static int __init mod_init(void)
+{
+    int ret;
+    
+    strcpy(rmt_factory.name,  RINA_DCTCP_PS_NAME);
+    strcpy(dtcp_factory.name, RINA_DCTCP_PS_NAME);
+    
+    ret = rmt_ps_publish(&rmt_factory);
+    if (ret) {
+            LOG_ERR("Failed to publish RMT policy set factory");
+            return -1;
+    }
+    
+    LOG_INFO("RMT DCTCP policy set loaded successfully");
+    
+    ret = dtcp_ps_publish(&dtcp_factory);
+    if (ret) {
+            LOG_ERR("Failed to publish DTCP policy set factory");
+            return -1;
+    }
+    
+    LOG_INFO("DTCP DCTCP policy set loaded successfully");
+    
+    return 0;
+}
+
+static void __exit mod_exit(void)
+{
+    int ret;
+    
+    ret = rmt_ps_unpublish(RINA_DCTCP_PS_NAME);
+    if (ret) {
+            LOG_ERR("Failed to unpublish DCTCP RMT policy set factory");
+            return;
+    }
+    
+    LOG_INFO("DCTCP RMT policy set unloaded successfully");
+    
+    ret = dtcp_ps_unpublish(RINA_DCTCP_PS_NAME);
+    if (ret) {
+            LOG_ERR("Failed to unpublish DCTCP DTCP policy set factory");
+            return;
+    }
+    
+    LOG_INFO("DCTCP DTCP policy set unloaded successfully");
+}
+
+module_init(mod_init);
+module_exit(mod_exit);
+
+MODULE_AUTHOR("Matej Gregr <igregr@fit.vutbr.cz>");
+MODULE_LICENSE ("GPL");
+MODULE_DESCRIPTION("Data Center TCP-like policy sets");

--- a/plugins/dctcp/dctcp-plugin.manifest
+++ b/plugins/dctcp/dctcp-plugin.manifest
@@ -1,0 +1,16 @@
+{
+        "PluginName": "dctcp-plugin",
+        "PluginVersion": "1",
+        "PolicySets" : [
+                {
+                        "Name": "dctcp-ps",
+                        "Component": "rmt",
+                        "Version" : "1"
+                },
+                {
+                        "Name": "dctcp-ps",
+                        "Component": "dtcp",
+                        "Version" : "1"
+                }
+        ]
+}

--- a/plugins/dctcp/dtcp-ps-dctcp.c
+++ b/plugins/dctcp/dtcp-ps-dctcp.c
@@ -1,0 +1,174 @@
+/*
+ * DCTCP Policy Set for DTCP
+ *
+ *    Matej Gregr <igregr@fit.vutbr.cz>
+ *
+ * This program is free software; you can dummyistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/export.h>
+#include <linux/module.h>
+#include <linux/string.h>
+
+#define RINA_PREFIX "dctcp-dtcp-ps"
+
+#include "rds/rmem.h"
+#include "dtcp-ps.h"
+#include "logs.h"
+
+#define DEC_PRECISION 1000000
+#define DCTCP_MAX_ALPHA 1024U
+
+enum tx_state {
+    SLOW_START,
+    CONG_AVOID
+};
+
+struct dctcp_dtcp_ps_data {
+    uint_t        init_credit;
+    uint_t        sshtresh;
+    enum tx_state state;
+    uint_t        dec_credit;
+    uint_t        shift_g;
+    uint_t        sent_total;
+    uint_t        ecn_total;
+    uint_t        dctcp_alpha;
+};
+
+static int dctcp_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
+{
+    struct dtcp * dtcp = ps->dm;
+    struct dctcp_dtcp_ps_data * data = ps->priv;
+    seq_num_t new_credit;
+    uint_t alpha_old = 0; 
+    
+    new_credit = dtcp_rcvr_credit(dtcp);
+    if (data->state == SLOW_START) {
+        new_credit++;
+        if (new_credit >= data->sshtresh) {
+            data->state = CONG_AVOID;
+        }
+    } else {
+        data->dec_credit += DEC_PRECISION/new_credit;
+        if (data->dec_credit >= DEC_PRECISION) {
+            new_credit++;
+            data->dec_credit -= DEC_PRECISION;
+        }
+    }
+    data->sent_total++;
+    alpha_old = data->dctcp_alpha;
+    if ((pci_flags_get(pci) & PDU_FLAGS_EXPLICIT_CONGESTION)) {
+        data->ecn_total++;
+        /* alpha = (1-g) * alpha + g * F according DCTCP kernel patch */
+        data->dctcp_alpha = alpha_old - (alpha_old >> data->shift_g) + (data->ecn_total << (10 - data->shift_g)) / data->sent_total;  
+        new_credit = max(new_credit - ((new_credit * data->dctcp_alpha) >> 11U), 2U);
+        data->sshtresh = new_credit;
+        data->state = CONG_AVOID;
+        LOG_INFO("DCTCP DTCP: dctcp_alpha: %d, new_credit %d", data->dctcp_alpha, new_credit);
+    }
+
+    /* set the new credit */
+    dtcp_rcvr_credit_set(dtcp, new_credit);
+    update_credit_and_rt_wind_edge(dtcp, new_credit);
+    return 0;
+}
+
+static int dtcp_ps_set_policy_set_param(struct ps_base * bps, const char * name, const char * value)
+{
+    struct dtcp_ps *ps = container_of(bps, struct dtcp_ps, base);
+    struct dctcp_dtcp_ps_data *data = ps->priv;
+    int ival = 0;
+    int ret = 0;
+
+    (void) ps;
+
+    if (!name) {
+        LOG_ERR("Null parameter name");
+        return -1;
+    }
+
+    if (!value) {
+        LOG_ERR("Null parameter value");
+        return -1;
+    }
+
+    if (strcmp(name, "shift_g") == 0) {
+        ret = kstrtoint(value, 10, &ival);
+        if (!ret) {
+            data->shift_g = ival;
+        }
+    }
+
+    return 0;
+}
+static struct ps_base * dtcp_ps_dctcp_create(struct rina_component * component)
+{
+    struct dtcp * dtcp = dtcp_from_component(component);
+    struct dtcp_ps * ps = rkzalloc(sizeof(*ps), GFP_KERNEL);
+    struct dctcp_dtcp_ps_data * data = rkzalloc(sizeof(*data), GFP_KERNEL);
+
+    if (!ps || !data || !dtcp) {
+        return NULL;
+    }
+        
+    data->state = SLOW_START;
+    data->init_credit = 3;
+    data->dec_credit = 0;
+    data->sshtresh = 0XFFFFFFFF;
+    data->shift_g = 4;
+    data->sent_total = 0;
+    data->ecn_total = 0;
+    dtcp_rcvr_credit_set(dtcp, data->init_credit);
+
+    ps->base.set_policy_set_param   = dtcp_ps_set_policy_set_param;
+    ps->dm                          = dtcp;
+    ps->priv                        = data;
+    ps->flow_init                   = NULL;
+    ps->lost_control_pdu            = NULL;
+    ps->rtt_estimator               = NULL;
+    ps->retransmission_timer_expiry = NULL;
+    ps->received_retransmission     = NULL;
+    ps->sender_ack                  = NULL;
+    ps->sending_ack                 = NULL;
+    ps->receiving_ack_list          = NULL;
+    ps->initial_rate                = NULL;
+    ps->receiving_flow_control      = NULL;
+    ps->update_credit               = NULL;
+    ps->rcvr_ack                    = NULL;
+    ps->rcvr_flow_control           = dctcp_rcvr_flow_control;
+    ps->rate_reduction              = NULL;
+    ps->rcvr_control_ack            = NULL;
+    ps->no_rate_slow_down           = NULL;
+    ps->no_override_default_peak    = NULL;
+
+    LOG_INFO("DCTCP DTCP policy created, shift_g value is %d", data->shift_g);
+
+    return &ps->base;
+}
+
+static void dtcp_ps_dctcp_destroy(struct ps_base * bps)
+{
+    struct dtcp_ps *ps = container_of(bps, struct dtcp_ps, base);
+
+    if (bps) {
+        rkfree(ps);
+    }
+}
+
+struct ps_factory dtcp_factory = {
+    .owner   = THIS_MODULE,
+    .create  = dtcp_ps_dctcp_create,
+    .destroy = dtcp_ps_dctcp_destroy,
+};

--- a/plugins/dctcp/rmt-ps-dctcp.c
+++ b/plugins/dctcp/rmt-ps-dctcp.c
@@ -1,0 +1,295 @@
+/*
+ * DCTCP RMT PS
+ *
+ *    Matej Gregr <igregr@fit.vutbr.cz>
+ *
+ * This program is free software; you can dummyistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/export.h>
+#include <linux/module.h>
+#include <linux/string.h>
+
+#define RINA_PREFIX "dctcp-rmt-ps"
+
+#include "logs.h"
+#include "rds/rmem.h"
+#include "rmt-ps.h"
+#include "policies.h"
+
+#define DEFAULT_Q_THRESHOLD 20
+#define DEFAULT_Q_MAX 200
+
+struct dctcp_rmt_ps_data {
+    /* Threshold after that we will begin to mark packets. */
+    unsigned int q_threshold;
+    /* Max length of a queue. */
+    unsigned int q_max;
+};
+
+struct dctcp_rmt_queue {
+        struct rfifo*  queue;
+        port_id_t      port_id;
+};
+
+static struct dctcp_rmt_queue* dctcp_queue_create(port_id_t port_id)
+{
+    struct dctcp_rmt_queue* tmp;
+
+    tmp = rkzalloc(sizeof(*tmp), GFP_ATOMIC);
+    if (!tmp) {
+        return NULL;
+    }
+        
+    tmp->queue = rfifo_create_ni();
+    if (!tmp->queue) {
+        rkfree(tmp);
+        return NULL;
+    }
+    tmp->port_id = port_id;
+
+    return tmp;
+}
+
+static int dctcp_rmt_queue_destroy(struct dctcp_rmt_queue *q)
+{
+    if (!q) {
+        LOG_ERR("No DCTCP RMT Key-queue to destroy...");
+        return -1;
+    }
+    if (q->queue) rfifo_destroy(q->queue, (void (*)(void *)) pdu_destroy);
+ 
+    rkfree(q);
+ 
+    return 0;
+}
+
+static void * dctcp_rmt_q_create_policy(struct rmt_ps *ps, struct rmt_n1_port *port)
+{
+    struct dctcp_rmt_queue     *q;
+    struct dctcp_rmt_ps_data   *data;
+
+    if (!ps || !port || !ps->priv) {
+        LOG_ERR("DCTCP RMT: Wrong input parameters for dctcp_rmt_scheduling_create_policy");
+        return NULL;
+    }
+
+    data = ps->priv;
+
+    q = dctcp_queue_create(port->port_id);
+    if (!q) {
+        LOG_ERR("DCTCP RMT: Could not create queue for n1_port %u", port->port_id);
+        return NULL;
+    }
+
+    LOG_DBG("DCTCP RMT: Structures for scheduling policies created...");
+    return q;
+}
+
+static int dctcp_rmt_q_destroy_policy(struct rmt_ps *ps, struct rmt_n1_port *port)
+{
+    struct dctcp_rmt_queue    *q;
+
+    if (!ps || !port) {
+        LOG_ERR("DCTCP RMT: Wrong input parameters for dctcp_rmt_scheduling_destroy_policy");
+        return -1;
+    }
+
+    q = port->rmt_ps_queues;
+    if (q) {
+        return dctcp_rmt_queue_destroy(q);
+    }
+
+    return -1;
+}
+
+static int dctcp_rmt_enqueue_policy(struct rmt_ps *ps, struct rmt_n1_port *port, struct pdu *pdu)
+{
+    struct dctcp_rmt_queue    *q;
+    struct dctcp_rmt_ps_data  *data = ps->priv;
+    unsigned int qlen;
+
+    if (!ps || !port || !pdu || !data) {
+        LOG_ERR("DCTCP RMT: Wrong input parameters for dctcp_enqueu_scheduling_policy_tx");
+        return RMT_PS_ENQ_ERR;
+    }
+
+    q = port->rmt_ps_queues;
+    if (!q) {
+        LOG_ERR("DCTCP RMT: Could not find queue for n1_port %u", port->port_id);
+        pdu_destroy(pdu);
+        return RMT_PS_ENQ_ERR;
+    }
+
+    qlen = rfifo_length(q->queue);
+    if(qlen >= data->q_max) {
+        if(pci_type(pdu_pci_get_ro(pdu)) != PDU_TYPE_MGMT) {
+            pdu_destroy(pdu);
+            LOG_INFO("DCTCP RMT: PDU dropped, q_max reached...");
+            return RMT_PS_ENQ_DROP;
+        }
+    }
+
+    LOG_INFO("DCTCP RMT: PDU enqued...");
+    rfifo_push_ni(q->queue, pdu);
+    return RMT_PS_ENQ_SCHED;
+}
+
+static struct pdu * dctcp_rmt_dequeue_policy(struct rmt_ps *ps, struct rmt_n1_port *port)
+{
+    struct dctcp_rmt_queue    *q;
+    struct dctcp_rmt_ps_data  *data = ps->priv;
+    struct pdu *ret_pdu;
+    struct pci *pci;
+    unsigned long pci_flags;
+    unsigned int qlen;
+
+    if (!ps || !port || !data) {
+        LOG_ERR("Wrong input parameters for red_rmt_dequeue_policy");
+        return NULL;
+    }
+
+    q = port->rmt_ps_queues;
+    if (!q) {
+        LOG_ERR("Could not find queue for n1_port %u", port->port_id);
+        return NULL;
+    }
+
+    qlen = rfifo_length(q->queue);
+    ret_pdu = rfifo_pop(q->queue);
+    LOG_DBG("DCTCP RMT: PDU dequed...");
+
+    if (!ret_pdu) {
+        LOG_ERR("Could not dequeue scheduled pdu");
+    }
+
+    if (qlen >= data->q_threshold) {
+        LOG_INFO("DCTCP RMT: Marking");
+        /* mark ECN bit */
+        pci = pdu_pci_get_rw(ret_pdu);
+        pci_flags = pci_flags_get(pci);
+        pci_flags_set(pci, pci_flags |= PDU_FLAGS_EXPLICIT_CONGESTION);
+    }
+
+    return ret_pdu;
+}
+
+static int dctcp_rmt_ps_set_policy_set_param(struct ps_base *bps, const char *name, const char *value)
+{
+    struct rmt_ps *ps = container_of(bps, struct rmt_ps, base);
+    struct dctcp_rmt_ps_data *data = ps->priv;
+    int ival;
+    int ret;
+
+    (void) ps;
+
+    if (!name) {
+        LOG_ERR("Null parameter name");
+        return -1;
+    }
+
+    if (!value) {
+        LOG_ERR("Null parameter value");
+        return -1;
+    }
+    if (strcmp(name, "q_threshold") == 0) {
+        ret = kstrtoint(value, 10, &ival);
+    if (!ret) {
+    data->q_threshold = ival;
+        }
+    }
+
+    if (strcmp(name, "q_max") == 0) {
+        ret = kstrtoint(value, 10, &ival);
+        if (!ret) {
+            data->q_max = ival;
+        }
+    }
+
+    return 0;
+}
+
+static int rmt_ps_load_param(struct rmt_ps *ps, const char *param_name)
+{
+    struct rmt_config * rmt_cfg;
+    struct policy_parm * ps_param;
+
+    rmt_cfg = rmt_config_get(ps->dm);
+
+    if (rmt_cfg) {
+        ps_param = policy_param_find(rmt_cfg->policy_set, param_name);
+    } else {
+        ps_param = NULL;
+    }
+
+    if (!ps_param) {
+        LOG_WARN("DCTCP RMT: No PS param %s specified", param_name);
+    } else {
+        dctcp_rmt_ps_set_policy_set_param(&ps->base, policy_param_name(ps_param), policy_param_value(ps_param));
+    }
+
+    return 0;
+}
+static struct ps_base * rmt_ps_dctcp_create(struct rina_component *component)
+{
+    struct rmt *rmt = rmt_from_component(component);
+    struct rmt_ps *ps = rkzalloc(sizeof(*ps), GFP_KERNEL);
+    struct dctcp_rmt_ps_data *data;
+
+    if (!ps) {
+        return NULL;
+    }
+
+    data = rkzalloc(sizeof(*data), GFP_KERNEL);
+    if (!data) {
+        kfree(ps);
+        return NULL;
+    }
+    ps->base.set_policy_set_param = dctcp_rmt_ps_set_policy_set_param;
+    ps->dm = rmt;
+    ps->priv = data;
+
+    // set defaults
+    data->q_max = DEFAULT_Q_MAX;    
+    data->q_threshold = DEFAULT_Q_THRESHOLD;    
+
+    //load configuration if available
+    rmt_ps_load_param(ps, "q_threshold");
+    rmt_ps_load_param(ps, "q_max");
+    
+    ps->rmt_q_create_policy = dctcp_rmt_q_create_policy;
+    ps->rmt_q_destroy_policy = dctcp_rmt_q_destroy_policy;
+    ps->rmt_enqueue_policy = dctcp_rmt_enqueue_policy;
+    ps->rmt_dequeue_policy = dctcp_rmt_dequeue_policy;
+
+    LOG_INFO("DCTCP RMT: PS loaded, q_max = %d, q_threshold = %d", data->q_max, data->q_threshold);
+
+    return &ps->base;
+}
+
+static void rmt_ps_dctcp_destroy(struct ps_base *bps)
+{
+    struct rmt_ps *ps = container_of(bps, struct rmt_ps, base);
+
+    if (bps) {
+        rkfree(ps);
+    }
+}
+
+struct ps_factory rmt_factory = {
+    .owner     = THIS_MODULE,
+    .create  = rmt_ps_dctcp_create,
+    .destroy = rmt_ps_dctcp_destroy,
+};


### PR DESCRIPTION
Data Center policies for RMT and DTCP. These policies mimic the DCTCP behavior described in DCTCP paper in IRATI. Resolves #862 
