### PR TITLE
librina: fixed tests

### DIFF
--- a/librina/test/test-rib_v2.cc
+++ b/librina/test/test-rib_v2.cc
@@ -369,8 +369,10 @@ public:
 	virtual ~MyDelegationObj(void) throw() {};
 
         void forward_object(const rina::cdap_rib::con_handle_t& con,
+                            rina::cdap::cdap_m_t::Opcode op_code,
                             const std::string obj_name,
                             const std::string obj_class,
+                            const ser_obj_t &obj_value,
                             const rina::cdap_rib::flags_t &flags,
                             const rina::cdap_rib::filt_info_t &filt,
                             int invoke_id) {};


### PR DESCRIPTION
This fixes:
```
g++ -DHAVE_CONFIG_H -I. -I../src  -I../include -I/usr/include/libnl3  -I/usr/include/libnl3   -I../src -D_FORTIFY_SOURCE=2 -Wall -Wformat -Wnon-virtual-dtor -Woverloaded-virtual -Werror -Wfatal-errors -Wno-unused-variable -Wno-unused-parameter -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -c -o test_rib_v2-test-rib_v2.o `test -f 'test-rib_v2.cc' || echo './'`test-rib_v2.cc
In file included from ../include/librina/irm.h:29:0,
                 from ../include/librina/enrollment.h:30,
                 from ../include/librina/ipc-process.h:34,
                 from test-rib_v2.cc:30:
../include/librina/rib_v2.h:486:15: error: 'virtual void rina::rib::DelegationObj::forward_object(const con_handle_t&, rina::cdap::CDAPMessage::Opcode, std::string, std::string, const ser_obj_t&, const flags_t&, const filt_info_t&, int)' was hidden [-Werror=overloaded-virtual]
  virtual void forward_object(const rina::cdap_rib::con_handle_t& con,
               ^
compilation terminated due to -Wfatal-errors.
```