### PR TITLE
rinad: ipcm: auto-generate IPCP names from a system name and the DIF name to join

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ Daemon starts its execution.
 
 **Local configuration**. The first part of the configuration file contains the settings for IRATI, 
 such as the paths to the  UNIX socket for the local console or the paths where to search for 
-user-space or kernel plugins.
+user-space or kernel plugins. It also specifies the system name, which is later used to auto-generate 
+the names of the IPC Processes instantiated in this system.
 
       "configFileVersion" : "1.4.1",
       "localConfiguration" : {
@@ -163,24 +164,21 @@ user-space or kernel plugins.
         "libraryPath" : "/usr/lib",
         "logPath" : "/var/log",
         "consoleSocket" : "/var/run/ipcm-console.sock",
+        "system-name" : "pe1",
         "pluginsPaths" : ["/usr/lib/rinad/ipcp"]
       },
 
 **IPC Processes to create**. The next section specifies which IPC processes should be created. 
 It requires for each IPC process the type, which can be either a normal IPC process, or a certain 
-shim IPC process. The names of the IPC process and the DIF then have to be specified. The name of 
+shim IPC process. The names of the IPCPs will be generated from the system name and the DIF name. The name of 
 the DIF the IPC process should register with is also supplied. Enrollment however, will have to be 
 done manually from the local management console.
 
     "ipcProcessesToCreate" : [ {
       "type" : "shim-eth-vlan",
-      "apName" : "test-eth-vlan",
-      "apInstance" : "1",
       "difName" : "110"
      }, {
       "type" : "normal-ipc",
-      "apName" : "test1.IRATI",
-      "apInstance" : "1",
       "difName" : "normal.DIF",
       "difsToRegisterAt" : ["110"]
      } ],

--- a/rinad/etc/ipcmanager.conf.orig.in
+++ b/rinad/etc/ipcmanager.conf.orig.in
@@ -5,17 +5,14 @@
     "libraryPath" : "@libdir@",
     "logPath" : "@localstatedir@/log",
     "consoleSocket" : "@runstatedir@/ipcm-console.sock",
+    "system-name" : "pe1",
     "pluginsPaths" : ["@libdir@/rinad/ipcp"]
   },
   "ipcProcessesToCreate" : [ {
     "type" : "shim-eth-vlan",
-    "apName" : "test-eth-vlan",
-    "apInstance" : "1",
     "difName" : "110"
    }, {
     "type" : "normal-ipc",
-    "apName" : "test1.IRATI",
-    "apInstance" : "1",
     "difName" : "normal.DIF",
     "difsToRegisterAt" : ["110"]
    } ],

