### PR TITLE
Add receive-side poll() kernel support

### DIFF
--- a/librina/src/common.cc
+++ b/librina/src/common.cc
@@ -738,7 +738,13 @@ IPCEvent * IPCEventProducer::eventPoll()
 #if STUB_API
 	return getIPCEvent();
 #else
-	return rinaManager->getEventQueue()->poll();
+	IPCEvent * event = rinaManager->getEventQueue()->poll();
+
+	if (event) {
+		rinaManager->eventQueuePopped();
+	}
+
+	return event;
 #endif
 }
 
@@ -747,7 +753,13 @@ IPCEvent * IPCEventProducer::eventWait()
 #if STUB_API
 	return getIPCEvent();
 #else
-	return rinaManager->getEventQueue()->take();
+	IPCEvent *event = rinaManager->getEventQueue()->take();
+
+	if (event) {
+		rinaManager->eventQueuePopped();
+	}
+
+	return event;
 #endif
 }
 
@@ -757,7 +769,13 @@ IPCEvent * IPCEventProducer::eventTimedWait(int seconds,
 #if STUB_API
 	return getIPCEvent();
 #else
-	return rinaManager->getEventQueue()->timedtake(seconds, nanoseconds);
+	IPCEvent * event = rinaManager->getEventQueue()->timedtake(seconds,
+								nanoseconds);
+	if (event) {
+		rinaManager->eventQueuePopped();
+	}
+
+	return event;
 #endif
 }
 

--- a/librina/src/core.cc
+++ b/librina/src/core.cc
@@ -495,6 +495,7 @@ void * doNetlinkMessageReaderWork(void * arg)
       event = myRINAManager->osProcessFinalized(message->getPortId());
       if (event) {
         eventsQueue->put(event);
+        myRINAManager->eventQueuePushed();
         LOG_DBG(
             "Added event of type %s and sequence number %u to events queue",
             IPCEvent::eventTypeToString(event->eventType).c_str(), event->sequenceNumber);
@@ -509,6 +510,7 @@ void * doNetlinkMessageReaderWork(void * arg)
             "Added event of type %s and sequence number %u to events queue",
             IPCEvent::eventTypeToString(event->eventType).c_str(), event->sequenceNumber);
         eventsQueue->put(event);
+        myRINAManager->eventQueuePushed();
       } else
         LOG_WARN("Event is null for message type %d",
                  incomingMessage->getOperationCode());

--- a/librina/src/core.h
+++ b/librina/src/core.h
@@ -164,6 +164,7 @@ public:
 
 	BlockingFIFOQueue<IPCEvent>* getEventQueue();
 	NetlinkManager* getNetlinkManager();
+	int getEventFd() const { return eventQueueReady; }
 	void eventQueuePushed();
 	void eventQueuePopped();
 	bool keep_on_reading;

--- a/librina/src/core.h
+++ b/librina/src/core.h
@@ -122,6 +122,10 @@ class RINAManager {
 	/** The events queue */
 	BlockingFIFOQueue<IPCEvent> * eventQueue;
 
+	/** eventfd to notify applications about events arriving in
+	 *  eventQueue. */
+	int eventQueueReady;
+
 	/** The thread that is continuously reading incoming Netlink messages */
 	Thread * netlinkMessageReader;
 

--- a/librina/src/core.h
+++ b/librina/src/core.h
@@ -164,6 +164,8 @@ public:
 
 	BlockingFIFOQueue<IPCEvent>* getEventQueue();
 	NetlinkManager* getNetlinkManager();
+	void eventQueuePushed();
+	void eventQueuePopped();
 	bool keep_on_reading;
 };
 

--- a/librina/src/ipc-api.cc
+++ b/librina/src/ipc-api.cc
@@ -722,7 +722,7 @@ std::vector<ApplicationRegistration *> IPCManager::getRegisteredApplications()
 
 int IPCManager::getControlFd()
 {
-        return rinaManager->getNetlinkManager()->getSocketFd();
+        return rinaManager->getEventFd();
 }
 
 Singleton<IPCManager> ipcManager;

--- a/linux/net/rina/common.h
+++ b/linux/net/rina/common.h
@@ -24,6 +24,7 @@
 #define RINA_COMMON_H
 
 #include <linux/types.h>
+#include <linux/poll.h>
 
 #include "rds/rstr.h"
 

--- a/linux/net/rina/iodev.c
+++ b/linux/net/rina/iodev.c
@@ -152,8 +152,9 @@ iodev_poll(struct file *f, poll_table *wait)
         }
 
         /* Set POLLIN if the receive queue is not empty or
-         * the flow has been deallocated. */
-        kfa_flow_readable(kfa, priv->port_id, &mask);
+         * the flow has been deallocated. Also call poll_wait(),
+         * as required by the caller. */
+        kfa_flow_readable(kfa, priv->port_id, &mask, f, wait);
 
         /* TODO check that the IPCP can handle the SDU write */
         mask |= POLLOUT | POLLWRNORM;

--- a/linux/net/rina/iodev.c
+++ b/linux/net/rina/iodev.c
@@ -143,6 +143,7 @@ iodev_read(struct file *f, char __user *buffer, size_t size, loff_t *ppos)
 static unsigned int
 iodev_poll(struct file *f, poll_table *wait)
 {
+        struct kfa *kfa = kipcm_kfa(default_kipcm);
         struct iodev_priv *priv = f->private_data;
         unsigned int mask = 0;
 
@@ -150,8 +151,9 @@ iodev_poll(struct file *f, poll_table *wait)
                 return -ENXIO;
         }
 
