### PR TITLE
1109 travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ before_install:
   - sudo apt-get install git
   - sudo apt-get install g++
   - sudo apt-get install libssl-dev
-  #- sudo apt-get install protobuf-compiler 
-  #- sudo apt-get install libprotobuf-dev 
+  #- sudo apt-get install protobuf-compiler
+  #- sudo apt-get install libprotobuf-dev
   - sudo apt-get install hostapd
   - sudo apt-get install wpasupplicant
 
 before_script:
-  # Make a build and install directory 
+  # Make a build and install directory
   - mkdir build
   - mkdir install
   # Install version 2.6.1 of Protocol Buffers
@@ -27,11 +27,12 @@ before_script:
   - cd protobuf-2.6.1
   - ./configure && make
   - sudo make install
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
   - cd ..
 
 script:
   # Run the IRATI stack build script
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/install/lib
+  - export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:~/install/lib/pkgconfig
   - sudo ldconfig
   - sudo ./configure --prefix ~/install
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: enabled
 dist: trusty
 
 env:
+   VERSION=1.2.0
    INSTALL_PREFIX=~/install
-   PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig 
+   PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig
    LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: enabled
 dist: trusty
 
+env:
+   INSTALL_PREFIX=~/install
+   PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig 
+   LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH
+
 before_install:
   # Install Dependencies
   #- sudo apt-get update -qq
@@ -32,5 +37,5 @@ before_script:
 script:
   # Run the IRATI stack build script
   - sudo ldconfig
-  - sudo ./configure --prefix ~/install
+  - sudo ./configure --prefix $INSTALL_PREFIX
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - cd protobuf-2.6.1
   - ./configure && make
   - sudo make install
+  - export LD_LIBRARY_PATH=/usr/local/lib
   - cd ..
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,29 +16,18 @@ before_install:
   #- sudo apt-get install libprotobuf-dev 
   - sudo apt-get install hostapd
   - sudo apt-get install wpasupplicant
-  - sudo apt-get install zlib1g-dev
 
 before_script:
-  - wget http://es.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/libprotobuf9v5_2.6.1-1.3_amd64.deb
-  - wget http://es.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/libprotobuf-lite9v5_2.6.1-1.3_amd64.deb
-  - wget http://es.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/libprotoc9v5_2.6.1-1.3_amd64.deb
-  - wget http://es.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/protobuf-compiler_2.6.1-1.3_amd64.deb
-  - wget http://es.archive.ubuntu.com/ubuntu/pool/main/p/protobuf/libprotobuf-dev_2.6.1-1.3_amd64.deb
-  - sudo dpkg -i libprotobuf9v5_2.6.1-1.3_amd64.deb
-  - sudo dpkg -i libprotobuf-lite9v5_2.6.1-1.3_amd64.deb
-  - sudo dpkg -i libprotoc9v5_2.6.1-1.3_amd64.deb
-  - sudo dpkg -i protobuf-compiler_2.6.1-1.3_amd64.deb
-  - sudo dpkg -i libprotobuf-dev_2.6.1-1.3_amd64.deb
   # Make a build and install directory 
   - mkdir build
   - mkdir install
   # Install version 2.6.1 of Protocol Buffers
-  #- wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
-  #- tar -xvzf protobuf-2.6.1.tar.gz
-  #- cd protobuf-2.6.1
-  #- ./configure && make
-  #- sudo make install
-  #- cd ..
+  - wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
+  - tar -xvzf protobuf-2.6.1.tar.gz
+  - cd protobuf-2.6.1
+  - ./configure && make
+  - sudo make install
+  - cd ..
 
 script:
   # Run the IRATI stack build script

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 before_install:
   # Install Dependencies
-  - sudo apt-get update -qq
+  #- sudo apt-get update -qq
   - sudo apt-get install linux-headers-$(uname -r)
   - sudo apt-get install autoconf
   - sudo apt-get install automake

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,6 @@ before_script:
 
 script:
   # Run the IRATI stack build script
+  - sudo ldconfig
   - sudo ./configure --prefix ~/install
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_script:
 
 script:
   # Run the IRATI stack build script
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/install/lib
-  - export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:~/install/lib/pkgconfig
+  - export LD_LIBRARY_PATH=~/install/lib:$LD_LIBRARY_PATH
+  - export PKG_CONFIG_PATH=~/install/lib/pkgconfig:$PKG_CONFIG_PATH
   - sudo ldconfig
   - sudo ./configure --prefix ~/install
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - cd protobuf-2.6.1
   - ./configure && make
   - sudo make install
-  - export LD_LIBRARY_PATH=/usr/local/lib
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
   - cd ..
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ before_script:
 
 script:
   # Run the IRATI stack build script
-  - export LD_LIBRARY_PATH=~/install/lib:$LD_LIBRARY_PATH
-  - export PKG_CONFIG_PATH=~/install/lib/pkgconfig:$PKG_CONFIG_PATH
   - sudo ldconfig
   - sudo ./configure --prefix ~/install
   - sudo make install

