### PR TITLE
Use eventfd as a control device

### DIFF
--- a/librina/src/common.cc
+++ b/librina/src/common.cc
@@ -738,7 +738,13 @@ IPCEvent * IPCEventProducer::eventPoll()
 #if STUB_API
 	return getIPCEvent();
 #else
-	return rinaManager->getEventQueue()->poll();
+	IPCEvent * event = rinaManager->getEventQueue()->poll();
+
+	if (event) {
+		rinaManager->eventQueuePopped();
+	}
+
+	return event;
 #endif
 }
 
@@ -747,7 +753,13 @@ IPCEvent * IPCEventProducer::eventWait()
 #if STUB_API
 	return getIPCEvent();
 #else
-	return rinaManager->getEventQueue()->take();
+	IPCEvent *event = rinaManager->getEventQueue()->take();
+
+	if (event) {
+		rinaManager->eventQueuePopped();
+	}
+
+	return event;
 #endif
 }
 
@@ -757,7 +769,13 @@ IPCEvent * IPCEventProducer::eventTimedWait(int seconds,
 #if STUB_API
 	return getIPCEvent();
 #else
-	return rinaManager->getEventQueue()->timedtake(seconds, nanoseconds);
+	IPCEvent * event = rinaManager->getEventQueue()->timedtake(seconds,
+								nanoseconds);
+	if (event) {
+		rinaManager->eventQueuePopped();
+	}
+
+	return event;
 #endif
 }
 

--- a/librina/src/core.cc
+++ b/librina/src/core.cc
@@ -495,6 +495,7 @@ void * doNetlinkMessageReaderWork(void * arg)
       event = myRINAManager->osProcessFinalized(message->getPortId());
       if (event) {
         eventsQueue->put(event);
+        myRINAManager->eventQueuePushed();
         LOG_DBG(
             "Added event of type %s and sequence number %u to events queue",
             IPCEvent::eventTypeToString(event->eventType).c_str(), event->sequenceNumber);
@@ -509,6 +510,7 @@ void * doNetlinkMessageReaderWork(void * arg)
             "Added event of type %s and sequence number %u to events queue",
             IPCEvent::eventTypeToString(event->eventType).c_str(), event->sequenceNumber);
         eventsQueue->put(event);
+        myRINAManager->eventQueuePushed();
       } else
         LOG_WARN("Event is null for message type %d",
                  incomingMessage->getOperationCode());

--- a/librina/src/core.h
+++ b/librina/src/core.h
@@ -164,6 +164,7 @@ public:
 
 	BlockingFIFOQueue<IPCEvent>* getEventQueue();
 	NetlinkManager* getNetlinkManager();
+	int getEventFd() const { return eventQueueReady; }
 	void eventQueuePushed();
 	void eventQueuePopped();
 	bool keep_on_reading;

--- a/librina/src/core.h
+++ b/librina/src/core.h
@@ -122,6 +122,10 @@ class RINAManager {
 	/** The events queue */
 	BlockingFIFOQueue<IPCEvent> * eventQueue;
 
+	/** eventfd to notify applications about events arriving in
+	 *  eventQueue. */
+	int eventQueueReady;
+
 	/** The thread that is continuously reading incoming Netlink messages */
 	Thread * netlinkMessageReader;
 

--- a/librina/src/core.h
+++ b/librina/src/core.h
@@ -164,6 +164,8 @@ public:
 
 	BlockingFIFOQueue<IPCEvent>* getEventQueue();
 	NetlinkManager* getNetlinkManager();
+	void eventQueuePushed();
+	void eventQueuePopped();
 	bool keep_on_reading;
 };
 

--- a/librina/src/ipc-api.cc
+++ b/librina/src/ipc-api.cc
@@ -722,7 +722,7 @@ std::vector<ApplicationRegistration *> IPCManager::getRegisteredApplications()
 
 int IPCManager::getControlFd()
 {
-        return rinaManager->getNetlinkManager()->getSocketFd();
+        return rinaManager->getEventFd();
 }
 
 Singleton<IPCManager> ipcManager;


### PR DESCRIPTION
ipcManager->getControlFd() used to return the netlink socket file descriptor. However, the netlink socket() is already read by the netlink reader, which implements a select() event loop. This makes impossible to let application select()/poll() on the netlink file descriptor.

This pull requests adds an eventfd to librina, associated to the events queue. Each time an event is pushed to the queue, a write() is done on the eventfd, and each time an event is popped from the queue, a read() is done on the eventfd. In this way the eventfd can be safely used by the application in its select()/poll() loop, without race conditions due to the concurrent select() loop of the netlink reader.

@edugrasa 