### PR TITLE
Arcfire: support kernel 4.1 - 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ of IRATI in future releases.
 ## 2. Build instructions                                                       #
 #############################################################################
 
-### Building on Debian 8
+### Building on Ubuntu 16.04 and Debian 8
 #############################################################################
 
-For the kernel modules, a Linux kernel with a version between 4.1 and 4.9 (included) has to be installed in 
-the system, with the kernel headers.
+**NOTE for Debian 8**: For the kernel modules, a Linux kernel with a version between 4.1 
+and 4.9 (included) has to be installed in the system, with the kernel headers. Ubuntu 
+16.04 already comes with Linux kernel 4.4, therefore no new kernel needs to be installed. 
 
 Once this is done, please install user-space dependencies
 
@@ -55,9 +56,9 @@ Once this is done, please install user-space dependencies
     $ apt-get install pkg-config
     $ apt-get install git
     $ apt-get install g++
-    $ apt-get install libssl-dev=1.0.1k-3
-    $ apt-get install protobuf-compiler=2.6.1-1
-    $ apt-get install libprotobuf-dev=2.6.1-1
+    $ apt-get install libssl-dev
+    $ apt-get install protobuf-compiler
+    $ apt-get install libprotobuf-dev
     $ apt-get install hostapd (if the system will be configured as an access point)
     $ apt-get install wpasupplicant (if the system will be configured as a mobile host)
 

--- a/kernel/ipcp-factories.h
+++ b/kernel/ipcp-factories.h
@@ -44,6 +44,8 @@ struct ipcp_factory {
         struct robject                  robj;
         struct ipcp_factory_data *      data;
         const struct ipcp_factory_ops * ops;
+        struct list_head       		list;
+        char * 				name;
 };
 
 struct ipcp_factories;

--- a/kernel/rds/robjects.c
+++ b/kernel/rds/robjects.c
@@ -142,13 +142,3 @@ void
 rset_unregister(struct rset * set)
 { return kset_unregister(to_kset(set)); }
 EXPORT_SYMBOL(rset_unregister);
-
-struct robject *rset_find_obj(struct rset *rset, const char *name)
-{
-	struct kobject * kobj;
-	kobj = kset_find_obj(to_kset(rset), name);
-	if (kobj)
-		return container_of(kobj, struct robject, kobj);
-	return NULL;
-}
-EXPORT_SYMBOL(rset_find_obj);

--- a/kernel/rds/robjects.h
+++ b/kernel/rds/robjects.h
@@ -200,5 +200,4 @@ rset_create_and_add(const char *name, struct robject *parent);
 void
 rset_unregister(struct rset * set);
 
-struct robject *rset_find_obj(struct rset *rset, const char *name);
 #endif


### PR DESCRIPTION
Avoid using symbol that was not exported in kernel versions previous to 4.4. This allows IRATI to support standard Ubuntu 16.04 (which runs on a 4.4 kernel)