### PR TITLE
Msg boundaries

### DIFF
--- a/common/serdes-utils.c
+++ b/common/serdes-utils.c
@@ -521,7 +521,7 @@ int flow_spec_serlen(const struct flow_spec * fspec)
 {
 	if (!fspec) return 0;
 
-	return 8 * sizeof(uint32_t) + sizeof(int32_t) + 2* sizeof(bool);
+	return 8 * sizeof(uint32_t) + sizeof(int32_t) + 3* sizeof(bool);
 }
 
 void serialize_flow_spec(void **pptr, const struct flow_spec *fspec)
@@ -539,6 +539,7 @@ void serialize_flow_spec(void **pptr, const struct flow_spec *fspec)
 	serialize_obj(*pptr, uint32_t, fspec->peak_bandwidth_duration);
 	serialize_obj(*pptr, uint32_t, fspec->peak_sdu_bandwidth_duration);
 	serialize_obj(*pptr, int32_t, fspec->undetected_bit_error_rate);
+	serialize_obj(*pptr, bool, fspec->msg_boundaries);
 }
 
 int deserialize_flow_spec(const void **pptr, struct flow_spec ** fspec)
@@ -558,6 +559,7 @@ int deserialize_flow_spec(const void **pptr, struct flow_spec ** fspec)
 	deserialize_obj(*pptr, uint32_t, &(*fspec)->peak_bandwidth_duration);
 	deserialize_obj(*pptr, uint32_t, &(*fspec)->peak_sdu_bandwidth_duration);
 	deserialize_obj(*pptr, int32_t, &(*fspec)->undetected_bit_error_rate);
+	deserialize_obj(*pptr, bool, &(*fspec)->msg_boundaries);
 
 	return 0;
 }

--- a/include/irati/kernel-msg.h
+++ b/include/irati/kernel-msg.h
@@ -560,6 +560,7 @@ struct irati_kmsg_ipcp_allocate_port {
 	ipc_process_id_t dest_ipcp_id;
 	uint32_t event_id;
 
+	bool msg_boundaries;
         struct name * app_name;
 } __attribute__((packed));
 

