### PR TITLE
Arcfire staticrouting

### DIFF
--- a/librina/src/ipc-process.cc
+++ b/librina/src/ipc-process.cc
@@ -1032,7 +1032,13 @@ RoutingTableEntry::RoutingTableEntry(){
 const std::string RoutingTableEntry::getKey() const
 {
 	std::stringstream ss;
-	ss << destination.name << "-" << qosId << "-" << nextHopNames.front().alts.front().name;
+	if (destination.name != "") {
+		ss << destination.name << "-" << qosId << "-" << cost << "-"
+		   << nextHopNames.front().alts.front().name;
+	} else {
+		ss << destination.addresses.front() << "-" << qosId << "-" << cost << "-"
+		   << nextHopNames.front().alts.front().addresses.front();
+	}
 
 	return ss.str();
 }

--- a/rinad/src/ipcp/components.h
+++ b/rinad/src/ipcp/components.h
@@ -354,6 +354,8 @@ public:
 
 	virtual int getManagementFlowToNeighbour(const std::string& name) = 0;
 
+	virtual int getManagementFlowToNeighbour(unsigned int address) = 0;
+
 	virtual unsigned int numberOfFlowsToNeighbour(const std::string& apn,
 			const std::string& api) = 0;
 };

--- a/rinad/src/ipcp/plugins/default/Makefile.am
+++ b/rinad/src/ipcp/plugins/default/Makefile.am
@@ -35,7 +35,8 @@ default_la_SOURCES =		 \
         resource-allocator-ps.cc \
         enrollment-task-ps.cc    \
         routing-ps.h 	 	 \
-        routing-ps.cc
+        routing-ps.cc        \
+        static-routing-ps.cc
 
 plugins_LTLIBRARIES += default.la
 

--- a/rinad/src/ipcp/plugins/default/default.manifest
+++ b/rinad/src/ipcp/plugins/default/default.manifest
@@ -17,12 +17,12 @@
                         "Component": "flow-allocator",
                         "Version" : "1"
                 },