--- a/configure
+++ b/configure
@@ -98,9 +98,6 @@ echo "Starting rinad phase"
 }
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
     echo "Cannot complete rinad phase"
-    echo "PKG_CONFIG_PATH=" $PKG_CONFIG_PATH
-    pkg-config --modversion librina
-    more $INSTALL_PREFIX/lib/pkgconfig/librina.pc
     exit 1
 }
 

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ do
             exit 255
         fi
         ;;
-        
+
         "--tcp-udp-buffer-size")
         if [ -n "$2" ]; then
             TCP_UDP_BUFFER_SIZE=$2
@@ -86,7 +86,7 @@ echo "Starting librina phase"
     echo "Cannot bootstrap"
     exit 1
 }
-(mkdir -p $BUILDDIR/librina && cd $BUILDDIR/librina && $SRCDIR/librina/configure --disable-java-bindings $FLAGS --prefix=$INSTALL_PREFIX && make clean install) || {
+(mkdir -p $BUILDDIR/librina && cd $BUILDDIR/librina && $SRCDIR/librina/configure --disable-java-bindings $FLAGS --prefix=$INSTALL_PREFIX && make clean install && sudo ldconfig) || {
     echo "Cannot complete librina phase"
     exit 1
 }

--- a/configure
+++ b/configure
@@ -98,9 +98,7 @@ echo "Starting rinad phase"
 }
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
     echo "Cannot complete rinad phase"
-    echo "PKG_CONFIG_PATH=" $PKG_CONFIG_PATH
-    pkg-config --modversion librina
-    more $INSTALL_PREFIX/lib/pkgconfig/librina.pc
+    echo "LIBRINA Version =" pkg-config --modversion librina
     exit 1
 }
 
@@ -111,6 +109,7 @@ echo "Starting rina-tools phase"
 }
 (mkdir -p $BUILDDIR/rina-tools && cd $BUILDDIR/rina-tools && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rina-tools/configure $FLAGS --prefix=$INSTALL_PREFIX) || {
     echo "Cannot complete rina-tools phase"
+    echo "LIBRINA Version =" pkg-config --modversion librina
     exit 1
 }
 

--- a/configure
+++ b/configure
@@ -98,8 +98,9 @@ echo "Starting rinad phase"
 }
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
     echo "Cannot complete rinad phase"
-    echo "PKG_CONFIG_PATH= " $PKG_CONFIG_PATH
+    echo "PKG_CONFIG_PATH=" $PKG_CONFIG_PATH
     pkg-config --list-all
+    more $INSTALL_PREFIX/lib/pkgconfig/librina.pc
     exit 1
 }
 

--- a/configure
+++ b/configure
@@ -99,7 +99,7 @@ echo "Starting rinad phase"
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
     echo "Cannot complete rinad phase"
     echo "PKG_CONFIG_PATH=" $PKG_CONFIG_PATH
-    pkg-config --list-all
+    pkg-config --modversion librina
     more $INSTALL_PREFIX/lib/pkgconfig/librina.pc
     exit 1
 }

--- a/configure
+++ b/configure
@@ -92,11 +92,11 @@ echo "Starting librina phase"
 }
 
 echo "Starting rinad phase"
-(cd rinad && export PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig && ./bootstrap) || {
+(cd rinad && ./bootstrap) || {
     echo "Cannot bootstrap"
     exit 1
 }
-(mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
+(mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS && echo $PKG_CONFIG_PATH) || {
     echo "Cannot complete rinad phase"
     exit 1
 }

--- a/configure
+++ b/configure
@@ -98,7 +98,8 @@ echo "Starting rinad phase"
 }
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
     echo "Cannot complete rinad phase"
-    echo "LIBRINA Version =" pkg-config --modversion librina
+    echo "LIBRINA Version ="
+    pkg-config --modversion librina
     exit 1
 }
 
@@ -109,7 +110,8 @@ echo "Starting rina-tools phase"
 }
 (mkdir -p $BUILDDIR/rina-tools && cd $BUILDDIR/rina-tools && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rina-tools/configure $FLAGS --prefix=$INSTALL_PREFIX) || {
     echo "Cannot complete rina-tools phase"
-    echo "LIBRINA Version =" pkg-config --modversion librina
+    echo "LIBRINA Version ="
+    pkg-config --modversion librina
     exit 1
 }
 

--- a/configure
+++ b/configure
@@ -86,13 +86,13 @@ echo "Starting librina phase"
     echo "Cannot bootstrap"
     exit 1
 }