--- a/include/irati/kucommon.h
+++ b/include/irati/kucommon.h
@@ -224,6 +224,9 @@ struct flow_spec {
         /* A value of 0 indicates 'do not care' */
         /* FIXME: This uint_t has to be transformed back to double */
         uint32_t undetected_bit_error_rate;
+
+        /* Preserve message boundaries */
+        bool msg_boundaries;
 };
 
 struct policy_parm {

--- a/kernel/ipcp-instances.h
+++ b/kernel/ipcp-instances.h
@@ -177,11 +177,16 @@ struct ipcp_instance_ops {
          * Start using new address after first timeout, deprecate old
          * address after second timeout
          */
-         int (* address_change)(struct ipcp_instance_data * data,
+        int (* address_change)(struct ipcp_instance_data * data,
          		       address_t new_address,
  			       address_t old_address,
  			       timeout_t use_new_address_t,
  			       timeout_t deprecate_old_address_t);
+
+        /*
+         * The maximum size of SDUs that this IPCP will accept
+         */
+        size_t (* max_sdu_size)(struct ipcp_instance_data * data);
 };
 
 /* FIXME: Should work on struct ipcp_instance, not on ipcp_instance_ops */

--- a/kernel/ipcps/normal-ipcp.c
+++ b/kernel/ipcps/normal-ipcp.c
@@ -919,6 +919,16 @@ static const struct name * normal_dif_name(struct ipcp_instance_data * data)
         return &data->dif_name;
 }
 
+static size_t normal_max_sdu_size(struct ipcp_instance_data * data)
+{
+        ASSERT(data);
+        if (!data->efcpc || !data->efcpc->config)
+        	return 0;
+
+        return data->efcpc->config->dt_cons->max_pdu_size -
+        		pci_calculate_size(data->efcpc->config, PDU_TYPE_DT);
+}
+
 ipc_process_id_t normal_ipcp_id(struct ipcp_instance_data * data)
 {
 	ASSERT(data);
@@ -1233,7 +1243,8 @@ static struct ipcp_instance_ops normal_instance_ops = {
         .disable_write             = disable_write,
         .update_crypto_state       = normal_update_crypto_state,
 	.address_change            = normal_address_change,
-        .dif_name		   = normal_dif_name
+        .dif_name		   = normal_dif_name,
+	.max_sdu_size		   = normal_max_sdu_size
 };
 
 static struct ipcp_instance * normal_create(struct ipcp_factory_data * data,

--- a/kernel/ipcps/shim-eth-vlan-core.c
+++ b/kernel/ipcps/shim-eth-vlan-core.c
@@ -1107,7 +1107,7 @@ static int eth_vlan_rcv_worker(void * o)
         if (!user_ipcp->ops->ipcp_name(user_ipcp->data)) {
                 LOG_DBG("This flow goes for an app");
                 if (kfa_flow_create(data->kfa, flow->port_id, ipcp, data->id,
-									NULL)) {
+                		    NULL, false)) {
                         LOG_ERR("Could not create flow in KFA");
                         kfa_port_id_release(data->kfa, flow->port_id);
                         if (flow_destroy(data, flow))
@@ -1751,6 +1751,16 @@ static const struct name * eth_vlan_dif_name(struct ipcp_instance_data * data)
         return data->dif_name;
 }
 
+static size_t eth_vlan_max_sdu_size(struct ipcp_instance_data * data)
+{
+	if (!data) {
+		LOG_ERR("Bogus data passed, bailing out");
+		return 0;
+	}
+
+        return data->dev->mtu - sizeof(struct ethhdr);
+}
+
 ipc_process_id_t eth_vlan_ipcp_id(struct ipcp_instance_data * data)
 {
 	ASSERT(data);
@@ -1813,7 +1823,8 @@ static struct ipcp_instance_ops eth_vlan_instance_ops = {
         .select_policy_set         = NULL,
         .update_crypto_state	   = NULL,
 	.address_change            = NULL,
-        .dif_name		   = eth_vlan_dif_name
+        .dif_name		   = eth_vlan_dif_name,
+	.max_sdu_size		   = eth_vlan_max_sdu_size
 };
 
 static int ntfy_user_ipcp_on_if_state_change(struct ipcp_instance_data * data,

--- a/kernel/ipcps/shim-hv-core.c
+++ b/kernel/ipcps/shim-hv-core.c
@@ -1149,6 +1149,15 @@ shim_hv_dif_name(struct ipcp_instance_data *priv)
         return &priv->dif_name;
 }
 
+static size_t
+shim_hv_max_sdu_size(struct ipcp_instance_data *priv)
+{
+        ASSERT(priv);
+
+        /* FIXME: return something that makes more sense*/
+        return 200000;
+}
+
 ipc_process_id_t shim_hv_ipcp_id(struct ipcp_instance_data * data)
 {
 	ASSERT(data);
@@ -1210,7 +1219,8 @@ static struct ipcp_instance_ops shim_hv_ipcp_ops = {
         .update_crypto_state	   = NULL,
 	.address_change		   = NULL,
         .dif_name		   = shim_hv_dif_name,
-	.ipcp_id		   = shim_hv_ipcp_id
+	.ipcp_id		   = shim_hv_ipcp_id,
+	.max_sdu_size		   = shim_hv_max_sdu_size
 };
 
 /* Initialize the IPC process factory. */

--- a/kernel/ipcps/shim-tcp-udp.c
+++ b/kernel/ipcps/shim-tcp-udp.c
@@ -1173,8 +1173,7 @@ static int udp_process_msg(struct ipcp_instance_data * data,
                 if (!user_ipcp->ops->ipcp_name(user_ipcp->data)) {
                         LOG_DBG("This flow goes for an app");
                         if (kfa_flow_create(data->kfa, flow->port_id, ipcp,
-								data->id,
-								NULL)) {
+                        		    data->id, NULL, false)) {
                                 LOG_ERR("Could not create flow in KFA");
                                 du_destroy(du);
                                 kfa_port_id_release(data->kfa, flow->port_id);
@@ -1621,8 +1620,7 @@ static int tcp_process(struct ipcp_instance_data * data, struct socket * sock)
                 if (!user_ipcp->ops->ipcp_name(user_ipcp->data)) {
                         LOG_DBG("This flow goes for an app");
                         if (kfa_flow_create(data->kfa, flow->port_id, ipcp,
-								data->id,
-								NULL)) {
+                        		    data->id, NULL, false)) {
                                 LOG_ERR("Could not create flow in KFA");
                                 kfa_port_id_release(data->kfa, flow->port_id);
                                 if (flow_destroy(data, flow))
@@ -2595,6 +2593,14 @@ static const struct name * tcp_udp_dif_name(struct ipcp_instance_data * data)
         return data->dif_name;
 }
 
+static size_t tcp_udp_max_sdu_size(struct ipcp_instance_data * data)
+{
+        ASSERT(data);
+
+        /* FIXME: return a value that makes more sense */
+        return 2000000;
+}
+
 ipc_process_id_t tcp_udp_ipcp_id(struct ipcp_instance_data * data)
 {
 	ASSERT(data);
@@ -2657,7 +2663,8 @@ static struct ipcp_instance_ops tcp_udp_instance_ops = {
         .select_policy_set         = NULL,
         .update_crypto_state	   = NULL,
 	.address_change            = NULL,
-        .dif_name		   = tcp_udp_dif_name
+        .dif_name		   = tcp_udp_dif_name,
+	.max_sdu_size		   = tcp_udp_max_sdu_size
 };
 
 static int tcp_udp_init(struct ipcp_factory_data * data)

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -594,14 +594,14 @@ int kfa_flow_ub_write(struct kfa * instance,
 	while (left) {
 		copylen = min(left, max_sdu_size);
 
-		du = du_create(size);
+		du = du_create(copylen);
 		if (!du) {
 			retval = -ENOMEM;
 			goto finish;
 		}
 
 		/* NOTE: We don't handle partial copies */
-		if (copy_from_user(du_buffer(du), buffer, size)) {
+		if (copy_from_user(du_buffer(du), buffer + data_written, copylen)) {
 			du_destroy(du);
 			retval = -EIO;
 			goto finish;
@@ -1136,19 +1136,6 @@ int kfa_flow_create(struct kfa           *instance,
 	struct ipcp_flow *flow;
 	bool ip_flow = false;
 	string_t name[64];
-
-	if (!instance) {
-		LOG_ERR("Bogus kfa instance passed, bailing out");
-		return -1;
-	}
-	if (!is_port_id_ok(pid)) {
-		LOG_ERR("Bogus PID passed, bailing out");
-		return -1;
-	}
-	if (!ipcp) {
-		LOG_ERR("Bogus ipcp passed, bailing out");
-		return -1;
-	}
 
 	ip_flow = (user_ipcp_name != NULL) &&
 		  (user_ipcp_name->entity_name != NULL) &&

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -564,11 +564,6 @@ int kfa_flow_ub_write(struct kfa * instance,
 	size_t copylen = 0;
 	size_t data_written = 0;
 
-	if (!instance || !is_port_id_ok(id) || !is_du_ok(du)) {
-		LOG_ERR("Bogus input params, bailing out");
-		return -EINVAL;
-	}
-
 	LOG_DBG("Trying to write SDU to port-id %d", id);
 
 	spin_lock_bh(&instance->lock);

--- a/kernel/kfa.h
+++ b/kernel/kfa.h
@@ -41,9 +41,14 @@ port_id_t   kfa_port_id_reserve(struct kfa      *instance,
 int	    kfa_port_id_release(struct kfa *instance,
 				port_id_t   port_id);
 
-int	    kfa_flow_du_write(struct ipcp_instance_data *data,
+int kfa_flow_du_write(struct kfa * kfa,
+		      port_id_t    id,
+		      struct du  * du);
+
+int	    kfa_flow_ub_write(struct kfa * kfa,
 			      port_id_t   id,
-			      struct du * du,
+			      const char __user *buffer,
+			      size_t size,
                               bool blocking);
 
 int	    kfa_flow_du_read(struct kfa  * instance,
@@ -77,7 +82,8 @@ int	    kfa_flow_create(struct kfa           *instance,
 			    port_id_t		  pid,
 			    struct ipcp_instance *ipcp,
 			    ipc_process_id_t	 ipc_id,
-		    	    struct name          *user_ipcp_name);
+		    	    struct name          *user_ipcp_name,
+			    bool		  msg_boundaries);
 
 struct ipcp_instance *kfa_ipcp_instance(struct kfa *instance);
 

--- a/kernel/kipcm.h
+++ b/kernel/kipcm.h
@@ -55,7 +55,8 @@ int            kipcm_ipc_destroy(struct kipcm *   kipcm,
 /* If successful: takes the ownership of the DU */
 int            kipcm_du_write(struct kipcm * kipcm,
                                port_id_t      id,
-                               struct du *   du,
+			       const char __user *buffer,
+			       size_t size,
                                bool blocking);
 /* If successful: passes the ownership of the SDU */
 int            kipcm_du_read(struct kipcm * kipcm,
@@ -71,6 +72,7 @@ int            kipcm_mgmt_du_write(struct kipcm *   kipcm,
 	                           struct du *   du);
 port_id_t      kipcm_flow_create(struct kipcm *   kipcm,
 				 ipc_process_id_t ipc_id,
+				 bool		  msg_boundaries,
 				 struct name *    process_name);
 
 int            kipcm_flow_destroy(struct kipcm *   kipcm,

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -38,7 +38,7 @@
 
 struct rina_device {
 	struct net_device_stats stats;
-	struct ipcp_instance* kfa_ipcp;
+	struct kfa* kfa;
 	port_id_t port;
 	struct net_device* dev;
 };
@@ -117,8 +117,7 @@ static int rina_dev_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	}
 
 	len = skb->len;
-        if(kfa_flow_du_write(rina_dev->kfa_ipcp->data, rina_dev->port,
-        		     du, false)){
+        if(kfa_flow_du_write(rina_dev->kfa, rina_dev->port, du)){
 		rina_dev->stats.tx_dropped++;
 		LOG_ERR("Could not xmit IP packet, unable to send to KFA...");
 		return NET_XMIT_DROP;
@@ -171,15 +170,12 @@ static void rina_dev_setup(struct net_device *dev)
 }
 
 struct rina_device* rina_dev_create(string_t* name,
-				    struct ipcp_instance* kfa_ipcp,
+				    struct kfa* kfa,
 				    port_id_t port)
 {
 	int rv;
 	struct net_device *dev;
 	struct rina_device* rina_dev;
-
-	if (!kfa_ipcp || !name)
-		return NULL;
 
 	if (strlen(name) > IFNAMSIZ) {
 		LOG_ERR("Could not allocate RINA IP network device %s, "
@@ -196,7 +192,7 @@ struct rina_device* rina_dev_create(string_t* name,
 
 	rina_dev = netdev_priv(dev);
 	rina_dev->dev = dev;
-	rina_dev->kfa_ipcp = kfa_ipcp;
+	rina_dev->kfa = kfa;
 	rina_dev->port = port;
 	memset(&rina_dev->stats, 0x00, sizeof(struct net_device_stats));
 

--- a/kernel/rina-device.h
+++ b/kernel/rina-device.h
@@ -33,7 +33,7 @@ struct ipcp_instance;
 struct rina_device;
 
 struct rina_device* rina_dev_create(string_t *name,
-				    struct ipcp_instance* kfa_ipcp,
+				    struct kfa* kfa,
 			  	    port_id_t port);
 int		    rina_dev_destroy(struct rina_device *rina_dev);
 int		    rina_dev_rcv(struct sk_buff *skb,

--- a/librina/include/librina/common.h
+++ b/librina/include/librina/common.h
@@ -173,6 +173,12 @@ public:
 	 */
 	unsigned int maxSDUsize;
 
+	/**
+	 * True if message boundaries have to be preserved, false
+	 * otherwise
+	 */
+	bool msg_boundaries;
+
 	FlowSpecification();
 	FlowSpecification(struct flow_spec * fspec);
 	bool operator==(const FlowSpecification &other) const;

--- a/librina/include/librina/ipc-process.h
+++ b/librina/include/librina/ipc-process.h
@@ -686,7 +686,8 @@ public:
 	 * @return the handle to the response message
 	 * @throws PortAllocationException if something goes wrong
 	 */
-	unsigned int allocatePortId(const ApplicationProcessNamingInformation& appName);
+	unsigned int allocatePortId(const ApplicationProcessNamingInformation& appName,
+				    const FlowSpecification& fspec);
 
 	/**
 	 * Request the kernel to free a used port-id

--- a/librina/src/common.cc
+++ b/librina/src/common.cc
@@ -253,7 +253,6 @@ decode_apnameinfo(const std::string &encodedString)
 }
 
 /* CLASS FLOW SPECIFICATION */
-
 FlowSpecification::FlowSpecification() {
 	averageSDUBandwidth = 0;
 	averageBandwidth = 0;
@@ -266,6 +265,7 @@ FlowSpecification::FlowSpecification() {
 	jitter = 0;
 	delay = 0;
 	maxSDUsize = 0;
+	msg_boundaries = false;
 }
 
 FlowSpecification::FlowSpecification(struct flow_spec * fspec)
@@ -281,13 +281,15 @@ FlowSpecification::FlowSpecification(struct flow_spec * fspec)
 	jitter = fspec->jitter;
 	delay = fspec->delay;
 	maxSDUsize = fspec->max_sdu_size;
+	msg_boundaries = fspec->msg_boundaries;
 }
 
 const std::string FlowSpecification::toString() {
         std::stringstream ss;
         ss<<"Jitter: "<<jitter<<"; Delay: "<<delay<<std::endl;
         ss<<"In oder delivery: "<<orderedDelivery;
-        ss<<"; Partial delivery allowed: "<<partialDelivery<<std::endl;
+        ss<<"; Partial delivery allowed: "<<partialDelivery;
+        ss<<"; Preserve message boundaries: "<<msg_boundaries<<std::endl;
         ss<<"Max allowed gap between SDUs: "<<maxAllowableGap;
         ss<<"; Undetected bit error rate: "<<undetectedBitErrorRate<<std::endl;
         ss<<"Average bandwidth (bytes/s): "<<averageBandwidth;
@@ -313,6 +315,7 @@ struct flow_spec * FlowSpecification::to_c_flowspec() const
 	fspec->peak_bandwidth_duration = peakBandwidthDuration;
 	fspec->peak_sdu_bandwidth_duration = peakSDUBandwidthDuration;
 	fspec->undetected_bit_error_rate = undetectedBitErrorRate;
+	fspec->msg_boundaries = msg_boundaries;
 
 	return fspec;
 }

--- a/librina/src/ipc-process.cc
+++ b/librina/src/ipc-process.cc
@@ -692,7 +692,8 @@ void ExtendedIPCManager::queryRIBResponse(const QueryRIBRequestEvent& event,
 #endif
 }
 
-unsigned int ExtendedIPCManager::allocatePortId(const ApplicationProcessNamingInformation& appName)
+unsigned int ExtendedIPCManager::allocatePortId(const ApplicationProcessNamingInformation& appName,
+						const FlowSpecification& fspec)
 {
 	unsigned int result = 0;
 
@@ -703,6 +704,7 @@ unsigned int ExtendedIPCManager::allocatePortId(const ApplicationProcessNamingIn
         msg = new irati_kmsg_ipcp_allocate_port();
         msg->msg_type = RINA_C_IPCP_ALLOCATE_PORT_REQUEST;
         msg->app_name = appName.to_c_name();
+        msg->msg_boundaries = fspec.msg_boundaries;
         msg->src_ipcp_id = ipcProcessId;
         msg->dest_ipcp_id = ipcProcessId;
         msg->dest_port = 0;

--- a/librina/wrap/rina-api/src/rina-api.cc
+++ b/librina/wrap/rina-api/src/rina-api.cc
@@ -305,13 +305,25 @@ irati_fa_req_fill(struct irati_kmsg_ipcm_allocate_flow *req, const char *dif_nam
 	req->local = ln;
 	req->remote = rn;
 	req->fspec = new flow_spec();
-	req->fspec->average_bandwidth = flowspec->avg_bandwidth;
-	req->fspec->average_sdu_bandwidth = 0;
-	req->fspec->delay = flowspec->max_delay;
-	req->fspec->jitter = flowspec->max_jitter;
-	req->fspec->max_allowable_gap = flowspec->max_sdu_gap;
-	req->fspec->undetected_bit_error_rate = flowspec->max_loss;
-	req->fspec->ordered_delivery = flowspec->in_order_delivery;
+	if (flowspec) {
+		req->fspec->average_bandwidth = flowspec->avg_bandwidth;
+		req->fspec->average_sdu_bandwidth = 0;
+		req->fspec->delay = flowspec->max_delay;
+		req->fspec->jitter = flowspec->max_jitter;
+		req->fspec->max_allowable_gap = flowspec->max_sdu_gap;
+		req->fspec->undetected_bit_error_rate = flowspec->max_loss;
+		req->fspec->ordered_delivery = flowspec->in_order_delivery;
+	} else {
+		req->fspec->average_bandwidth = 0;
+		req->fspec->average_sdu_bandwidth = 0;
+		req->fspec->delay = 0;
+		req->fspec->jitter = 0;
+		req->fspec->max_allowable_gap = 10;
+		req->fspec->ordered_delivery = false;
+		req->fspec->undetected_bit_error_rate = 0;
+		req->fspec->partial_delivery = true;
+	}
+
 	req->pid = getpid();
 
 	return 0;

--- a/librina/wrap/rina-api/src/rina-api.cc
+++ b/librina/wrap/rina-api/src/rina-api.cc
@@ -313,6 +313,7 @@ irati_fa_req_fill(struct irati_kmsg_ipcm_allocate_flow *req, const char *dif_nam
 		req->fspec->max_allowable_gap = flowspec->max_sdu_gap;
 		req->fspec->undetected_bit_error_rate = flowspec->max_loss;
 		req->fspec->ordered_delivery = flowspec->in_order_delivery;
+		req->fspec->msg_boundaries = flowspec->msg_boundaries;
 	} else {
 		req->fspec->average_bandwidth = 0;
 		req->fspec->average_sdu_bandwidth = 0;
@@ -322,6 +323,7 @@ irati_fa_req_fill(struct irati_kmsg_ipcm_allocate_flow *req, const char *dif_nam
 		req->fspec->ordered_delivery = false;
 		req->fspec->undetected_bit_error_rate = 0;
 		req->fspec->partial_delivery = true;
+		req->fspec->msg_boundaries = false;
 	}
 
 	req->pid = getpid();

--- a/rina-tools/src/key-managers/km-common.cc
+++ b/rina-tools/src/key-managers/km-common.cc
@@ -633,6 +633,7 @@ void KMIPCResourceManager::allocate_flow(const ApplicationProcessNamingInformati
         //Request a reliable flow
         qosspec.maxAllowableGap = 0;
         qosspec.orderedDelivery = true;
+        qosspec.msg_boundaries = true;
 
         ipcManager->requestFlowAllocation(local_app_name,
         				  remote_app_name,

--- a/rina-tools/src/rina-cdap-echo/cdap-echo-client.cc
+++ b/rina-tools/src/rina-cdap-echo/cdap-echo-client.cc
@@ -90,6 +90,7 @@ void Client::createFlow()
     IPCEvent* event;
     uint seqnum;
 
+    qosspec.msg_boundaries = true;
     if (gap >= 0)
         qosspec.maxAllowableGap = gap;
 

--- a/rina-tools/src/rina-echo-time/et-client.cc
+++ b/rina-tools/src/rina-echo-time/et-client.cc
@@ -181,6 +181,7 @@ int Client::createFlow()
         if (gap >= 0)
                 qosspec.maxAllowableGap = gap;
 
+        qosspec.msg_boundaries = true;
         qosspec.delay = delay;
 
         get_current_time(begintp);

--- a/rinad/etc/default.dif
+++ b/rinad/etc/default.dif
@@ -10,7 +10,7 @@
     	"frameLength" : 4,
     	"sequenceNumberLength" : 4,
     	"ctrlSequenceNumberLength" : 4,
-    	"maxPduSize" : 10000,
+    	"maxPduSize" : 1470,
     	"maxPduLifetime" : 60000
     },
     "qosCubes" : [ {

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -917,6 +917,7 @@ rina::messages::qosSpecification_t* get_qosSpecification_t(
 	gpf_flow_spec->set_maxallowablegapsdu(flow_spec.maxAllowableGap);
 	gpf_flow_spec->set_delay(flow_spec.delay);
 	gpf_flow_spec->set_jitter(flow_spec.jitter);
+	gpf_flow_spec->set_msg_boundaries(flow_spec.msg_boundaries);
 
 	return gpf_flow_spec;
 }
@@ -942,6 +943,7 @@ void get_FlowSpecification(const rina::messages::qosSpecification_t &gpf_qos,
         qos.maxAllowableGap = gpf_qos.maxallowablegapsdu();
         qos.delay = gpf_qos.delay();
         qos.jitter = gpf_qos.jitter();
+        qos.msg_boundaries = gpf_qos.msg_boundaries();
 }
 }  // namespace flow_helpers
 

--- a/rinad/src/common/encoders/QoSSpecification.proto
+++ b/rinad/src/common/encoders/QoSSpecification.proto
@@ -17,4 +17,5 @@ message qosSpecification_t{									//The QoS parameters requested by an applica
 	optional uint32 delay = 11; 					//in milliseconds, indicates the maximum delay allowed in this flow. A value of 0 indicates don't care
 	optional uint32 jitter = 12;					//in milliseconds, indicates indicates the maximum jitter allowed in this flow. A value of 0 indicates don't care
 	repeated property_t extraParameters = 13; 		//the extra parameters specified by the application process that requested this flow
+	optional bool msg_boundaries = 14;			    //preserve message boundaries if true, don't do it otherwise
 }

--- a/rinad/src/ipcp/enrollment-task.cc
+++ b/rinad/src/ipcp/enrollment-task.cc
@@ -1245,6 +1245,8 @@ void EnrollmentTask::initiateEnrollment(const rina::EnrollmentRequest& request)
 	flowInformation.localAppName.processName = ipcp->get_name();
 	flowInformation.localAppName.processInstance = ipcp->get_instance();
 	flowInformation.difName = request.neighbor_.supporting_dif_name_;
+	flowInformation.flowSpecification.msg_boundaries = true;
+	flowInformation.flowSpecification.orderedDelivery = true;
 	unsigned int handle = -1;
 	try {
 		handle = irm_->allocateNMinus1Flow(flowInformation);

--- a/rinad/src/ipcp/flow-allocator.cc
+++ b/rinad/src/ipcp/flow-allocator.cc
@@ -392,7 +392,8 @@ void FlowAllocator::createFlowRequestMessageReceived(configs::Flow * flow,
 		connection->setDestCepId(connection->getSourceCepId());
 
 		try {
-			seq_num = rina::extendedIPCManager->allocatePortId(app_info);
+			seq_num = rina::extendedIPCManager->allocatePortId(app_info,
+									   flow->flow_specification);
 		} catch (rina::Exception &e) {
 			LOG_IPCP_ERR("Problems requesting an available port-id to the Kernel IPC Manager: %s",
 					e.what());
@@ -474,7 +475,8 @@ void FlowAllocator::submitAllocateRequest(const rina::FlowRequestEvent& event,
 	rina::ScopedLock g(port_alloc_lock);
 
 	try {
-		seq_num = rina::extendedIPCManager->allocatePortId(app_info);
+		seq_num = rina::extendedIPCManager->allocatePortId(app_info,
+								   event.flowSpecification);
 	} catch (rina::Exception &e) {
 		LOG_IPCP_ERR("Problems requesting an available port-id to the Kernel IPC Manager: %s",
 				e.what());

--- a/tests/conf/default.dif
+++ b/tests/conf/default.dif
@@ -10,7 +10,7 @@
         "frameLength" : 4,
     	"sequenceNumberLength" : 4,
         "ctrlSequenceNumberLength" : 4,
-    	"maxPduSize" : 10000,
+    	"maxPduSize" : 1470,
     	"maxPduLifetime" : 60000
     },
     "qosCubes" : [ {


### PR DESCRIPTION
Implemented the msg_boundaries flag of the flow_spec, return -EMSGSIZE when msg boundaries are preserved and SDU is too large for underlying DIF.