### PR TITLE
rinad: fixed bug in Neighbors RIB object

### DIFF
--- a/rina-tools/src/cdapc/dmsworker.cc
+++ b/rina-tools/src/cdapc/dmsworker.cc
@@ -212,6 +212,7 @@ void DMSWorker::process_value(CDAPMessage & cdap_message)
 			// We might have something to do
 			string type = value.typeval();
 			LOG_INFO("Type is:[%s]", type.c_str());
+			LOG_INFO("Value is:[%s]", value.jsonval().c_str());
 			//const DescriptorPool* dp = DescriptorPool::generated_pool();
 
 			if (type == "rina.messages.ipcp_config_t") {


### PR DESCRIPTION
Preventing a segfault when the Manager sends a CREATE CDAP operation on the neighbors RIB object of an IPCP.