-        /* TODO check that receive queue is not empty */
-        mask |= POLLIN | POLLRDNORM;
+        /* Set POLLIN if the receive queue is not empty or
+         * the flow has been deallocated. */
+        kfa_flow_readable(kfa, priv->port_id, &mask);
 
         /* TODO check that the IPCP can handle the SDU write */
         mask |= POLLOUT | POLLWRNORM;

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -605,7 +605,9 @@ static bool queue_ready(struct ipcp_flow *flow)
 
 void kfa_flow_readable(struct kfa       *instance,
                        port_id_t        id,
-                       unsigned int     *mask)
+                       unsigned int     *mask,
+                       struct file      *f,
+                       poll_table       *wait)
 {
         struct ipcp_flow *flow;
 
@@ -630,6 +632,8 @@ void kfa_flow_readable(struct kfa       *instance,
                 *mask |= POLLERR;
 		return;
 	}
+
+        poll_wait(f, &flow->read_wqueue, wait);
 
         /* We set a POLLIN event if there is something in the receive queue
          * or if the flow has been deallocated, which is our EOF condition. */

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -634,7 +634,7 @@ void kfa_flow_readable(struct kfa       *instance,
         /* We set a POLLIN event if there is something in the receive queue
          * or if the flow has been deallocated, which is our EOF condition. */
         if (queue_ready(flow)) {
-                *mask |= POLLIN;
+                *mask |= POLLIN | POLLRDNORM;
         }
 
 	spin_unlock_bh(&instance->lock);

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -840,7 +840,8 @@ static int kfa_sdu_post(struct ipcp_instance_data *data,
 		ASSERT(wq);
 
 		/* set_tsk_need_resched(current); */
-		wake_up_interruptible(wq);
+		wake_up_interruptible_poll(wq, POLLIN | POLLRDNORM
+                                                | POLLRDBAND);
 		LOG_DBG("SDU posted");
 	}
 

--- a/linux/net/rina/kfa.c
+++ b/linux/net/rina/kfa.c
@@ -30,6 +30,9 @@
 #include <linux/sched.h>
 #include <linux/wait.h>
 
+/* For POLLIN etc. */
+#include <linux/poll.h>
+
 #define RINA_PREFIX "kfa"
 
 #include "logs.h"
@@ -598,6 +601,43 @@ static bool queue_ready(struct ipcp_flow *flow)
 	}
 
 	return false;
+}
+
+void kfa_flow_readable(struct kfa       *instance,
+                       port_id_t        id,
+                       unsigned int     *mask)
+{
+        struct ipcp_flow *flow;
+
+	if (!instance) {
+		LOG_ERR("Bogus instance passed, bailing out");
+                *mask |= POLLERR;
+                return;
+	}
+
+	if (!is_port_id_ok(id)) {
+		LOG_ERR("Bogus port-id, bailing out");
+                *mask |= POLLERR;
+		return;
+	}
+
+	spin_lock_bh(&instance->lock);
+
+	flow = kfa_pmap_find(instance->flows, id);
+	if (!flow) {
+		spin_unlock_bh(&instance->lock);
+		LOG_ERR("There is no flow bound to port-id %d", id);
+                *mask |= POLLERR;
+		return;
+	}
+
+        /* We set a POLLIN event if there is something in the receive queue
+         * or if the flow has been deallocated, which is our EOF condition. */
+        if (queue_ready(flow)) {
+                *mask |= POLLIN;
+        }
+
+	spin_unlock_bh(&instance->lock);
 }
 
 int kfa_flow_sdu_read(struct kfa  *instance,

--- a/linux/net/rina/kfa.h
+++ b/linux/net/rina/kfa.h
@@ -52,7 +52,9 @@ int	    kfa_flow_sdu_read(struct kfa  *instance,
 
 void    kfa_flow_readable(struct kfa       *instance,
                           port_id_t        id,
-                          unsigned int     *mask);
+                          unsigned int     *mask,
+                          struct file      *f,
+                          poll_table       *wait);
 #if 0
 struct ipcp_flow *kfa_flow_find_by_pid(struct kfa *instance,
 				       port_id_t   pid);

--- a/linux/net/rina/kfa.h
+++ b/linux/net/rina/kfa.h
@@ -50,6 +50,9 @@ int	    kfa_flow_sdu_read(struct kfa  *instance,
 			      struct sdu **sdu,
                               bool blocking);
 
+void    kfa_flow_readable(struct kfa       *instance,
+                          port_id_t        id,
+                          unsigned int     *mask);
 #if 0
 struct ipcp_flow *kfa_flow_find_by_pid(struct kfa *instance,
 				       port_id_t   pid);

--- a/linux/net/rina/logs.h
+++ b/linux/net/rina/logs.h
@@ -51,7 +51,7 @@
 
 #ifdef CONFIG_RINA_DEBUG
 #ifdef CONFIG_RINA_SUPPRESS_DEBUG_LOGS
-#warning Debugging logs WILL BE suppressed
+//#warning Debugging logs WILL BE suppressed
 #define LOG_DBG(FMT,   ARGS...) do { } while (0)
 #else
 #define LOG_DBG(FMT,   ARGS...) __LOG(RINA_PREFIX, KERN_DEBUG,      \


### PR DESCRIPTION
This patch adds the necessary mechanism to implement selective wake up on poll()/select()/epoll() userspace callers with POLLIN events.
When a packet is received on the flow (or the flow is deallocated), the poll()er is waken up so that it can react to the event.

This depends on (and includes) #1054 