### PR TITLE
For Issue #1246 changing Travis CI build to include build dependancy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
   - sudo apt-get install hostapd
   - sudo apt-get install wpasupplicant
   - sudo apt-get install linux-headers-$(uname -r)
+  - sudo apt-get install libelf-dev
 
 script:
   - "[ ${KERNEL_VERSION} != local ] || ./ci/build-all"


### PR DESCRIPTION
As outlined in Issue #1246 this change helps with the Travis CI build particularly for Kernel version 4.15.

With this change the build now passes as can bee seen on [Travis CI build 337](https://travis-ci.org/IRATI/stack/builds/422514834)