### PR TITLE
Pristine 1.5: partition FlowStateObject update in different messages

### DIFF
--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -1249,9 +1249,9 @@ void FlowStateObjects::encodeAllFSOs(rina::ser_obj_t& obj)
 	}
 }
 
-void FlowStateObjects::getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos)
+void FlowStateObjects::getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos,
+						unsigned int max_objects)
 {
-	int max_size = 15;
 	rina::ScopedLock g(lock);
 	std::list<FlowStateObject> fsolist;
 
@@ -1261,7 +1261,7 @@ void FlowStateObjects::getAllFSOsForPropagation(std::list< std::list<FlowStateOb
 	for (std::map<std::string, FlowStateObject*>::iterator it
 			= objects.begin(); it != objects.end();++it)
 	{
-		if (fsolist.size() == max_size) {
+		if (fsolist.size() == max_objects) {
 			fsos.push_back(fsolist);
 			fsolist.clear();
 		}
@@ -1416,10 +1416,9 @@ void FlowStateManager::updateObjects(const std::list<FlowStateObject>& newObject
 	}
 }
 
-void FlowStateManager::prepareForPropagation(
-	std::map<int, std::list< std::list<FlowStateObject> > >&  to_propagate) const
+void FlowStateManager::prepareForPropagation(std::map<int, std::list< std::list<FlowStateObject> > >&  to_propagate,
+					     unsigned int max_objects) const
 {
-	int max_size = 15;
 	std::list<FlowStateObject> newfsolist;
 	bool added = false;
 
@@ -1446,7 +1445,7 @@ void FlowStateManager::prepareForPropagation(
 
 				for(std::list< std::list<FlowStateObject> >::iterator it3 = it2->second.begin();
 						it3 != it2->second.end(); ++it3) {
-					if (it3->size() < max_size) {
+					if (it3->size() < max_objects) {
 						it3->push_back(**it);
 						added = true;
 						break;
@@ -1480,9 +1479,10 @@ void FlowStateManager::getAllFSOs(std::list<FlowStateObject>& list) const
 	fsos->getAllFSOs(list);
 }
 
-void FlowStateManager::getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsolist)
+void FlowStateManager::getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsolist,
+						unsigned int max_objects)
 {
-	fsos->getAllFSOsForPropagation(fsolist);
+	fsos->getAllFSOsForPropagation(fsolist, max_objects);
 }
 
 void FlowStateManager::deprecateObjectsNeighbor(unsigned int neigh_address,
@@ -1575,6 +1575,7 @@ const std::string LinkStateRoutingPolicy::ROUTING_ALGORITHM = "routingAlgorithm"
 const int LinkStateRoutingPolicy::MAXIMUM_BUFFER_SIZE = 4096;
 const std::string LinkStateRoutingPolicy::DIJKSTRA_ALG = "Dijkstra";
 const std::string LinkStateRoutingPolicy::ECMP_DIJKSTRA_ALG = "ECMPDijkstra";
+const std::string LinkStateRoutingPolicy::MAXIMUM_OBJECTS_PER_ROUTING_UPDATE = "maxObjectsPerUpdate";
 
 LinkStateRoutingPolicy::LinkStateRoutingPolicy(IPCProcess * ipcp)
 {
@@ -1585,6 +1586,7 @@ LinkStateRoutingPolicy::LinkStateRoutingPolicy(IPCProcess * ipcp)
 	resiliency_algorithm_ = 0;
 	source_vertex_ = 0;
 	db_ = 0;
+	max_objects_per_rupdate_ = MAX_OBJECTS_PER_ROUTING_UPDATE_DEFAULT;
 
 	subscribeToEvents();
 	timer_ = new rina::Timer();
@@ -1677,6 +1679,13 @@ void LinkStateRoutingPolicy::set_dif_configuration(
 		PropagateFSODBTimerTask * pfttask = new PropagateFSODBTimerTask(this,
 				delay);
 		timer_->scheduleTask(pfttask, delay);
+
+		// Task to increment age
+		try {
+			max_objects_per_rupdate_ = psconf.get_param_value_as_uint(MAXIMUM_OBJECTS_PER_ROUTING_UPDATE);
+		} catch (rina::Exception &e) {
+			max_objects_per_rupdate_ = MAX_OBJECTS_PER_ROUTING_UPDATE_DEFAULT;
+		}
 	}
 
 }
@@ -1781,7 +1790,7 @@ void LinkStateRoutingPolicy::processNeighborAddedEvent(
 
 	std::list< std::list<FlowStateObject> > all_fsos;
 	FlowStateObjectListEncoder encoder;
-	db_->getAllFSOsForPropagation(all_fsos);
+	db_->getAllFSOsForPropagation(all_fsos, max_objects_per_rupdate_);
 	for (std::list< std::list<FlowStateObject> >::iterator it = all_fsos.begin();
 			it != all_fsos.end(); ++it) {
 		try {
@@ -1822,7 +1831,7 @@ void LinkStateRoutingPolicy::propagateFSDB()
 	}
 
 	//3 Get the objects to send
-	db_->prepareForPropagation(objectsToSend);
+	db_->prepareForPropagation(objectsToSend, max_objects_per_rupdate_);
 
 	if (objectsToSend.size() == 0) {
 		return;

--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -1249,6 +1249,31 @@ void FlowStateObjects::encodeAllFSOs(rina::ser_obj_t& obj)
 	}
 }
 
+void FlowStateObjects::getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos)
+{
+	int max_size = 15;
+	rina::ScopedLock g(lock);
+	std::list<FlowStateObject> fsolist;
+
+	if (objects.empty())
+		return;
+
+	for (std::map<std::string, FlowStateObject*>::iterator it
+			= objects.begin(); it != objects.end();++it)
+	{
+		if (fsolist.size() == max_size) {
+			fsos.push_back(fsolist);
+			fsolist.clear();
+		}
+
+		fsolist.push_back(*(it->second));
+	}
+
+	if (fsolist.size() != 0) {
+		fsos.push_back(fsolist);
+	}
+}
+
 bool FlowStateObjects::is_modified() const
 {
 	return modified_;
@@ -1392,8 +1417,12 @@ void FlowStateManager::updateObjects(const std::list<FlowStateObject>& newObject
 }
 
 void FlowStateManager::prepareForPropagation(
-	std::map<int, std::list<FlowStateObject> >&  to_propagate) const
+	std::map<int, std::list< std::list<FlowStateObject> > >&  to_propagate) const
 {
+	int max_size = 15;
+	std::list<FlowStateObject> newfsolist;
+	bool added = false;
+
 	//1 Get the FSOs to propagate
 	std::list<FlowStateObject *> modifiedFSOs;
 	fsos->getModifiedFSOs(modifiedFSOs);
@@ -1407,14 +1436,30 @@ void FlowStateManager::prepareForPropagation(
 			(*it)->get_age(),
 			(*it)->is_state());
 
-		for(std::map<int, std::list<FlowStateObject> >::iterator it2 =
+		for(std::map<int, std::list< std::list<FlowStateObject> > >::iterator it2 =
 				to_propagate.begin(); it2 != to_propagate.end(); ++it2)
 		{
 			if(it2->first != (*it)->get_avoidport())
 			{
-				it2->second.push_back(**it);
+				added = false;
+				newfsolist.clear();
+
+				for(std::list< std::list<FlowStateObject> >::iterator it3 = it2->second.begin();
+						it3 != it2->second.end(); ++it3) {
+					if (it3->size() < max_size) {
+						it3->push_back(**it);
+						added = true;
+						break;
+					}
+				}
+
+				if (!added) {
+					newfsolist.push_back(**it);
+					it2->second.push_back(newfsolist);
+				}
 			}
 		}
+
 		(*it)->has_modified(false);
 		(*it)->set_avoidport(NO_AVOID_PORT);
 	}
@@ -1433,6 +1478,11 @@ void FlowStateManager::set_maximum_age(unsigned int max_age)
 void FlowStateManager::getAllFSOs(std::list<FlowStateObject>& list) const
 {
 	fsos->getAllFSOs(list);
+}
+
+void FlowStateManager::getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsolist)
+{
+	fsos->getAllFSOsForPropagation(fsolist);
 }
 
 void FlowStateManager::deprecateObjectsNeighbor(unsigned int neigh_address,
@@ -1729,24 +1779,30 @@ void LinkStateRoutingPolicy::processNeighborAddedEvent(
 		}
 	}
 
-	try {
-		rina::cdap_rib::obj_info_t obj;
-		rina::cdap_rib::con_handle_t con;
-		obj.class_ = FlowStateRIBObjects::clazz_name;
-		obj.name_ = FlowStateRIBObjects::object_name;
-		db_->encodeAllFSOs(obj.value_);
-		obj.inst_ = 0;
-		rina::cdap_rib::flags_t flags;
-		rina::cdap_rib::filt_info_t filt;
-		con.port_id = portId;
-		if (obj.value_.size_ != 0)
-			rib_daemon_->getProxy()->remote_write(con,
-							      obj,
-							      flags,
-							      filt,
-							      0);
-	} catch (rina::Exception &e) {
-		LOG_IPCP_ERR("Problems encoding and sending CDAP message: %s", e.what());
+	std::list< std::list<FlowStateObject> > all_fsos;
+	FlowStateObjectListEncoder encoder;
+	db_->getAllFSOsForPropagation(all_fsos);
+	for (std::list< std::list<FlowStateObject> >::iterator it = all_fsos.begin();
+			it != all_fsos.end(); ++it) {
+		try {
+			rina::cdap_rib::obj_info_t obj;
+			rina::cdap_rib::con_handle_t con;
+			obj.class_ = FlowStateRIBObjects::clazz_name;
+			obj.name_ = FlowStateRIBObjects::object_name;
+			encoder.encode(*it, obj.value_);
+			obj.inst_ = 0;
+			rina::cdap_rib::flags_t flags;
+			rina::cdap_rib::filt_info_t filt;
+			con.port_id = portId;
+			if (obj.value_.size_ != 0)
+				rib_daemon_->getProxy()->remote_write(con,
+						obj,
+						flags,
+						filt,
+						0);
+		} catch (rina::Exception &e) {
+			LOG_IPCP_ERR("Problems encoding and sending CDAP message: %s", e.what());
+		}
 	}
 }
 
@@ -1758,11 +1814,11 @@ void LinkStateRoutingPolicy::propagateFSDB()
 	std::list<rina::FlowInformation> nMinusOneFlows =
 			ipc_process_->resource_allocator_->get_n_minus_one_flow_manager()->getAllNMinusOneFlowInformation();
 	//2 Initilize the map
-	std::map <int, std::list<FlowStateObject> > objectsToSend;
+	std::map <int, std::list< std::list<FlowStateObject> > > objectsToSend;
 	for(std::list<rina::FlowInformation>::iterator it = nMinusOneFlows.begin();
 		it != nMinusOneFlows.end(); ++it) 
 	{
-		objectsToSend[it->portId] = std::list<FlowStateObject>();
+		objectsToSend[it->portId] = std::list< std::list<FlowStateObject> >();
 	}
 
 	//3 Get the objects to send
@@ -1774,31 +1830,34 @@ void LinkStateRoutingPolicy::propagateFSDB()
 
 	FlowStateObjectListEncoder encoder;
 	rina::cdap_rib::con_handle_t con;
-	for (std::map<int, std::list<FlowStateObject> >::iterator it = objectsToSend.begin();
+	for (std::map<int, std::list< std::list<FlowStateObject> > >::iterator it = objectsToSend.begin();
 		it != objectsToSend.end(); ++it)
 
 	{
 		if (it->second.size() == 0)
 			continue;
 
-		rina::cdap_rib::flags flags;
-		rina::cdap_rib::filt_info_t filter;
-		try
-		{
-			rina::cdap_rib::object_info obj;
-			obj.class_ = FlowStateRIBObjects::clazz_name;
-			obj.name_ = FlowStateRIBObjects::object_name;
-			encoder.encode(it->second, obj.value_);
-			con.port_id = it->first;
-			rib_daemon_->getProxy()->remote_write(con,
-							      obj,
-							      flags,
-							      filter,
-							      0);
-		}
-		catch (rina::Exception &e) 
-		{
-			LOG_IPCP_ERR("Errors sending message: %s", e.what());
+		for (std::list< std::list<FlowStateObject> >::iterator it2 = it->second.begin();
+				it2 != it->second.end(); ++it2) {
+			rina::cdap_rib::flags flags;
+			rina::cdap_rib::filt_info_t filter;
+			try
+			{
+				rina::cdap_rib::object_info obj;
+				obj.class_ = FlowStateRIBObjects::clazz_name;
+				obj.name_ = FlowStateRIBObjects::object_name;
+				encoder.encode(*it2, obj.value_);
+				con.port_id = it->first;
+				rib_daemon_->getProxy()->remote_write(con,
+						obj,
+						flags,
+						filter,
+						0);
+			}
+			catch (rina::Exception &e)
+			{
+				LOG_IPCP_ERR("Errors sending message: %s", e.what());
+			}
 		}
 	}
 }

--- a/rinad/src/ipcp/plugins/default/routing-ps.h
+++ b/rinad/src/ipcp/plugins/default/routing-ps.h
@@ -379,7 +379,8 @@ public:
 	void updateObject(const std::string& fqn, 
 			  unsigned int avoid_port);
 	void encodeAllFSOs(rina::ser_obj_t& obj);
-	void getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos);
+	void getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos,
+				      unsigned int max_objects);
 	bool is_modified() const;
 	void has_modified(bool modified);
 private:
@@ -457,11 +458,13 @@ public:
 	void updateObjects(const std::list<FlowStateObject>& newObjects,
 			   unsigned int avoidPort,
 			   unsigned int address);
-	void prepareForPropagation(std::map<int, std::list< std::list<FlowStateObject> > >& to_propagate) const;
+	void prepareForPropagation(std::map<int, std::list< std::list<FlowStateObject> > >& to_propagate,
+				   unsigned int max_objects) const;
 	void encodeAllFSOs(rina::ser_obj_t& obj) const;
 	void getAllFSOs(std::list<FlowStateObject>& list) const;
 	bool tableUpdate() const;
-	void getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos);
+	void getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos,
+				      unsigned int max_objects);
 
 	// accessors
 	void set_maximum_age(unsigned int max_age);
@@ -534,6 +537,7 @@ public:
 	static const std::string WAIT_UNTIL_FSODB_PROPAGATION;
 	static const std::string WAIT_UNTIL_AGE_INCREMENT;
 	static const std::string ROUTING_ALGORITHM;
+	static const std::string MAXIMUM_OBJECTS_PER_ROUTING_UPDATE;
 
         static const int PULSES_UNTIL_FSO_EXPIRATION_DEFAULT = 100000;
         static const int WAIT_UNTIL_READ_CDAP_DEFAULT = 5001;
@@ -541,6 +545,7 @@ public:
         static const int WAIT_UNTIL_PDUFT_COMPUTATION_DEFAULT = 103;
         static const int WAIT_UNTIL_FSODB_PROPAGATION_DEFAULT = 101;
         static const int WAIT_UNTIL_AGE_INCREMENT_DEFAULT = 997;
+        static const unsigned int MAX_OBJECTS_PER_ROUTING_UPDATE_DEFAULT = 15;
         static const std::string DIJKSTRA_ALG;
         static const std::string ECMP_DIJKSTRA_ALG;
 
@@ -588,6 +593,7 @@ private:
 	IResiliencyAlgorithm * resiliency_algorithm_;
 	unsigned int source_vertex_;
 	unsigned int maximum_age_;
+	unsigned int max_objects_per_rupdate_;
 	bool test_;
 	FlowStateManager *db_;
 	rina::Lockable lock_;

--- a/rinad/src/ipcp/plugins/default/routing-ps.h
+++ b/rinad/src/ipcp/plugins/default/routing-ps.h
@@ -379,6 +379,7 @@ public:
 	void updateObject(const std::string& fqn, 
 			  unsigned int avoid_port);
 	void encodeAllFSOs(rina::ser_obj_t& obj);
+	void getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos);
 	bool is_modified() const;
 	void has_modified(bool modified);
 private:
@@ -451,16 +452,16 @@ public:
 	void deprecateObject(std::string fqn);
 	void deprecateObjectsNeighbor(unsigned int neigh_address,
 	                              unsigned int address);
-	std::map <int, std::list<FlowStateObject*> > prepareForPropagation
-	        (const std::list<rina::FlowInformation>& flows);
+	std::map <int, std::list<FlowStateObject*> > prepareForPropagation(const std::list<rina::FlowInformation>& flows);
 	void incrementAge();
 	void updateObjects(const std::list<FlowStateObject>& newObjects,
 			   unsigned int avoidPort,
 			   unsigned int address);
-	void prepareForPropagation(std::map<int, std::list<FlowStateObject> >& to_propagate) const;
+	void prepareForPropagation(std::map<int, std::list< std::list<FlowStateObject> > >& to_propagate) const;
 	void encodeAllFSOs(rina::ser_obj_t& obj) const;
 	void getAllFSOs(std::list<FlowStateObject>& list) const;
 	bool tableUpdate() const;
+	void getAllFSOsForPropagation(std::list< std::list<FlowStateObject> >& fsos);
 
 	// accessors
 	void set_maximum_age(unsigned int max_age);


### PR DESCRIPTION
So that they are not too large to be sent through the N-1 DIF. This is a workaround until fragmentation/reassembly is implemented.