### PR TITLE
qta-mux & bug fixes

### DIFF
--- a/kernel/ipcps/shim-eth-vlan-core.c
+++ b/kernel/ipcps/shim-eth-vlan-core.c
@@ -40,6 +40,7 @@
 #define SHIM_NAME   	    "shim-eth-vlan"
 #define SHIM_WIFI_STA_NAME  "shim-wifi-sta"
 #define SHIM_WIFI_AP_NAME   "shim-wifi-ap"
+#define ENABLE_PORT_NOTIFS 20
 
 #define RINA_PREFIX SHIM_NAME
 
@@ -927,7 +928,7 @@ static void eth_vlan_skb_destructor(struct sk_buff *skb)
 
 	spin_lock_bh(&data->lock);
 	notify = data->tx_busy;
-	data->tx_busy = 0;
+	data->tx_busy--;
 	spin_unlock_bh(&data->lock);
 
 	if (notify) {
@@ -1039,7 +1040,7 @@ static int eth_vlan_du_write(struct ipcp_instance_data * data,
         if (retval != NET_XMIT_SUCCESS) {
         	spin_lock_bh(&data->lock);
         	LOG_DBG("qdisc cannot enqueue now (%d), try later", retval);
-        	data->tx_busy = 1;
+        	data->tx_busy = ENABLE_PORT_NOTIFS;
         	spin_unlock_bh(&data->lock);
         	return -EAGAIN;
         }

--- a/plugins/qta_mux/README.md
+++ b/plugins/qta_mux/README.md
@@ -97,10 +97,11 @@ must contain one parameter describing the C/U mux configuration, and then one pa
 QoS id to a cherish-urgency level and also describe the configuration of its associated Policer/Shaper.
 
 The format of the **cumux** configuration is the following:
-* parameter name: "**cumux**"
-* parameter vaue: "<cherish_levels>**:**<urgency_levels>**:**<abs_thres_cherish_level1>**,**<prob_thres_cherish_level1>**,**<drop_prob_cherish_level1>**:**...
-   * <urgency_levels> : The number of urgency levels
+* parameter name: "<urgency_level>.**cumux**"
+   * <urgency_level> : The urgency level being configured
+* parameter vaue: "<cherish_levels>**:**<drop>**:**<abs_thres_cherish_level1>**,**<prob_thres_cherish_level1>**,**<drop_prob_cherish_level1>**:**...
    * <cherish_levels> : The number of cherish levels
+   * <drop> : If 0, probabilistically mark packets with ECN flag (within the probabilistic threshold), otherwise probabilistically drop them
    * <abs_thres_cherish_level1> : The absolute threshold for the first cherish level
    * <prob_thres_cherish_level1> : The probabilistic threshold for the first cherish level
    * <drop_prob_cherish_level1> : The drop probability for the first cherish level
@@ -127,8 +128,11 @@ The example below illustrates a configuration of a QTAMux with a 2 by 2 C/U matr
           "name" : "qta-mux-ps",
           "version" : "1",
            "parameters" : [{
-               "name"  : "cumux",
-               "value" : "2:2:120,120,0:100,90,10"
+               "name"  : "1.cumux",
+               "value" : "2:1:120,120,0:100,90,10"
+             }, {
+               "name"  : "2.cumux",
+               "value" : "2:1:60,60,0:50,40,30"
              }, {
                "name"  : "1.qosid",
                "value" : "1:1:25000:10000000"
@@ -145,15 +149,27 @@ The example below illustrates a configuration of a QTAMux with a 2 by 2 C/U matr
         }
      },
 
-The **cumux** parameter value (2:2:120,120,0:100,90,10) describes a 2x2 C/U mux, with the following thresholds for each cherish level:
-* Cherish level 1
-   * Absolute threshold: 120 PDUs
-   * Probabilistic threshold: 120 PDUs
-   * Drop probability: 0%
-* Cherish level 2
-   * Absolute threshold: 100 PDUs
-   * Probabilistic threshold: 90 PDUs
-   * Drop probability: 10%
+The **cumux** parameter values describes a 2x2 C/U mux, with the following thresholds for each urgency/cherish level:
+* Urgency level 1
+   * Drop / set ECN flag: set ECN flag
+   * Cherish level 1
+      * Absolute threshold: 120 PDUs
+      * Probabilistic threshold: 120 PDUs
+      * Drop / ECN probability: 0%
+   * Cherish level 2
+      * Absolute threshold: 100 PDUs
+      * Probabilistic threshold: 90 PDUs
+      * Drop / ECN probability: 10%
+* Urgency level 2
+   * Drop / set ECN flag: Drop
+   * Cherish level 1
+      * Absolute threshold: 60 PDUs
+      * Probabilistic threshold: 60 PDUs
+      * Drop / ECN probability: 0%
+   * Cherish level 2
+      * Absolute threshold: 50 PDUs
+      * Probabilistic threshold: 40 PDUs
+      * Drop / ECN probability: 30%
 
 The **qosid** parameter values describe 4 QoS classes, with the following configuration:
 * QoS id 1

--- a/plugins/qta_mux/README.md
+++ b/plugins/qta_mux/README.md
@@ -99,12 +99,13 @@ QoS id to a cherish-urgency level and also describe the configuration of its ass
 The format of the **cumux** configuration is the following:
 * parameter name: "<urgency_level>.**cumux**"
    * <urgency_level> : The urgency level being configured
-* parameter vaue: "<cherish_levels>**:**<drop>**:**<abs_thres_cherish_level1>**,**<prob_thres_cherish_level1>**,**<drop_prob_cherish_level1>**:**...
+* parameter vaue: "<cherish_levels>**:**<drop>**:**<dequeue_prob>**:**<abs_thres_cherish_level1>**,**<prob_thres_cherish_level1>**,**<drop_prob_cherish_level1>**:**...
    * <cherish_levels> : The number of cherish levels
    * <drop> : If 0, probabilistically mark packets with ECN flag (within the probabilistic threshold), otherwise probabilistically drop them
+   * <dequeue_prob> : If there is a PDU in this queue, the probability to dequeue it in case queues with lower urgency levels also have queued PDUs [0-100]
    * <abs_thres_cherish_level1> : The absolute threshold for the first cherish level
    * <prob_thres_cherish_level1> : The probabilistic threshold for the first cherish level
-   * <drop_prob_cherish_level1> : The drop probability for the first cherish level
+   * <drop_prob_cherish_level1> : The drop probability for the first cherish level [0-100]
    * ...
    * <abs_thres_cherish_levelN> : The absolute threshold for the Nth cherish level
    * ...
@@ -129,10 +130,10 @@ The example below illustrates a configuration of a QTAMux with a 2 by 2 C/U matr
           "version" : "1",
            "parameters" : [{
                "name"  : "1.cumux",
-               "value" : "2:0:120,120,0:100,90,10"
+               "value" : "2:1:90:120,120,0:100,90,10"
              }, {
                "name"  : "2.cumux",
-               "value" : "2:1:60,60,0:50,40,30"
+               "value" : "2:1:100:60,60,0:50,40,30"
              }, {
                "name"  : "1.qosid",
                "value" : "1:1:25000:10000000"
@@ -152,6 +153,7 @@ The example below illustrates a configuration of a QTAMux with a 2 by 2 C/U matr
 The **cumux** parameter values describes a 2x2 C/U mux, with the following thresholds for each urgency/cherish level:
 * Urgency level 1
    * Drop / set ECN flag: set ECN flag
+   * Dequeue probability: 90%
    * Cherish level 1
       * Absolute threshold: 120 PDUs
       * Probabilistic threshold: 120 PDUs
@@ -162,6 +164,7 @@ The **cumux** parameter values describes a 2x2 C/U mux, with the following thres
       * Drop / ECN probability: 10%
 * Urgency level 2
    * Drop / set ECN flag: Drop
+   * Dequeue probability: 100%
    * Cherish level 1
       * Absolute threshold: 60 PDUs
       * Probabilistic threshold: 60 PDUs

--- a/plugins/qta_mux/README.md
+++ b/plugins/qta_mux/README.md
@@ -129,7 +129,7 @@ The example below illustrates a configuration of a QTAMux with a 2 by 2 C/U matr
           "version" : "1",
            "parameters" : [{
                "name"  : "1.cumux",
-               "value" : "2:1:120,120,0:100,90,10"
+               "value" : "2:0:120,120,0:100,90,10"
              }, {
                "name"  : "2.cumux",
                "value" : "2:1:60,60,0:50,40,30"

--- a/plugins/qta_mux/qta-mux.c
+++ b/plugins/qta_mux/qta-mux.c
@@ -55,6 +55,7 @@ struct urgency_queue {
 	uint_t		 	   dropped_bytes;
 	uint_t		 	   tx_pdus;
 	uint_t		 	   tx_bytes;
+	uint_t			   dequeue_prob;
 #if QTA_MUX_DEBUG
 	struct urgency_queue_debug_info * debug_info;
 #endif
@@ -106,6 +107,7 @@ struct cherish_thres_t {
 struct urgency_queue_conf {
 	struct list_head         list;
 	uint_t   	         urgency_level;
+	uint_t			 dequeue_prob;
 	struct cherish_thres_t * cherish_thresholds;
 };
 
@@ -158,6 +160,9 @@ static ssize_t urgency_queue_attr_show(struct robject * robj,
 	if (strcmp(robject_attr_name(attr), "urgency") == 0) {
 		return sprintf(buf, "%u\n", q->urgency_level);
 	}
+	if (strcmp(robject_attr_name(attr), "dequeue_prob") == 0) {
+			return sprintf(buf, "%u\n", q->urgency_level);
+		}
 	if (strcmp(robject_attr_name(attr), "queued_pdus") == 0) {
 		return sprintf(buf, "%u\n", q->length);
 	}
@@ -249,7 +254,7 @@ RINA_SYSFS_OPS(cu_mux);
 RINA_ATTRS(cu_mux, urgency_levels, cherish_levels);
 RINA_KTYPE(cu_mux);
 RINA_SYSFS_OPS(urgency_queue);
-RINA_ATTRS(urgency_queue, urgency, queued_pdus, dropped_pdus, tx_pdus);
+RINA_ATTRS(urgency_queue, urgency, dequeue_prob, queued_pdus, dropped_pdus, tx_pdus);
 RINA_KTYPE(urgency_queue);
 RINA_SYSFS_OPS(token_bucket_filter);
 RINA_ATTRS(token_bucket_filter, abs_cherish_th, prob_cherish_th, drop_prob,
@@ -298,6 +303,7 @@ static struct urgency_queue_conf * urgency_queue_conf_create(void)
 
 	INIT_LIST_HEAD(&tmp->list);
 	tmp->urgency_level = 0;
+	tmp->dequeue_prob = 100;
 	tmp->cherish_thresholds = NULL;
 
 	return tmp;
@@ -546,6 +552,7 @@ static struct token_bucket_filter * token_bucket_filter_create(struct urgency_qu
 }
 
 static struct urgency_queue * urgency_queue_create(uint_t urgency_level,
+						   uint_t dequeue_prob,
 						   port_id_t port_id,
 						   struct rset *parent)
 {
@@ -561,6 +568,7 @@ static struct urgency_queue * urgency_queue_create(uint_t urgency_level,
 	INIT_LIST_HEAD(&tmp->queued_pdus);
 	tmp->length = 0;
 	tmp->urgency_level = urgency_level;
+	tmp->dequeue_prob = dequeue_prob;
 	tmp->dropped_bytes = 0;
 	tmp->dropped_pdus = 0;
 	tmp->tx_bytes = 0;
@@ -665,6 +673,8 @@ struct du * qta_rmt_dequeue_policy(struct rmt_ps	  *ps,
 	struct du *            ret_pdu;
 	struct qta_mux *       qta_mux;
 	struct urgency_queue * pos;
+	uint_t		       random_bytes;
+	struct urgency_queue * candidate;
 
 	if (!ps || !n1_port || !n1_port->rmt_ps_queues) {
 		LOG_ERR("Wrong input parameters for "
@@ -682,27 +692,40 @@ struct du * qta_rmt_dequeue_policy(struct rmt_ps	  *ps,
 
 	/* Go through the urgency queues in urgency level: the queues */
 	/* with a higher urgency level are checked first */
+	candidate = NULL;
 	list_for_each_entry(pos, &qta_mux->cu_mux.urgency_queues, list) {
 		if (!list_empty(&pos->queued_pdus)) {
-			ret_pdu = dequeue_pdu(&pos->queued_pdus);
-			pos->length--;
-			pos->tx_pdus++;
-			pos->tx_bytes += du_len(ret_pdu);
-
-#if QTA_MUX_DEBUG
-	if (pos->debug_info->q_index < UQUEUE_DEBUG_SIZE) {
-		pos->debug_info->q_log[pos->debug_info->q_index][0] = pos->length;
-		pos->debug_info->q_log[pos->debug_info->q_index][1] = ktime_get_ns();
-		pos->debug_info->q_index++;
-	}
-#endif
-
-			return ret_pdu;
+			/* This queue is not empty, can be a candidate */
+			get_random_bytes(&random_bytes, sizeof(random_bytes));
+			random_bytes = random_bytes % NORM_PROB;
+			if (pos->dequeue_prob > random_bytes) {
+				/* We can dequeue from this urgency queue */
+				candidate = pos;
+				goto exit;
+			} else if (!candidate) {
+				candidate = pos;
+			}
 		}
 	}
 
-	/* Nothing to dequeue */
-	return NULL;
+exit:
+	if (!candidate)
+		return NULL;
+
+	ret_pdu = dequeue_pdu(&candidate->queued_pdus);
+	candidate->length--;
+	candidate->tx_pdus++;
+	candidate->tx_bytes += du_len(ret_pdu);
+
+#if QTA_MUX_DEBUG
+if (candidate->debug_info->q_index < UQUEUE_DEBUG_SIZE) {
+	candidate->debug_info->q_log[candidate->debug_info->q_index][0] = candidate->length;
+	candidate->debug_info->q_log[candidate->debug_info->q_index][1] = ktime_get_ns();
+	candidate->debug_info->q_index++;
+}
+#endif
+
+	return ret_pdu;
 }
 
 int qta_rmt_enqueue_policy(struct rmt_ps	  *ps,
@@ -941,6 +964,7 @@ void * qta_rmt_q_create_policy(struct rmt_ps      *ps,
 	/* Create one urgency_queue per urgency level, add it to the qta_mux */
 	list_for_each_entry(uq_conf, &config->urgency_queue_conf, list) {
 		urgency_queue = urgency_queue_create(uq_conf->urgency_level,
+						     uq_conf->dequeue_prob,
 						     n1_port->port_id,
 						     qta_mux->cu_mux.rset);
 		if (!urgency_queue) {
@@ -1009,7 +1033,8 @@ static int qta_mux_ps_set_policy_set_param_priv(struct qta_mux_set * data,
 {
 	int offset, delta_offset;
 	qos_id_t qos_id;
-	uint_t urgency_level, cherish_level, max_burst_size, max_rate, drop;
+	uint_t urgency_level, cherish_level, max_burst_size, max_rate,
+	       drop, dequeue_prob;
 	char *qos, *mux;
 	int i, c;
 	struct cherish_thres_t * cherish_levels;
@@ -1111,28 +1136,37 @@ static int qta_mux_ps_set_policy_set_param_priv(struct qta_mux_set * data,
 	}
 
 	/*
-	 * Parse entry of type name = cumux.<urgency_level>
-	 * value = <cherish_levels>:<drop>:
+	 * Parse entry of type name = <urgency_level>.cumux
+	 * value = <cherish_levels>:<drop>:<dequeue_prob>:
 	 * <abs_cherish_thres1>,<prob_cherish_thres1>,<drop_prob1>:...
 	 *
 	 */
 	if (mux) {
 		/* Parse urgency-level from the parameter name */
-		if (parse_int_value(name, '.', (int *) &urgency_level, &offset))
+		offset = 0;
+		if (parse_int_value(name, '.', (int *) &urgency_level,
+				    &delta_offset))
 			return -1;
 
-		/* Parse urgency levels from the parameter value */
+		/* Parse # of cherish levels from the parameter value */
 		offset = 0;
 		if (parse_int_value(value, ':', (int *) &cherish_level,
 				    &delta_offset))
 			return -1;
 
-		/* Parse cherish levels from the parameter value */
+		/* Parse drop from the parameter value */
 		offset += delta_offset;
 		if (parse_int_value(value + offset, ':',
 				    (int *) &drop, &delta_offset))
 			return -1;
 
+		/* Parse dequeue prob from the parameter value */
+		offset += delta_offset;
+		if (parse_int_value(value + offset, ':', (int*) &dequeue_prob,
+				    &delta_offset))
+			return -1;
+
+		/* Parse info of each cherish level from the parameter value */
 		cherish_levels = rkzalloc(cherish_level * sizeof(struct cherish_thres_t),
 					  GFP_ATOMIC);
 		if (!cherish_levels) {
@@ -1140,7 +1174,8 @@ static int qta_mux_ps_set_policy_set_param_priv(struct qta_mux_set * data,
 			return -1;
 		}
 
-		LOG_INFO("Urgency level: %u, Drop: %u", urgency_level, drop);
+		LOG_INFO("Urgency level: %u, Drop: %u, Dequeue prob: %u",
+				urgency_level, drop, dequeue_prob);
 
 		for (i=0; i< cherish_level; i++) {
 			if (i < cherish_level -1) {
@@ -1201,6 +1236,7 @@ static int qta_mux_ps_set_policy_set_param_priv(struct qta_mux_set * data,
 		}
 
 		urgency_queue_conf->cherish_thresholds = cherish_levels;
+		urgency_queue_conf->dequeue_prob = dequeue_prob;
 		if (append) {
 			list_add_tail(&urgency_queue_conf->list,
 				      &data->qta_mux_conf->urgency_queue_conf);

--- a/plugins/qta_mux/qta-mux.c
+++ b/plugins/qta_mux/qta-mux.c
@@ -808,6 +808,10 @@ int qta_rmt_enqueue_policy(struct rmt_ps	  *ps,
 	tbf->tx_bytes += pdu_length;
 	tbf->tx_pdus++;
 
+	/* If we don't need to enqueue it means there are 0 queued PDUs, tx */
+	if (!must_enqueue)
+		return RMT_PS_ENQ_SEND;
+
 	/* Put PDU put it in the right urgency queue */
 	urgency_queue = urgency_queue_find(qta_mux, tbf->urgency_level);
 	if (!urgency_queue) {

--- a/plugins/qta_mux/qta-mux.c
+++ b/plugins/qta_mux/qta-mux.c
@@ -683,7 +683,6 @@ struct du * qta_rmt_dequeue_policy(struct rmt_ps	  *ps,
 	/* Go through the urgency queues in urgency level: the queues */
 	/* with a higher urgency level are checked first */
 	list_for_each_entry(pos, &qta_mux->cu_mux.urgency_queues, list) {
-		/* If this urgency level contains one or more QoS ids */
 		if (!list_empty(&pos->queued_pdus)) {
 			ret_pdu = dequeue_pdu(&pos->queued_pdus);
 			pos->length--;
@@ -888,7 +887,8 @@ static void qta_mux_add_uqueue(struct qta_mux *     qta_mux,
 			return;
 		}
 	}
-	list_add(&uq->list, &pos->list);
+
+	list_add_tail(&uq->list, &qta_mux->cu_mux.urgency_queues);
 }
 
 void * qta_rmt_q_create_policy(struct rmt_ps      *ps,


### PR DESCRIPTION
Improvements to qta-mux:
* Allow configuration of different cherish levels per urgency queue
* Add probabilistic dequeue (to prevent starvation of lower traffic classes)

Fix bug in vertical flow control in shim-eth-vlan