### PR TITLE
librina: ipc-api: fix include for ioctl()

### DIFF
--- a/librina/src/ipc-api.cc
+++ b/librina/src/ipc-api.cc
@@ -25,7 +25,7 @@
 #include <errno.h>
 #include <stdexcept>
 #include <fcntl.h>
-#include <stropts.h>
+#include <sys/ioctl.h>
 
 #define RINA_PREFIX "librina.ipc-api"
 


### PR DESCRIPTION
Simple fix required to build with buildroot