-(mkdir -p $BUILDDIR/librina && cd $BUILDDIR/librina && $SRCDIR/librina/configure --disable-java-bindings $FLAGS --prefix=$INSTALL_PREFIX && make clean install && sudo ldconfig) || {
+(mkdir -p $BUILDDIR/librina && cd $BUILDDIR/librina && $SRCDIR/librina/configure --disable-java-bindings $FLAGS --prefix=$INSTALL_PREFIX && make clean install) || {
     echo "Cannot complete librina phase"
     exit 1
 }
 
 echo "Starting rinad phase"
-(cd rinad && ./bootstrap) || {
+(cd rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig ./bootstrap) || {
     echo "Cannot bootstrap"
     exit 1
 }

--- a/configure
+++ b/configure
@@ -92,7 +92,7 @@ echo "Starting librina phase"
 }
 
 echo "Starting rinad phase"
-(cd rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig ./bootstrap) || {
+(cd rinad && export PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig && ./bootstrap) || {
     echo "Cannot bootstrap"
     exit 1
 }

--- a/configure
+++ b/configure
@@ -98,6 +98,9 @@ echo "Starting rinad phase"
 }
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
     echo "Cannot complete rinad phase"
+    echo "PKG_CONFIG_PATH=" $PKG_CONFIG_PATH
+    pkg-config --modversion librina
+    more $INSTALL_PREFIX/lib/pkgconfig/librina.pc
     exit 1
 }
 

--- a/configure
+++ b/configure
@@ -96,8 +96,10 @@ echo "Starting rinad phase"
     echo "Cannot bootstrap"
     exit 1
 }
-(mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS && echo $PKG_CONFIG_PATH) || {
-    echo "Cannot complete rinad phase"
+(mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
+    echo "Cannot complete rinad phase \n"
+    echo $PKG_CONFIG_PATH
+    pkg-config --list-all
     exit 1
 }
 

--- a/configure
+++ b/configure
@@ -97,8 +97,8 @@ echo "Starting rinad phase"
     exit 1
 }
 (mkdir -p $BUILDDIR/rinad && cd $BUILDDIR/rinad && PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH $SRCDIR/rinad/configure --prefix=$INSTALL_PREFIX --disable-java-bindings $FLAGS) || {
-    echo "Cannot complete rinad phase \n"
-    echo $PKG_CONFIG_PATH
+    echo "Cannot complete rinad phase"
+    echo "PKG_CONFIG_PATH= " $PKG_CONFIG_PATH
     pkg-config --list-all
     exit 1
 }

--- a/rina-tools/configure.ac
+++ b/rina-tools/configure.ac
@@ -138,7 +138,7 @@ AM_CONDITIONAL([HAVE_PYTHON_MATPLOT_LIB], [ test "$ax_cv_have_matplotlib" != "no
 
 PKG_PROG_PKG_CONFIG([0.26])
 
-PKG_CHECK_MODULES([LIBRINA], [librina >= 0.2.0],, [
+PKG_CHECK_MODULES([LIBRINA], [librina],, [
     AC_MSG_ERROR([Your system lacks of librina support])
 ])
 # FIXME: A cleaner solution would be better

--- a/rina-tools/configure.ac
+++ b/rina-tools/configure.ac
@@ -144,7 +144,7 @@ PKG_CHECK_MODULES([LIBRINA], [librina],, [
 # FIXME: A cleaner solution would be better
 AC_SUBST([LIBRINA_VERSION],`pkg-config --modversion librina`)
 
-PKG_CHECK_MODULES([LIBRINA_API], [librina-api >= 0.2.0],, [
+PKG_CHECK_MODULES([LIBRINA_API], [librina-api],, [
     AC_MSG_ERROR([Your system lacks of librina-api support])
 ])
 # FIXME: A cleaner solution would be better

--- a/rinad/configure.ac
+++ b/rinad/configure.ac
@@ -114,7 +114,7 @@ AC_SUBST(CXXFLAGS_EXTRA, $CXXFLAGS_EXTRA)
 
 PKG_PROG_PKG_CONFIG([0.26])
 
-PKG_CHECK_MODULES([LIBRINA], [librina >= 0.2.0],, [
+PKG_CHECK_MODULES([LIBRINA], [librina],, [
     AC_MSG_ERROR([Your system lacks of librina support])
 ])
 # FIXME: A cleaner solution would be better


### PR DESCRIPTION
Finally got the IRATI stack to build on the Travis CI service. All is explained in the issue ticket](https://github.com/IRATI/stack/issues/1109).

This branch has the latest commits from the arcfire branch and gets a nice green tick mark beside it to show that the build passes.

The main point for review is that I had to remove the dependency on version 0.2.0 of librina in the configuration of [rinad](https://github.com/IRATI/stack/blob/1109-travis-ci/rinad/configure.ac#L117) and [rina-tools](https://github.com/IRATI/stack/blob/1109-travis-ci/rina-tools/configure.ac#L141). 

The system still checks that librina is there, but it does not check for a specific version. 

The reason, this check is not done, is due to the fact that librina uses [git-version-gen](https://github.com/IRATI/stack/blob/1109-travis-ci/librina/build-aux/git-version-gen) to create it's PACKAGE_VERSION, however in the Travis CI world the $VERSION that is generated by this system build is not passed as a global environment variable and thus the VERSION of librina gets set to UNKNOWN in it's package config file .pc. The knock on effect is that configure just bombs out when checking for librina at 0.2.0 or greater.
 
As stated with this change, the configure script still looks for `librina` but no version is specified.

Please review and let me know if any further changes are necessary.
 