### PR TITLE
rina-tools: use large read() in rina-echo-time client

### DIFF
--- a/rina-tools/src/common/application.cc
+++ b/rina-tools/src/common/application.cc
@@ -98,4 +98,4 @@ void Application::applicationRegister()
         	throw ApplicationRegistrationException("Could not register application to any DIF");
 }
 
-const uint Application::max_buffer_size = 1 << 18;
+const uint Application::max_buffer_size = 1 << 16;

--- a/rina-tools/src/rina-echo-time/et-client.cc
+++ b/rina-tools/src/rina-echo-time/et-client.cc
@@ -386,14 +386,14 @@ void Client::floodFlow()
 	unsigned long sn;
 	double delta = 0;
 	double current_rtt = 0;
-	unsigned char *buffer2 = new unsigned char[data_size];
+	unsigned char *buffer2 = new unsigned char[max_buffer_size];
 
 	snd = startSender();
 	cout << "Sender started" << endl;
 	while(true) {
 		int bytes_read = 0;
 
-		bytes_read = read(fd, buffer2, data_size);
+		bytes_read = read(fd, buffer2, max_buffer_size);
                 if (bytes_read < 0) {
                         if (errno == EAGAIN) {
                                 continue;


### PR DESCRIPTION
Use a large buffer for read().
This prevents error related to partial SDU read, which happens if packets larger than expected come on the flow.

@edugrasa 