### PR TITLE
Pristine 1.5 Solve #1033

### DIFF
--- a/librina/src/concurrency.cc
+++ b/librina/src/concurrency.cc
@@ -21,6 +21,7 @@
 //
 
 #include <cerrno>
+#include <pthread.h>
 #include <unistd.h>
 
 #define RINA_PREFIX "librina.concurrency"

--- a/librina/src/core.cc
+++ b/librina/src/core.cc
@@ -560,6 +560,7 @@ void RINAManager::initialize()
   //3 Start Netlink message reader thread
   ThreadAttributes threadAttributes;
   threadAttributes.setJoinable();
+  threadAttributes.setName("netlink-message-reader");
   netlinkMessageReader = new Thread(&doNetlinkMessageReaderWork,
 		  	  	    (void *) this,
 		  	  	    &threadAttributes);

--- a/librina/src/timer.cc
+++ b/librina/src/timer.cc
@@ -108,6 +108,7 @@ void TaskScheduler::runTasks() {
 			try {
 				ThreadAttributes threadAttributes;
 				threadAttributes.setDettached();
+				threadAttributes.setName("timer_task");
 				Thread *t = new Thread(&doWorkTask,
 						       (void *) (*iter_list),
 						       &threadAttributes);

--- a/rina-tools/src/cdapc/unittests.cc
+++ b/rina-tools/src/cdapc/unittests.cc
@@ -26,7 +26,22 @@
 // SUCH DAMAGE.
 //
 
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include "catch.h"
 
+
+/* Define our own main to ignore --version argument passed by make-check and
+ * make it pass when install-user-from-scratch script calls it */
+int
+main(int argc, char** argv)
+{
+	Catch::Session session;
+	if(strcmp (argv[1], "--version") == 0){
+		Catch::Version libraryVersion( 1, 5, 6, "", 0 );
+		Catch::cout() << "\nCatch v" << libraryVersion << "\n";
+		return 0;
+	}
+	session.applyCommandLine(argc, argv);
+	return session.run();
+}
 // more to add later.

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -162,6 +162,7 @@ IPCMConsole::IPCMConsole(const std::string& socket_path_) :
 
 	keep_on_running = true;
 	rina::ThreadAttributes ta;
+	ta.setName("mgmt-console");
 	worker = new rina::Thread(console_function, this, &ta);
 	worker->start();
 }

--- a/rinad/src/ipcm/dif-template-manager.cc
+++ b/rinad/src/ipcm/dif-template-manager.cc
@@ -207,6 +207,7 @@ DIFTemplateManager::DIFTemplateManager(const std::string& folder,
 	//Create a thread that monitors the DIF template folder when required
 	rina::ThreadAttributes thread_attrs;
 	thread_attrs.setJoinable();
+	thread_attrs.setName("dif-config-folder-monitor");
 	monitor = new DIFConfigFolderMonitor(&thread_attrs,
 					     folder_name,
 					     this,

--- a/rinad/src/ipcp/enrollment-task.cc
+++ b/rinad/src/ipcp/enrollment-task.cc
@@ -737,6 +737,7 @@ void EnrollmentTask::set_dif_configuration(const rina::DIFConfiguration& dif_con
 	if (neigh_enroll_per_ms_ > 0) {
 		rina::ThreadAttributes * threadAttributes = new rina::ThreadAttributes();
 		threadAttributes->setJoinable();
+		threadAttributes->setName("neighbor-enroller");
 		neighbors_enroller_ = new rina::Thread(&doNeighborsEnrollerWork,
 						      (void *) ipcp,
 						      threadAttributes);

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -281,6 +281,7 @@ void IPCProcessImpl::processAssignToDIFResponseEvent(const rina::AssignToDIFResp
 
 	rina::ThreadAttributes threadAttributes;
 	threadAttributes.setJoinable();
+	threadAttributes.setName("sysfs-sync");
 	kernel_sync = new KernelSyncTrigger(&threadAttributes, this, 4000);
 	kernel_sync->start();
 

--- a/rinad/src/ipcp/rib-daemon.cc
+++ b/rinad/src/ipcp/rib-daemon.cc
@@ -533,6 +533,7 @@ void IPCPRIBDaemonImpl::set_application_process(rina::ApplicationProcess * ap)
 
         rina::ThreadAttributes * threadAttributes = new rina::ThreadAttributes();
         threadAttributes->setJoinable();
+        threadAttributes->setName("mgmt-sdu-reader");
         ManagementSDUReaderData * data = new ManagementSDUReaderData(max_sdu_size_in_bytes);
         management_sdu_reader_ = new rina::Thread(&doManagementSDUReaderWork,
         					  (void *) data,


### PR DESCRIPTION
using install-user-from-scratch fails in rina-tools/src/cadapc because the resulting binary unittests does not have the --version argument.

This pull request solves #1033 