### PR TITLE
E2ens: fix issues in closed window queue

### DIFF
--- a/kernel/dtcp.c
+++ b/kernel/dtcp.c
@@ -1096,6 +1096,8 @@ struct dtcp * dtcp_create(struct dtp *         dtp,
                 if (dtcp_window_based_fctrl(dtcp_cfg)) {
 			RINA_DECLARE_AND_ADD_ATTRS(&tmp->robj, dtcp, sndr_credit, rcvr_credit,
 				snd_rt_win_edge, rcv_rt_win_edge);
+			/* Set closed window queue length to 1 always */
+			tmp->cfg->fctrl_cfg->wfctrl_cfg->max_closed_winq_length = 1;
 		}
                 if (dtcp_rate_based_fctrl(dtcp_cfg)) {
 			RINA_DECLARE_AND_ADD_ATTRS(&tmp->robj, dtcp, pdu_per_time_unit, time_unit,

--- a/kernel/dtp-utils.c
+++ b/kernel/dtp-utils.c
@@ -304,7 +304,7 @@ void cwq_deliver(struct cwq * queue,
                 dtp_pdu_send(dtp, rmt, du);
         }
 
-        if (!can_deliver(dtp, dtcp)) {
+        if (!rqueue_is_empty(queue->q)) {
         	if(dtcp_window_based_fctrl(dtcp->cfg)) {
 			dtp->sv->window_closed = true;
         	}
@@ -313,12 +313,8 @@ void cwq_deliver(struct cwq * queue,
                 	LOG_DBG("rbfc Cannot deliver anymore, closing...");
                 	dtp->sv->rate_fulfiled = true;
                 	dtp_start_rate_timer(dtp, dtcp);
-
-                	// Cannot use anymore that port.
-                	//efcp_disable_write(dt_efcp(dtp));
                 }
 
-                enable_write(queue, dtp);
                 spin_unlock(&queue->lock);
                 return;
         }


### PR DESCRIPTION
Set it to always 1 to avoid undesired PDU reordering issues