--- a/rinad/src/common/rina-configuration.h
+++ b/rinad/src/common/rina-configuration.h
@@ -167,6 +167,9 @@ struct LocalConfiguration {
 	/* The paths where to look for policy plugins. */
 	std::list<std::string> pluginsPaths;
 
+	/* The system name */
+	rina::ApplicationProcessNamingInformation system_name;
+
         std::string toString() const;
 
         LocalConfiguration() { }

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -38,20 +38,19 @@ const string IPCMConsole::NAME = "console";
 class CreateIPCPConsoleCmd: public rina::ConsoleCmdInfo {
 public:
 	CreateIPCPConsoleCmd(IPCMConsole * console) :
-		rina::ConsoleCmdInfo("USAGE: create-ipcp <process-name> "
-				"<process-instance> <ipcp-type>", console) {};
+		rina::ConsoleCmdInfo("USAGE: create-ipcp <ipcp-type> <dif-name>", console) {};
 
 	int execute(std::vector<string>& args) {
 		CreateIPCPPromise promise;
 
-		if (args.size() < 4) {
+		if (args.size() < 3) {
 			console->outstream << console->commands_map[args[0]]->usage << endl;
 			return rina::UNIXConsole::CMDRETCONT;
 		}
 
-		rina::ApplicationProcessNamingInformation ipcp_name(args[1], args[2]);
+		rina::ApplicationProcessNamingInformation ipcp_name;
 
-		if(IPCManager->create_ipcp((IPCMConsole*) console, &promise, ipcp_name, args[3]) == IPCM_FAILURE ||
+		if(IPCManager->create_ipcp((IPCMConsole*) console, &promise, ipcp_name, args[2], args[3]) == IPCM_FAILURE ||
 				promise.wait() != IPCM_SUCCESS){
 			console->outstream << "Error while creating IPC process" << endl;
 			return rina::UNIXConsole::CMDRETCONT;

--- a/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
+++ b/rinad/src/ipcm/addons/ma/ribs/ipcp_obj.cc
@@ -227,7 +227,8 @@ int IPCPObj::createIPCP(configs::ipcp_config_t &object)
                         object.name.processName, object.name.processInstance);
 
         if (IPCManager->create_ipcp(ManagementAgent::inst, &ipcp_promise,
-                                    ipcp_name, object.dif_to_assign.dif_type_)
+                                    ipcp_name, object.dif_to_assign.dif_type_,
+				    object.dif_to_assign.dif_name_.processName)
                         == IPCM_FAILURE || ipcp_promise.wait() != IPCM_SUCCESS)
         {
                 LOG_ERR("Error while creating IPC process");

--- a/rinad/src/ipcm/addons/mobility-manager.cc
+++ b/rinad/src/ipcm/addons/mobility-manager.cc
@@ -669,7 +669,7 @@ int MobilityManager::initialize_arcfire_exp5_mac()
 		//Create IPCP for the Internet DIF
 		ipcp_name.processName = "ue.internet";
 		ipcp_name.processInstance = "1";
-                if (IPCManager->create_ipcp(this, &c_promise, ipcp_name, rina::NORMAL_IPC_PROCESS) == IPCM_FAILURE
+                if (IPCManager->create_ipcp(this, &c_promise, ipcp_name, rina::NORMAL_IPC_PROCESS, "internet.DIF") == IPCM_FAILURE
                 		|| c_promise.wait() != IPCM_SUCCESS) {
                 	LOG_WARN("Problems creating IPCP %s of type %s",
                 			ipcp_name.toString().c_str(),
@@ -714,7 +714,7 @@ int MobilityManager::initialize_arcfire_exp5_mac()
 		//Create IPCP for the Slice1 DIF
 		ipcp_name.processName = "ue.slice1";
 		ipcp_name.processInstance = "1";
-                if (IPCManager->create_ipcp(this, &c_promise, ipcp_name, rina::NORMAL_IPC_PROCESS) == IPCM_FAILURE
+                if (IPCManager->create_ipcp(this, &c_promise, ipcp_name, rina::NORMAL_IPC_PROCESS, "slice1.DIF") == IPCM_FAILURE
                 		|| c_promise.wait() != IPCM_SUCCESS) {
                 	LOG_WARN("Problems creating IPCP %s of type %s",
                 			ipcp_name.toString().c_str(),
@@ -1642,7 +1642,7 @@ int MobilityManager::execute_handover_arcfire_exp5_mac_wifi_fixed()
 	//Create IPCP for the fixed DIF
 	ipcp_name.processName = "ue.fixed";
 	ipcp_name.processInstance = "1";
-        if (IPCManager->create_ipcp(this, &c_promise, ipcp_name, rina::NORMAL_IPC_PROCESS) == IPCM_FAILURE
+        if (IPCManager->create_ipcp(this, &c_promise, ipcp_name, rina::NORMAL_IPC_PROCESS, "fixed.DIF") == IPCM_FAILURE
         		|| c_promise.wait() != IPCM_SUCCESS) {
         	LOG_WARN("Problems creating IPCP %s of type %s",
         			ipcp_name.toString().c_str(),

--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -448,6 +448,15 @@ void parse_local_conf(const Json::Value &         root,
 					plugins_paths[j].asString());
 		}
 	}
+
+	local.system_name.processName = local_conf.get("system-name",
+						       local.system_name.processName).asString();
+	if (local.system_name.processName.empty()) {
+		local.system_name.processName = "";
+		local.system_name.processInstance = "";
+	} else {
+		local.system_name.processInstance = "1";
+	}
 }
 
 void parse_dif_configs(const Json::Value   & root,

--- a/rinad/src/ipcm/dif-allocator.cc
+++ b/rinad/src/ipcm/dif-allocator.cc
@@ -195,6 +195,24 @@ void DIFAllocator::get_ipcp_name(rina::ApplicationProcessNamingInformation& ipcp
 	}
 }
 
+int DIFAllocator::generate_ipcp_name(rina::ApplicationProcessNamingInformation& ipcp_name,
+		                     const std::string& dif_name)
+{
+	std::stringstream ss;
+
+	if (sys_name.processName == "") {
+		LOG_DBG("No system name provided, cannot generate IPCP name");
+		return -1;
+	}
+
+	ss << sys_name.processName << "." << dif_name;
+
+	ipcp_name.processName = ss.str();
+	ipcp_name.processInstance = "1";
+
+	return 0;
+}
+
 const std::string StaticDIFAllocator::TYPE = "static-dif-allocator";
 
 StaticDIFAllocator::StaticDIFAllocator() : DIFAllocator()

--- a/rinad/src/ipcm/flow-alloc-handlers.cc
+++ b/rinad/src/ipcm/flow-alloc-handlers.cc
@@ -193,7 +193,7 @@ void IPCManager_::join_dif_continue_flow_alloc(Promise * promise, rina::FlowRequ
         dif_allocator->get_ipcp_name_for_dif(ipcp_name, dif_name);
         try {
         	if (create_ipcp(NULL, &c_promise, ipcp_name,
-        			dif_template.difType) == IPCM_FAILURE
+        			dif_template.difType, dapp_name.processName) == IPCM_FAILURE
         			|| c_promise.wait() != IPCM_SUCCESS) {
         		LOG_ERR("Problems creating IPCP");
 

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -340,8 +340,9 @@ public:
 	// @ret IPCM_FAILURE on failure, otherwise the IPCM_PENDING
 	//
 	ipcm_res_t create_ipcp(Addon* callee, CreateIPCPPromise* promise,
-			const rina::ApplicationProcessNamingInformation& name,
-			const std::string& type);
+			       rina::ApplicationProcessNamingInformation& name,
+			       const std::string& type,
+			       const std::string& dif_name);
 
 	//
 	// Destroys an IPCP process
@@ -1001,13 +1002,17 @@ public:
 	static DIFAllocator * create_instance(const rinad::RINAConfiguration& config,
 					      IPCManager_ * ipcm);
 
+	/// Parse the DIF Allocator configuration information from the main config file
+	static void parse_config(DIFAllocatorConfig& da_config,
+				 const rinad::RINAConfiguration& config);
+
 	static void get_ipcp_name(rina::ApplicationProcessNamingInformation& ipcp_name,
    	   	   		  const std::string& dif_name,
 				  const std::list<NeighborData> joinable_difs);
 
-	/// Parse the DIF Allocator configuration information from the main config file
-	static void parse_config(DIFAllocatorConfig& da_config,
-				 const rinad::RINAConfiguration& config);
+	/// Generate the IPCP name for the DIF dif_name
+	virtual int generate_ipcp_name(rina::ApplicationProcessNamingInformation& ipcp_name,
+			               const std::string& dif_name);
 
 	/// Returns 0 is configuration is correclty applied, -1 otherwise
 	virtual int set_config(const DIFAllocatorConfig& da_config) = 0;
@@ -1033,6 +1038,8 @@ public:
 			                   const std::string& dif_name) = 0;
 
         virtual void update_directory_contents() = 0;
+
+        rina::ApplicationProcessNamingInformation sys_name;
 
 private:
         static void populate_with_default_conf(DIFAllocatorConfig& da_config,


### PR DESCRIPTION
According to the reference model, the DIF Allocator (which incorporates a namespace manager DAF) is the one responsible for managing the names assigned to IPC Processes. 

This PR augments the DIF allocator with this functionality, with a very simple policy in which each DIF Allocator instance has the responsibility for allocating names of the IPCPs in its system. Names of IPCPs are generated based on the concatenation of a system-name (specified at system boostrap time) which is assumed to be unique in the scope of the DIF Allocator, and the DIF name that the IPCPs will join.

Old manual assignment of names via the configuration file is still supported, in order to maintain compatibility with older config files.