-		{
-			"Name": "DelayBased",
+				{
+						"Name": "DelayBased",
                         "Component": "flow-allocator",
                         "Version" : "1"
                 },
-		{
+				{
                         "Name": "RoundRobin",
                         "Component": "flow-allocator",
                         "Version" : "1"
@@ -44,6 +44,11 @@
                 },
                 {
                         "Name": "link-state",
+                        "Component": "routing",
+                        "Version" : "1"
+                },
+                {
+                        "Name": "static",
                         "Component": "routing",
                         "Version" : "1"
                 }

--- a/rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
+++ b/rinad/src/ipcp/plugins/default/flow-allocator-ps.cc
@@ -34,7 +34,7 @@ public:
 	configs::Flow *newFlowRequest(IPCProcess * ipc_process,
 			const rina::FlowRequestEvent& flowRequestEvent);
 	int set_policy_set_param(const std::string& name,
-							 const std::string& value);
+				 const std::string& value);
 	virtual ~FlowAllocatorPs() {}
 
 private:

--- a/rinad/src/ipcp/plugins/default/plugin.cc
+++ b/rinad/src/ipcp/plugins/default/plugin.cc
@@ -56,6 +56,12 @@ createRoutingComponentPs(rina::ApplicationEntity * context);
 extern "C" void
 destroyRoutingComponentPs(rina::IPolicySet * instance);
 
+extern "C" rina::IPolicySet *
+createStaticRoutingComponentPs(rina::ApplicationEntity * context);
+
+extern "C" void
+destroyStaticRoutingComponentPs(rina::IPolicySet * instance);
+
 extern "C" int
 get_factories(std::vector<struct rina::PsFactory>& factories)
 {
@@ -67,6 +73,7 @@ get_factories(std::vector<struct rina::PsFactory>& factories)
         struct rina::PsFactory pduft_gen_factory;
         struct rina::PsFactory et_factory;
         struct rina::PsFactory rc_factory;
+        struct rina::PsFactory src_factory;
 
         sm_factory.info.name = rina::IPolicySet::DEFAULT_PS_SET_NAME;
         sm_factory.info.app_entity = rina::ApplicationEntity::SECURITY_MANAGER_AE_NAME;
@@ -122,6 +129,12 @@ get_factories(std::vector<struct rina::PsFactory>& factories)
         rc_factory.create = createRoutingComponentPs;
         rc_factory.destroy = destroyRoutingComponentPs;
 	factories.push_back(rc_factory);
+
+        src_factory.info.name = "static";
+        src_factory.info.app_entity = IRoutingComponent::ROUTING_COMPONENT_AE_NAME;
+        src_factory.create = createStaticRoutingComponentPs;
+        src_factory.destroy = destroyStaticRoutingComponentPs;
+	factories.push_back(src_factory);
 
 	return 0;
 }

--- a/rinad/src/ipcp/plugins/default/resource-allocator-ps.cc
+++ b/rinad/src/ipcp/plugins/default/resource-allocator-ps.cc
@@ -67,6 +67,7 @@ void DefaultPDUFTGeneratorPs::routingTableUpdated(const std::list<rina::RoutingT
 			entry = new rina::PDUForwardingTableEntry();
 			entry->address = *at;
 			entry->qosId = (*it)->qosId;
+			entry->cost = (*it)->cost;
 
 			LOG_IPCP_DBG("Processing entry for destination %u", *at);
 
@@ -76,8 +77,11 @@ void DefaultPDUFTGeneratorPs::routingTableUpdated(const std::list<rina::RoutingT
 
 				for (kt = jt->alts.begin();
 						kt != jt->alts.end(); kt++) {
-					port_id = n1fm->
-							getManagementFlowToNeighbour(kt->name);
+					if (kt->name != "") {
+						port_id = n1fm->getManagementFlowToNeighbour(kt->name);
+					} else {
+						port_id = n1fm->getManagementFlowToNeighbour(kt->addresses.front());
+					}
 					if (port_id == -1)
 						continue;
 

--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -70,13 +70,13 @@ LinkStateRoutingPs::~LinkStateRoutingPs()
 extern "C" rina::IPolicySet *
 createRoutingComponentPs(rina::ApplicationEntity * ctx)
 {
-		IRoutingComponent * rc = dynamic_cast<IRoutingComponent *>(ctx);
+	IRoutingComponent * rc = dynamic_cast<IRoutingComponent *>(ctx);
 
-		if (!rc) {
-			return NULL;
-		}
+	if (!rc) {
+		return NULL;
+	}
 
-		return new LinkStateRoutingPs(rc);
+	return new LinkStateRoutingPs(rc);
 }
 
 extern "C" void
@@ -1786,7 +1786,7 @@ void LinkStateRoutingPolicy::set_dif_configuration(
         rina::PolicyConfig psconf;
         long delay;
 
-        psconf = dif_configuration.routing_configuration_.policy_set_;;
+        psconf = dif_configuration.routing_configuration_.policy_set_;
 
         try {
         	routing_alg = psconf.get_param_value_as_string(ROUTING_ALGORITHM);

--- a/rinad/src/ipcp/plugins/default/routing-ps.h
+++ b/rinad/src/ipcp/plugins/default/routing-ps.h
@@ -67,12 +67,12 @@ class LinkStateRoutingPolicy;
 
 class LinkStateRoutingPs: public IRoutingPs {
 public:
-		static std::string LINK_STATE_POLICY;
-		LinkStateRoutingPs(IRoutingComponent * rc);
-		void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
-		int set_policy_set_param(const std::string& name,
+	static std::string LINK_STATE_POLICY;
+	LinkStateRoutingPs(IRoutingComponent * rc);
+	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
+	int set_policy_set_param(const std::string& name,
 			const std::string& value);
-		~LinkStateRoutingPs();
+	~LinkStateRoutingPs();
 
 private:
         // Data model of the routing component.

--- a/rinad/src/ipcp/plugins/default/static-routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/static-routing-ps.cc
@@ -1,0 +1,185 @@
+//
+// Static routing policy set
+//
+//    Eduard Grasa <eduard.grasa@i2cat.net>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA  02110-1301  USA
+//
+
+#define IPCP_MODULE "routing-ps-static"
+#include "../../ipcp-logging.h"
+#include <string>
+#include <climits>
+
+#include "ipcp/components.h"
+
+namespace rinad {
+
+class StaticRoutingPs: public IRoutingPs {
+public:
+	StaticRoutingPs(IRoutingComponent * dm);
+	void set_dif_configuration(const rina::DIFConfiguration& dif_configuration);
+	int set_policy_set_param(const std::string& name,
+				 const std::string& value);
+	virtual ~StaticRoutingPs() {}
+
+private:
+	void parse_policy_param(rina::PolicyParameter pm);
+	void split(std::vector<std::string> & result,
+	           const char *str, char c);
+	void get_rt_entries_as_list(std::list<rina::RoutingTableEntry *> & result);
+
+        // Data model of the security manager component.
+	IRoutingComponent * rc;
+	std::map<std::string, rina::RoutingTableEntry *> rt_entries;
+};
+
+StaticRoutingPs::StaticRoutingPs(IRoutingComponent * dm) {
+	rc = dm;
+}
+
+int StaticRoutingPs::set_policy_set_param(const std::string& name,
+			 	 	  const std::string& value)
+{
+	LOG_INFO("Ignoring set policy set parm, name: %s, value: %s",
+		  name.c_str(), value.c_str());
+	return 0;
+}
+
+void StaticRoutingPs::set_dif_configuration(const rina::DIFConfiguration& dif_configuration)
+{
+	rina::PolicyConfig psconf;
+	std::list<rina::PolicyParameter>::const_iterator it;
+	std::list<rina::RoutingTableEntry *> current_entries;
+
+	psconf = dif_configuration.routing_configuration_.policy_set_;
+	for (it = psconf.parameters_.begin();
+			it != psconf.parameters_.end(); ++it) {
+		parse_policy_param(*it);
+	}
+
+	get_rt_entries_as_list(current_entries);
+	rc->ipcp->resource_allocator_->pduft_gen_ps->routingTableUpdated(current_entries);
+}
+
+//Parameter name is the destination address,
+//Parameter value is <qos_id>-<cost>-<nhop_address>
+void StaticRoutingPs::parse_policy_param(rina::PolicyParameter pm)
+{
+	rina::RoutingTableEntry * entry;
+	std::stringstream ss;
+	unsigned int aux;
+	char *dummy;
+	std::vector<std::string> result;
+	rina::NHopAltList nhop_alt;
+	rina::IPCPNameAddresses ipcpna;
+
+	//Tokenize parameter value
+	split(result, pm.value_.c_str(), '-');
+	if (result.size() != 3) {
+		LOG_ERR("Parameter value does not have the right format: %s",
+				pm.value_.c_str());
+	}
+
+	//Parse destination address
+	entry = new rina::RoutingTableEntry();
+	aux = strtoul(pm.name_.c_str(), &dummy, 10);
+	if (!pm.name_.size() || *dummy != '\0') {
+		LOG_ERR("Error converting dest. address to ulong: %s",
+				pm.name_.c_str());
+		delete entry;
+		return;
+	}
+	entry->destination.addresses.push_back(aux);
+
+	//Parse qos_id
+	entry->qosId = strtoul(result[0].c_str(), &dummy, 10);
+	if (!result[0].c_str() || *dummy != '\0') {
+		LOG_ERR("Error converting qos-id to ulong: %s",
+				result[0].c_str());
+		delete entry;
+		return;
+	}
+
+	//Parse cost
+	entry->cost = strtoul(result[1].c_str(), &dummy, 10);
+	if (!result[1].c_str() || *dummy != '\0') {
+		LOG_ERR("Error converting cost to ulong: %s",
+				result[1].c_str());
+		delete entry;
+		return;
+	}
+
+	//Parse nhop address
+	aux = strtoul(result[2].c_str(), &dummy, 10);
+	if (!result[1].c_str() || *dummy != '\0') {
+		LOG_ERR("Error converting nhop address to ulong: %s",
+				result[2].c_str());
+		delete entry;
+		return;
+	}
+	ipcpna.addresses.push_back(aux);
+	nhop_alt.alts.push_back(ipcpna);
+	entry->nextHopNames.push_back(nhop_alt);
+
+	ss << pm.name_ << "-" << pm.value_;
+	rt_entries[ss.str()] = entry;
+}
+
+void StaticRoutingPs::split(std::vector<std::string> & result,
+			    const char *str, char c)
+{
+	do
+	{
+		const char *begin = str;
+
+		while(*str != c && *str)
+			str++;
+
+		result.push_back(std::string(begin, str));
+	} while (0 != *str++);
+}
+
+void StaticRoutingPs::get_rt_entries_as_list(std::list<rina::RoutingTableEntry *> & result)
+{
+	std::map<std::string, rina::RoutingTableEntry *>::iterator it;
+
+	for (it = rt_entries.begin(); it != rt_entries.end(); ++it) {
+		result.push_back(it->second);
+	}
+}
+
+extern "C" rina::IPolicySet *
+createStaticRoutingComponentPs(rina::ApplicationEntity * ctx)
+{
+	IRoutingComponent * rc = dynamic_cast<IRoutingComponent *>(ctx);
+
+	if (!rc) {
+		return NULL;
+	}
+
+	return new StaticRoutingPs(rc);
+}
+
+extern "C" void
+destroyStaticRoutingComponentPs(rina::IPolicySet * ps)
+{
+        if (ps) {
+                delete ps;
+        }
+}
+
+}

--- a/rinad/src/ipcp/plugins/default/static-routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/static-routing-ps.cc
@@ -188,9 +188,15 @@ void StaticRoutingPs::split(std::vector<std::string> & result,
 void StaticRoutingPs::get_rt_entries_as_list(std::list<rina::RoutingTableEntry *> & result)
 {
 	std::map<std::string, rina::RoutingTableEntry *>::iterator it;
+	rina::RoutingTableEntry * rte;
 
 	for (it = rt_entries.begin(); it != rt_entries.end(); ++it) {
-		result.push_back(it->second);
+		rte = new rina::RoutingTableEntry();
+		rte->cost = it->second->cost;
+		rte->qosId = it->second->qosId;
+		rte->destination = it->second->destination;
+		rte->nextHopNames = it->second->nextHopNames;
+		result.push_back(rte);
 	}
 }
 

--- a/rinad/src/ipcp/plugins/default/static-routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/static-routing-ps.cc
@@ -61,6 +61,10 @@ void StaticRoutingPs::subscribeToEvents()
 		subscribeToEvent(rina::InternalEvent::APP_N_MINUS_1_FLOW_DEALLOCATED, this);
 	rc->ipcp->internal_event_manager_->
 		subscribeToEvent(rina::InternalEvent::APP_N_MINUS_1_FLOW_ALLOCATED, this);
+	rc->ipcp->internal_event_manager_->
+		subscribeToEvent(rina::InternalEvent::APP_NEIGHBOR_ADDED, this);
+	rc->ipcp->internal_event_manager_->
+		subscribeToEvent(rina::InternalEvent::APP_CONNECTIVITY_TO_NEIGHBOR_LOST, this);
 }
 
 void StaticRoutingPs::update_forwarding_table(void)

--- a/rinad/src/ipcp/resource-allocator.cc
+++ b/rinad/src/ipcp/resource-allocator.cc
@@ -340,6 +340,20 @@ int NMinusOneFlowManager::getManagementFlowToNeighbour(const std::string& name) 
 	return -1;
 }
 
+int NMinusOneFlowManager::getManagementFlowToNeighbour(unsigned int address)
+{
+	const std::list<rina::Neighbor> neighbors =
+			ipc_process_->enrollment_task_->get_neighbors();
+	for (std::list<rina::Neighbor>::const_iterator it = neighbors.begin();
+			it != neighbors.end(); ++it) {
+		if (it->address_ == address) {
+			return it->underlying_port_id_;
+		}
+	}
+
+	return -1;
+}
+
 unsigned int NMinusOneFlowManager::numberOfFlowsToNeighbour(const std::string& apn,
 		const std::string& api) {
 	std::vector<rina::FlowInformation> flows = rina::extendedIPCManager->getAllocatedFlows();

--- a/rinad/src/ipcp/resource-allocator.h
+++ b/rinad/src/ipcp/resource-allocator.h
@@ -179,6 +179,7 @@ public:
 	void processRegistrationNotification(const rina::IPCProcessDIFRegistrationEvent& event);;
 	std::list<int> getNMinusOneFlowsToNeighbour(unsigned int address);
 	int getManagementFlowToNeighbour(const std::string& name);
+	int getManagementFlowToNeighbour(unsigned int address);
 	unsigned int numberOfFlowsToNeighbour(const std::string& apn,
 			const std::string& api);
 


### PR DESCRIPTION
Fix #1111 . Adds a static routing policy. Routing entries are specified in the config file, as parameters of the routing policy. Example:

````
     "routingConfiguration" : {
         "policySet" : {
           "name" : "static",
           "version" : "1",
           "parameters" : [{
             "name"  : "17",
             "value" : "0-1-17"
           }]
     }
````
Each policy parameter is a routing table entry. The name of the parameter is the destination address, the value of the parameter has the format <qos_id>-<cost>-<next hop address>.

Installing routing and forwarding table entries can be queried from the IPCM console, using the "query-rib" command.

````
Name: /resalloc/nhopt; Class: NextHopTable; Instance: 11
Value: -

Name: /resalloc/nhopt/key=17-0-1-17; Class: NextHopTableEntry; Instance: 37
Value: Destination name: ; Addresses: 17; ; QoS-id: 0; Cost: 1; Next hop addresses:  17; / 

Name: /resalloc/pduft; Class: PDUForwardingTable; Instance: 12
Value: -

Name: /resalloc/pduft/key=17-0-6; Class: PDUForwardingTableEntry; Instance: 38
Value: Destination address: 17; QoS-id: 0; Port-ids to be forwarded: 6/ 
````
@miqueltarzan could you test to make sure it complies with your experimentation requirements? Thanks!