### PR TITLE
Add protocol to www.irati.eu href to load correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 <h3>
 <a id="contributors" class="anchor" href="#contributors" aria-hidden="true"><span class="octicon octicon-link"></span></a>Contributors</h3>
 
-<p>This source code was developed by members of the <a href="www.irati.eu">IRATI project</a>, funded by
+<p>This source code was developed by members of the <a href="http://www.irati.eu">IRATI project</a>, funded by
 the European commission under the 7th Framework Programme grant number 317814. </p>
 
 <p>The contributing members of the project are (alphabetical order):</p>


### PR DESCRIPTION
The anchor link href for www.irati.eu uses a relative syntax, causing the browser to try to load "http://irati.github.io/stack/www.irati.eu" instead. Adding the protocol so the href is "http://www.irati.eu" should fix the issue.