### PR TITLE
Ip over RINA via dedicated netwok device

### DIFF
--- a/kernel/Makefile.in
+++ b/kernel/Makefile.in
@@ -46,7 +46,7 @@ rina-irati-core-y:=						\
 	ipcp-factories.o ipcp-instances.o			\
 	cidm.o dtp-utils.o dtcp.o dtp.o efcp-utils.o efcp.o	\
 	delim.o pff.o rmt.o						\
-	pim.o pidm.o kfa-utils.o kfa.o		\
+	pim.o pidm.o kfa-utils.o kfa.o rina-device.o \
 	kipcm-utils.o kipcm.o					\
 	sdup.o							\
 	ps-factory.o						\

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -499,11 +499,13 @@ int kfa_flow_ub_write(struct kfa * instance,
 	if (!flow) {
 		spin_unlock_bh(&instance->lock);
 		LOG_ERR("There is no flow bound to port-id %d", id);
+		if (skb) kfree_skb(skb);
 		return -EBADF;
 	}
 	if (flow->state == PORT_STATE_DEALLOCATED) {
 		spin_unlock_bh(&instance->lock);
 		LOG_ERR("Flow with port-id %d is already deallocated", id);
+		if (skb) kfree_skb(skb);
 		return -ESHUTDOWN;
 	}
 
@@ -513,6 +515,7 @@ int kfa_flow_ub_write(struct kfa * instance,
 		spin_unlock_bh(&instance->lock);
 		LOG_ERR("SDU is larger than the max SDU handled by "
 				"the IPCP: %zd, %zd", max_sdu_size, left);
+		if (skb) kfree_skb(skb);
 	        return -EMSGSIZE;
 	}
 

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -35,6 +35,7 @@
 #include "pidm.h"
 #include "kfa.h"
 #include "kfa-utils.h"
+#include "rina-device.h"
 
 #define RINA_IP_FLOW_ENT_NAME "RINA_IP"
 
@@ -65,11 +66,13 @@ struct ipcp_flow {
 	atomic_t	       writers;
 	atomic_t	       posters;
 	bool		       msg_boundaries;
+	struct rina_device   * ip_dev;
 };
 
 struct flowdel_data {
 	struct kfa *kfa;
 	port_id_t  id;
+	struct rina_device *ip_dev;
 };
 
 struct ipcp_instance_data {
@@ -79,8 +82,8 @@ struct ipcp_instance_data {
 //Fwd dec
 static int kfa_flow_deallocate_worker(void *data);
 
-port_id_t kfa_port_id_reserve(struct kfa      *instance,
-			      ipc_process_id_t id)
+port_id_t kfa_port_id_reserve(struct kfa      * instance,
+			      ipc_process_id_t  id)
 {
 	port_id_t     pid;
 
@@ -116,6 +119,9 @@ static int kfa_flow_destroy(struct kfa       *instance,
 			    port_id_t	      id)
 {
 	int retval = 0;
+	struct rina_device * ip_dev;
+	struct rwq_work_item * item;
+	struct flowdel_data  * wqdata;
 
 	ASSERT(flow);
 
@@ -147,7 +153,26 @@ static int kfa_flow_destroy(struct kfa       *instance,
 		wake_up_interruptible_all(&flow->wqs->write_wqueue);
 	}
 
+	ip_dev = flow->ip_dev;
+	flow->ip_dev = NULL;
 	rkfree(flow);
+
+	if(!ip_dev)
+		return retval;
+
+	//the net device can not be unregistered in atomic, postpone it...
+	wqdata	       = rkzalloc(sizeof(*wqdata), GFP_ATOMIC);
+	wqdata->kfa    = NULL;
+	wqdata->id     = 0;
+	wqdata->ip_dev = ip_dev;
+
+	item = rwq_work_create_ni(kfa_flow_deallocate_worker, (void *) wqdata);
+	if (!item) {
+		rkfree(wqdata);
+		return -1;
+	}
+
+	rwq_work_post(instance->flowdelq, item);
 
 	return retval;
 }
@@ -201,10 +226,11 @@ EXPORT_SYMBOL(kfa_port_id_release);
 
 static int kfa_flow_deallocate_worker(void *data)
 {
-	struct ipcp_flow    *flow;
-	struct kfa          *instance;
-	port_id_t	     id;
-	struct flowdel_data *wqdata;
+	struct ipcp_flow    * flow;
+	struct kfa          * instance;
+	port_id_t	      id;
+	struct flowdel_data * wqdata;
+	struct rina_device  * ip_dev;
 
 	wqdata = (struct flowdel_data *) data;
 	if (!wqdata) {
@@ -214,8 +240,14 @@ static int kfa_flow_deallocate_worker(void *data)
 
 	instance = wqdata->kfa;
 	id = wqdata->id;
+	ip_dev = wqdata->ip_dev;
 	rkfree(wqdata);
 
+	//If we only need to clean the rina device
+	if(ip_dev)
+		return rina_dev_destroy(ip_dev);
+
+	// In any other case
 	if (!instance) {
 		LOG_ERR("Bogus instance passed, bailing out");
 		return -1;
@@ -307,6 +339,7 @@ static int kfa_flow_deallocate(struct ipcp_instance_data *data,
 	wqdata	       = rkzalloc(sizeof(*wqdata), GFP_ATOMIC);
 	wqdata->kfa    = instance;
 	wqdata->id     = id;
+	wqdata->ip_dev = NULL;
 
 	item = rwq_work_create_ni(kfa_flow_deallocate_worker, (void *) wqdata);
 	if (!item) {
@@ -430,10 +463,21 @@ static int enable_write(struct ipcp_instance_data *data, port_id_t id)
 	return 0;
 }
 
+int kfa_flow_skb_write(struct ipcp_instance_data * data,
+		       port_id_t   id,
+		       struct sk_buff * skb,
+		       size_t size,
+                       bool blocking)
+{
+	return kfa_flow_ub_write(data->kfa, id, NULL, NULL, skb,
+				 size, blocking);
+}
+
 int kfa_flow_ub_write(struct kfa * instance,
 		      port_id_t    id,
 		      const char __user * buffer,
 		      struct iov_iter * iov,
+		      struct sk_buff * skb,
 		      size_t size,
                       bool   blocking)
 {
@@ -479,7 +523,15 @@ int kfa_flow_ub_write(struct kfa * instance,
 
 		copylen = min(left, max_sdu_size);
 
-		du = du_create(copylen);
+		if (skb) {
+			/* This SDU comes from the networking stack */
+			du = du_create_from_skb(skb);
+			if (!du) kfree_skb(skb);
+		} else {
+			/* This SDU comes from the I/O device */
+			du = du_create(copylen);
+		}
+
 		if (!du) {
 			retval = -ENOMEM;
 			goto finish;
@@ -932,10 +984,11 @@ static int kfa_du_post(struct ipcp_instance_data *data,
 		       port_id_t		   id,
 		       struct du                * du)
 {
-	struct ipcp_flow  *flow;
-	wait_queue_head_t *wq;
-	struct kfa        *instance;
-	int		   retval = 0;
+	struct ipcp_flow  * flow;
+	wait_queue_head_t * wq;
+	struct kfa        * instance;
+	struct sk_buff	  * skb;
+	int		    retval = 0;
 
 	if (!data || !is_port_id_ok(id) || !is_du_ok(du)) {
 		LOG_ERR("Bogus ipcp data instance passed, cannot post SDU");
@@ -968,10 +1021,18 @@ static int kfa_du_post(struct ipcp_instance_data *data,
 		return -1;
 	}
 
-	if (rfifo_push_ni(flow->sdu_ready, du)) {
-		LOG_ERR("Could not write %zd bytes into port-id %d fifo",
+	if (flow->ip_dev) {
+		/* SDU will be consumed through IP networking stack */
+		skb = du_detach_skb(du);
+		du_destroy(du);
+		retval = rina_dev_rcv(skb, flow->ip_dev);
+	} else {
+		/* SDU will be consumed through I/O dev */
+		if (rfifo_push_ni(flow->sdu_ready, du)) {
+			LOG_ERR("Could not write %zd bytes into port-id %d",
 				sizeof(struct du *), id);
-		retval = -1;
+			retval = -1;
+		}
 	}
 
 	atomic_inc(&flow->posters);
@@ -1024,6 +1085,8 @@ int kfa_flow_create(struct kfa           *instance,
 		    bool		  msg_boundaries)
 {
 	struct ipcp_flow *flow;
+	bool ip_flow = false;
+	string_t name[64];
 
 	flow = rkzalloc(sizeof(*flow), GFP_KERNEL);
 	if (!flow) {
@@ -1034,16 +1097,35 @@ int kfa_flow_create(struct kfa           *instance,
 	atomic_set(&flow->writers, 0);
 	atomic_set(&flow->posters, 0);
 	flow->wqs = 0;
-	flow->msg_boundaries = msg_boundaries;
 
 	flow->ipc_process = ipcp;
 
 	flow->state	  = PORT_STATE_PENDING;
 	LOG_DBG("Flow pre-bound to port-id %d", pid);
 
+	/* Determine if this is an IP tunnel */
+	ip_flow = (user_ipcp_name != NULL) &&
+		  (!strcmp(user_ipcp_name->entity_name,
+			   RINA_IP_FLOW_ENT_NAME));
+	if (ip_flow) {
+		sprintf(name, "rina.%u.%u", ipc_id, pid);
+		flow->ip_dev = rina_dev_create(name, instance->ipcp, pid);
+		if (!flow->ip_dev) {
+			LOG_ERR("Could not allocate memory for RINA IP virtual device");
+			rkfree(flow);
+			return -1;
+		}
+		flow->msg_boundaries = true;
+	} else {
+		flow->ip_dev = NULL;
+		flow->msg_boundaries = msg_boundaries;
+	}
+
+
 	spin_lock_bh(&instance->lock);
 
 	if (kfa_pmap_add_ni(instance->flows, pid, flow)) {
+		if (flow->ip_dev) rina_dev_destroy(flow->ip_dev);
 		rkfree(flow);
 
 		spin_unlock_bh(&instance->lock);

--- a/kernel/kfa.h
+++ b/kernel/kfa.h
@@ -41,10 +41,17 @@ port_id_t   kfa_port_id_reserve(struct kfa      *instance,
 int	    kfa_port_id_release(struct kfa *instance,
 				port_id_t   port_id);
 
+int	    kfa_flow_skb_write(struct ipcp_instance_data * data,
+			       port_id_t   id,
+			       struct sk_buff * skb,
+			       size_t size,
+                               bool blocking);
+
 int	    kfa_flow_ub_write(struct kfa * kfa,
 			      port_id_t   id,
 			      const char __user *buffer,
 			      struct iov_iter * iov,
+			      struct sk_buff * skb,
 			      size_t size,
                               bool blocking);
 
@@ -52,17 +59,17 @@ int	    kfa_flow_ub_write(struct kfa * kfa,
  * it may report an error with a negative value or return
  * the number of bytes read (positive value)
  */
-int	    kfa_flow_du_read(struct kfa  * instance,
-			      port_id_t    id,
-			      struct du ** du,
-			      size_t       size,
-                              bool blocking);
+int kfa_flow_du_read(struct kfa  * instance,
+		     port_id_t    id,
+		     struct du ** du,
+		     size_t       size,
+                     bool blocking);
 
-int    kfa_flow_readable(struct kfa       *instance,
-                          port_id_t        id,
-                          unsigned int     *mask,
-                          struct file      *f,
-                          poll_table       *wait);
+int kfa_flow_readable(struct kfa       *instance,
+                      port_id_t        id,
+                      unsigned int     *mask,
+                      struct file      *f,
+                      poll_table       *wait);
 
 int kfa_flow_set_iowqs(struct kfa      * instance,
 		       struct iowaitqs * wqs,
@@ -79,12 +86,12 @@ struct ipcp_flow *kfa_flow_find_by_pid(struct kfa *instance,
 struct rmt;
 
 /* structure automatically freed when there are no more readers or writers */
-int	    kfa_flow_create(struct kfa           *instance,
-			    port_id_t		  pid,
-			    struct ipcp_instance *ipcp,
-			    ipc_process_id_t	 ipc_id,
-		    	    struct name          *user_ipcp_name,
-			    bool		  msg_boundaries);
+int kfa_flow_create(struct kfa           *instance,
+		    port_id_t		  pid,
+		    struct ipcp_instance *ipcp,
+		    ipc_process_id_t	 ipc_id,
+		    struct name          *user_ipcp_name,
+		    bool		  msg_boundaries);
 
 struct ipcp_instance *kfa_ipcp_instance(struct kfa *instance);
 

--- a/kernel/kipcm.c
+++ b/kernel/kipcm.c
@@ -2224,7 +2224,7 @@ int kipcm_du_write(struct kipcm * kipcm,
                 return -EINVAL;
         }
 
-        return kfa_flow_ub_write(kipcm->kfa, port_id, buffer, iov, 
+        return kfa_flow_ub_write(kipcm->kfa, port_id, buffer, iov, NULL,
 				 size, blocking);
 }
 

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -154,7 +154,11 @@ static void rina_dev_setup(struct net_device *dev)
 	dev->flags = IFF_POINTOPOINT | IFF_NOARP | IFF_MULTICAST;
 	dev->priv_flags	|= IFF_LIVE_ADDR_CHANGE | IFF_NO_QUEUE
 		| IFF_DONT_BRIDGE
-		| IFF_PHONY_HEADROOM;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
+		| IFF_DONT_BRIDGE | IFF_PHONY_HEADROOM;
+#else
+		| IFF_DONT_BRIDGE;
+#endif
 	netif_keep_dst(dev);
 	dev->features = NETIF_F_HW_CSUM;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,9)

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -110,7 +110,7 @@ static int rina_dev_start_xmit(struct sk_buff * skb, struct net_device *dev)
 	iph = ip_hdr(skb);
 	ASSERT(iph);
 
-	LOG_DBG("Device %s about to send a packet of length %zd via port %d",
+	LOG_DBG("Device %s about to send a packet of length %u via port %d",
 		dev->name, skb->len, rina_dev->port);
 
 	data_sent = kfa_flow_skb_write(rina_dev->kfa_ipcp->data,
@@ -152,8 +152,11 @@ static void rina_dev_setup(struct net_device *dev)
 	dev->addr_len = 0;
 	dev->type = ARPHRD_NONE;
 	dev->flags = IFF_POINTOPOINT | IFF_NOARP | IFF_MULTICAST;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
+	dev->priv_flags |= IFF_LIVE_ADDR_CHANGE
+#else
 	dev->priv_flags	|= IFF_LIVE_ADDR_CHANGE | IFF_NO_QUEUE
-		| IFF_DONT_BRIDGE
+#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
 		| IFF_DONT_BRIDGE;
 #else

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -45,7 +45,7 @@ struct rina_device {
 
 static int rina_dev_open(struct net_device *dev)
 {
-	/*netif_tx_start_all_queues(dev);*/
+	netif_tx_start_all_queues(dev);
 	LOG_DBG("RINA IP device %s opened...", dev->name);
 
 	return 0;
@@ -53,7 +53,7 @@ static int rina_dev_open(struct net_device *dev)
 
 static int rina_dev_close(struct net_device *dev)
 {
-	/*netif_tx_stop_all_queues(dev);*/
+	netif_tx_stop_all_queues(dev);
 	LOG_DBG("RINA IP device %s closed...", dev->name);
 
 	return 0;
@@ -111,6 +111,8 @@ static int rina_dev_start_xmit(struct sk_buff * skb, struct net_device *dev)
 	ASSERT(iph);
 
 	len = skb->len;
+	LOG_INFO("About to send a packet of length %zd via port %d", len, 
+			 rina_dev->port);
         if (kfa_flow_skb_write(rina_dev->kfa_ipcp->data, rina_dev->port,
         		       skb, len, false)) {
 		rina_dev->stats.tx_dropped++;

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -1,0 +1,210 @@
+/*
+ * RINA virtual network device (rina_device)
+ * At the moment only for IP support
+ *
+ *    Leonardo Bergesio     <leonardo.bergesio@i2cat.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+/* For net_device related code */
+
+#include <linux/if_arp.h>
+#include <linux/ip.h>
+#include <linux/if.h>
+
+#define RINA_PREFIX "rina-device"
+
+#include "logs.h"
+#include "debug.h"
+#include "kfa.h"
+#include "du.h"
+#include "rds/rmem.h"
+#include "rina-device.h"
+
+#define RINA_EXTRA_HEADER_LENGTH 50
+
+struct rina_device {
+	struct net_device_stats stats;
+	struct ipcp_instance* kfa_ipcp;
+	port_id_t port;
+	struct net_device* dev;
+};
+
+static int rina_dev_open(struct net_device *dev)
+{
+	netif_tx_start_all_queues(dev);
+	LOG_DBG("RINA IP device %s opened...", dev->name);
+
+	return 0;
+}
+
+static int rina_dev_close(struct net_device *dev)
+{
+	netif_tx_stop_all_queues(dev);
+	LOG_DBG("RINA IP device %s closed...", dev->name);
+
+	return 0;
+}
+
+static struct net_device_stats *rina_dev_get_stats(struct net_device *dev)
+{
+    struct rina_device* rina_dev = netdev_priv(dev);
+    if(!rina_dev)
+	    return NULL;
+    return &rina_dev->stats;
+}
+
+int rina_dev_rcv(struct sk_buff *skb, struct rina_device *rina_dev)
+{
+	ssize_t len;
+
+	if(!(skb->data[0] & 0xf0)) {
+		LOG_INFO("RINA IP device %s rcv a non IP packet, dropping...",
+			  rina_dev->dev->name);
+		rina_dev->stats.rx_dropped++;
+		kfree_skb(skb);
+		return -1;
+	}
+
+	skb->protocol = htons(ETH_P_IP);
+	skb->dev = rina_dev->dev;
+	len = skb->len;
+
+	if(likely(netif_rx(skb) == NET_RX_SUCCESS)) {
+		rina_dev->stats.rx_packets++;
+		rina_dev->stats.rx_bytes += len;
+	} else {
+		rina_dev->stats.rx_dropped++;
+	}
+
+	LOG_INFO("RINA IP device %s rcv a IP packet...",
+		 rina_dev->dev->name);
+
+	return 0;
+}
+
+static int rina_dev_start_xmit(struct sk_buff * skb, struct net_device *dev)
+{
+	struct iphdr* iph = NULL;
+	struct rina_device* rina_dev = netdev_priv(dev);
+	ssize_t len;
+	ASSERT(rina_dev);
+
+	skb_orphan(skb);
+	//skb_dst_force(skb);
+
+	iph = ip_hdr(skb);
+	ASSERT(iph);
+
+	len = skb->len;
+        if (kfa_flow_skb_write(rina_dev->kfa_ipcp->data, rina_dev->port,
+        		       skb, len, false)) {
+		rina_dev->stats.tx_dropped++;
+		LOG_ERR("Could not xmit IP packet, unable to send to KFA...");
+		return NET_XMIT_DROP;
+	}
+
+	rina_dev->stats.tx_packets++;
+	rina_dev->stats.tx_bytes += len;
+
+	LOG_INFO("RINA IP device %s sent a packet...", dev->name);
+
+	return NETDEV_TX_OK;
+}
+
+static void rina_dev_free(struct net_device *dev)
+{ return free_netdev(dev); }
+
+static const struct net_device_ops rina_dev_ops = {
+	.ndo_start_xmit	= rina_dev_start_xmit,
+	.ndo_get_stats	= rina_dev_get_stats,
+	.ndo_open	= rina_dev_open,
+	.ndo_stop	= rina_dev_close,
+};
+
+static void rina_dev_setup(struct net_device *dev)
+{
+	/* This should be set according to the N-1 DIF properties,
+         * for the moment an upper bound is provided */
+	dev->needed_headroom += RINA_EXTRA_HEADER_LENGTH;
+	dev->needed_tailroom += RINA_EXTRA_HEADER_LENGTH;
+	/* This should be set depending on supporting DIF */
+	dev->mtu = 1400;
+	dev->hard_header_len = 0;
+	dev->addr_len = 0;
+	dev->type = ARPHRD_NONE;
+	dev->flags = IFF_POINTOPOINT | IFF_NOARP | IFF_MULTICAST;
+	dev->priv_flags	|= IFF_LIVE_ADDR_CHANGE | IFF_NO_QUEUE
+		| IFF_DONT_BRIDGE
+		| IFF_PHONY_HEADROOM;
+	netif_keep_dst(dev);
+	dev->features = NETIF_F_HW_CSUM;
+	dev->destructor	= rina_dev_free;
+	dev->netdev_ops	= &rina_dev_ops;
+
+	return;
+}
+
+struct rina_device* rina_dev_create(string_t* name,
+				    struct ipcp_instance* kfa_ipcp,
+				    port_id_t port)
+{
+	int rv;
+	struct net_device *dev;
+	struct rina_device* rina_dev;
+
+	if (!kfa_ipcp || !name)
+		return NULL;
+
+	if (strlen(name) > IFNAMSIZ) {
+		LOG_ERR("Could not allocate RINA IP network device %s, "
+				"name too long", name);
+		return NULL;
+	}
+
+	dev = alloc_netdev(sizeof(struct rina_device), name,
+			   NET_NAME_UNKNOWN, rina_dev_setup);
+	if (!dev) {
+		LOG_ERR("Could not allocate RINA IP network device %s", name);
+		return NULL;
+	}
+
+	rina_dev = netdev_priv(dev);
+	rina_dev->dev = dev;
+	rina_dev->kfa_ipcp = kfa_ipcp;
+	rina_dev->port = port;
+	memset(&rina_dev->stats, 0x00, sizeof(struct net_device_stats));
+
+	rv = register_netdev(dev);
+	if(rv) {
+		LOG_ERR("Could not register RINA IP device %s: %d", name, rv);
+		free_netdev(dev);
+		return NULL;
+	}
+
+	LOG_INFO("RINA IP device %s (%pk) created with dev %p",
+		 name, rina_dev, dev);
+
+	return rina_dev;
+}
+
+int rina_dev_destroy(struct rina_device *rina_dev)
+{
+	if(!rina_dev)
+		return -1;
+
+	unregister_netdev(rina_dev->dev);
+	return 0;
+}

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -23,6 +23,7 @@
 #include <linux/if_arp.h>
 #include <linux/ip.h>
 #include <linux/if.h>
+#include <linux/version.h>
 
 #define RINA_PREFIX "rina-device"
 
@@ -151,7 +152,11 @@ static void rina_dev_setup(struct net_device *dev)
 		| IFF_PHONY_HEADROOM;
 	netif_keep_dst(dev);
 	dev->features = NETIF_F_HW_CSUM;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,9)
 	dev->destructor	= rina_dev_free;
+#else
+	dev->priv_destructor = rina_dev_free;
+#endif
 	dev->netdev_ops	= &rina_dev_ops;
 
 	return;

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -155,9 +155,9 @@ static void rina_dev_setup(struct net_device *dev)
 	dev->priv_flags	|= IFF_LIVE_ADDR_CHANGE | IFF_NO_QUEUE
 		| IFF_DONT_BRIDGE
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
-		| IFF_DONT_BRIDGE | IFF_PHONY_HEADROOM;
-#else
 		| IFF_DONT_BRIDGE;
+#else
+		| IFF_DONT_BRIDGE | IFF_PHONY_HEADROOM;
 #endif
 	netif_keep_dst(dev);
 	dev->features = NETIF_F_HW_CSUM;

--- a/kernel/rina-device.c
+++ b/kernel/rina-device.c
@@ -45,7 +45,7 @@ struct rina_device {
 
 static int rina_dev_open(struct net_device *dev)
 {
-	netif_tx_start_all_queues(dev);
+	/*netif_tx_start_all_queues(dev);*/
 	LOG_DBG("RINA IP device %s opened...", dev->name);
 
 	return 0;
@@ -53,7 +53,7 @@ static int rina_dev_open(struct net_device *dev)
 
 static int rina_dev_close(struct net_device *dev)
 {
-	netif_tx_stop_all_queues(dev);
+	/*netif_tx_stop_all_queues(dev);*/
 	LOG_DBG("RINA IP device %s closed...", dev->name);
 
 	return 0;
@@ -61,10 +61,11 @@ static int rina_dev_close(struct net_device *dev)
 
 static struct net_device_stats *rina_dev_get_stats(struct net_device *dev)
 {
-    struct rina_device* rina_dev = netdev_priv(dev);
-    if(!rina_dev)
-	    return NULL;
-    return &rina_dev->stats;
+	struct rina_device* rina_dev = netdev_priv(dev);
+	if(!rina_dev)
+		return NULL;
+	
+	return &rina_dev->stats;
 }
 
 int rina_dev_rcv(struct sk_buff *skb, struct rina_device *rina_dev)
@@ -120,7 +121,7 @@ static int rina_dev_start_xmit(struct sk_buff * skb, struct net_device *dev)
 	rina_dev->stats.tx_packets++;
 	rina_dev->stats.tx_bytes += len;
 
-	LOG_INFO("RINA IP device %s sent a packet...", dev->name);
+	LOG_INFO("RINA IP device %s sent a packet", dev->name);
 
 	return NETDEV_TX_OK;
 }
@@ -137,6 +138,8 @@ static const struct net_device_ops rina_dev_ops = {
 
 static void rina_dev_setup(struct net_device *dev)
 {
+	LOG_INFO("In RINA dev setup");
+
 	/* This should be set according to the N-1 DIF properties,
          * for the moment an upper bound is provided */
 	dev->needed_headroom += RINA_EXTRA_HEADER_LENGTH;
@@ -158,6 +161,8 @@ static void rina_dev_setup(struct net_device *dev)
 	dev->priv_destructor = rina_dev_free;
 #endif
 	dev->netdev_ops	= &rina_dev_ops;
+
+	LOG_INFO("Finish RINA dev setup");
 
 	return;
 }

--- a/kernel/rina-device.h
+++ b/kernel/rina-device.h
@@ -1,0 +1,42 @@
+/*
+ * RINA virtual network device (rina_device)
+ * At the moment only for IP support
+ *
+ *    Leonardo Bergesio     <leonardo.bergesio@i2cat.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+/* For net_device related code */
+
+#ifndef RINA_IP_DEV_H
+#define RINA_IP_DEV_H
+
+#include <linux/if_arp.h>
+#include "common.h"
+
+#define ipaddr_t __be32
+
+struct ipcp_instance;
+
+struct rina_device;
+
+struct rina_device* rina_dev_create(string_t *name,
+				    struct ipcp_instance* kfa_ipcp,
+			  	    port_id_t port);
+int		    rina_dev_destroy(struct rina_device *rina_dev);
+int		    rina_dev_rcv(struct sk_buff *skb,
+			  	 struct rina_device *rina_dev);
+
+#endif

--- a/librina/include/librina/common.h
+++ b/librina/include/librina/common.h
@@ -483,16 +483,16 @@ public:
         /** PID of the process that registered */
         pid_t pid;
 
-	/** The type of registration requested */
-	ApplicationRegistrationType applicationRegistrationType;
+        /** The type of registration requested */
+        ApplicationRegistrationType applicationRegistrationType;
 
-	/** Optional DIF name where the application wants to register */
-	ApplicationProcessNamingInformation difName;
+        /** Optional DIF name where the application wants to register */
+        ApplicationProcessNamingInformation difName;
 
-	ApplicationRegistrationInformation();
-	ApplicationRegistrationInformation(
-		ApplicationRegistrationType applicationRegistrationType);
-	const std::string toString();
+        ApplicationRegistrationInformation();
+        ApplicationRegistrationInformation(
+        		ApplicationRegistrationType applicationRegistrationType);
+        const std::string toString();
 };
 
 /**

--- a/rinad/src/ipcm/Makefile.am
+++ b/rinad/src/ipcm/Makefile.am
@@ -51,6 +51,7 @@ ipcm_SOURCES  =								\
 	dif-allocator.cc		dif-allocator.h			\
 	dif-template-manager.cc		dif-template-manager.h		\
 	process-event-listener.cc process-event-listener.h \
+	ip-vpn-manager.cc   ip-vpn-manager.h \
 	catalog.cc			catalog.h
 
 test_empty_SOURCES  =				\

--- a/rinad/src/ipcm/addons/console.cc
+++ b/rinad/src/ipcm/addons/console.cc
@@ -867,8 +867,8 @@ IPCMConsole::IPCMConsole(const string& socket_path_) :
 	commands_map["list-da-map"] = new ListDIFAllocatorMapCmd(this);
 	commands_map["register-ip-prefix"] = new RegisterIPPrefixConsoleCmd(this);
 	commands_map["unregister-ip-prefix"] = new UnegisterIPPrefixConsoleCmd(this);
-	//commands_map["allocate-iporina-flow"] = new AllocateIPoRINAFlowConsoleCmd(this);
-	//commands_map["deallocate-iporina-flow"] = new DeallocateIPoRINAFlowConsoleCmd(this);
+	commands_map["allocate-iporina-flow"] = new AllocateIPoRINAFlowConsoleCmd(this);
+	commands_map["deallocate-iporina-flow"] = new DeallocateIPoRINAFlowConsoleCmd(this);
 }
 
 int IPCMConsole::plugin_load_unload(vector<string>& args, bool load)

--- a/rinad/src/ipcm/ip-vpn-manager.cc
+++ b/rinad/src/ipcm/ip-vpn-manager.cc
@@ -1,0 +1,547 @@
+/*
+ * IP VPN Manager. Manages creation and deletion of IP over RINA flows
+ * and VPNs. Manages registration of IP prefixes as application names
+ * in RINA DIFs, as well as allocation of flows between IP prefixes,
+ * the creation of VPNs and the reconfiguration of the IP forwarding table.
+ *
+ *    Eduard Grasa <eduard.grasa@i2cat.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <stdio.h>
+
+#define RINA_PREFIX     "ipcm.ip-vpn-manager"
+#include <librina/logs.h>
+
+#include "app-handlers.h"
+#include "ip-vpn-manager.h"
+#include "ipcm.h"
+
+namespace rinad {
+
+//Class IPVPNManager
+IPVPNManager::IPVPNManager()
+{
+}
+
+IPVPNManager::~IPVPNManager()
+{
+	std::map<int, rina::FlowRequestEvent>::iterator it;
+	rina::FlowRequestEvent event;
+
+	//Remove all IP over RINA routes and set RINA devs down
+	for (it = iporina_flows.begin(); it != iporina_flows.end(); ++it) {
+		event = it->second;
+		add_or_remove_ip_route(event.remoteApplicationName.processName,
+				       event.ipcProcessId, event.portId, false);
+	}
+}
+
+int IPVPNManager::add_registered_ip_prefix(const std::string& ip_prefix)
+{
+	rina::ScopedLock g(lock);
+
+	if (__ip_prefix_registered(ip_prefix)) {
+		LOG_ERR("IP prefix %s is already registered",
+			ip_prefix.c_str());
+		return -1;
+	}
+
+	reg_ip_prefixes.push_back(ip_prefix);
+
+	return 0;
+}
+
+int IPVPNManager::remove_registered_ip_prefix(const std::string& ip_prefix)
+{
+	std::list<std::string>::iterator it;
+
+	rina::ScopedLock g(lock);
+
+	for (it = reg_ip_prefixes.begin(); it != reg_ip_prefixes.end(); ++it) {
+		if ((*it) == ip_prefix) {
+			reg_ip_prefixes.erase(it);
+			return 0;
+		}
+	}
+
+	LOG_ERR("IP prefix %s is not registered", ip_prefix.c_str());
+
+	return -1;
+}
+
+bool IPVPNManager::ip_prefix_registered(const std::string& ip_prefix)
+{
+	rina::ScopedLock g(lock);
+
+	return __ip_prefix_registered(ip_prefix);
+}
+
+bool IPVPNManager::__ip_prefix_registered(const std::string& ip_prefix)
+{
+	std::list<std::string>::iterator it;
+
+	for (it = reg_ip_prefixes.begin(); it != reg_ip_prefixes.end(); ++it) {
+		if ((*it) == ip_prefix) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int IPVPNManager::iporina_flow_allocated(const rina::FlowRequestEvent& event)
+{
+	int res = 0;
+
+	rina::ScopedLock g(lock);
+
+	res = add_flow(event);
+	if (res != 0) {
+		return res;
+	}
+
+	//Add entry to the IP forwarding table
+	res = add_or_remove_ip_route(event.remoteApplicationName.processName,
+			             event.ipcProcessId, event.portId, true);
+	if (res != 0) {
+		LOG_ERR("Problems adding route to IP routing table");
+	}
+
+	LOG_INFO("IP over RINA flow between %s and %s allocated, port-id: %d",
+		  event.localApplicationName.processName.c_str(),
+		  event.remoteApplicationName.processName.c_str(),
+		  event.portId);
+
+	return 0;
+}
+
+void IPVPNManager::
+iporina_flow_allocation_requested(const rina::FlowRequestEvent& event)
+{
+	int res = 0;
+
+	rina::ScopedLock g(lock);
+
+	if (!__ip_prefix_registered(event.localApplicationName.processName)) {
+		LOG_INFO("Rejected IP over RINA flow between %s and %s",
+			  event.localApplicationName.processName.c_str(),
+			  event.remoteApplicationName.processName.c_str());
+		IPCManager->allocate_iporina_flow_response(event, -1, true);
+		return;
+	}
+
+	res = add_flow(event);
+	if (res != 0) {
+		LOG_ERR("Flow with port-id %d already exists", event.portId);
+		IPCManager->allocate_iporina_flow_response(event, -1, true);
+		return;
+	}
+
+	//Add entry to the IP forwarding table
+	res = add_or_remove_ip_route(event.remoteApplicationName.processName,
+			             event.ipcProcessId, event.portId, true);
+	if (res != 0) {
+		LOG_ERR("Problems adding route to IP routing table");
+	}
+
+	LOG_INFO("Accepted IP over RINA flow between %s and %s; port-id: %d",
+			event.localApplicationName.processName.c_str(),
+			event.remoteApplicationName.processName.c_str(),
+			event.portId);
+
+	IPCManager->allocate_iporina_flow_response(event, 0, true);
+}
+
+int IPVPNManager::get_iporina_flow_info(int port_id,
+					rina::FlowRequestEvent& event)
+{
+	int res = 0;
+	std::map<int, rina::FlowRequestEvent>::iterator it;
+
+	rina::ScopedLock g(lock);
+
+	it = iporina_flows.find(port_id);
+	if (it == iporina_flows.end()) {
+		LOG_ERR("Could not find IP over RINA flow with port-id %d", port_id);
+		return -1;
+	}
+
+	event = it->second;
+
+	return 0;
+}
+
+int IPVPNManager::iporina_flow_deallocated(int port_id, const int ipcp_id)
+{
+	int res = 0;
+	rina::FlowRequestEvent event;
+
+	rina::ScopedLock g(lock);
+
+	event.portId = port_id;
+	res = remove_flow(event);
+	if (res != 0) {
+		return res;
+	}
+
+	//Remove entry from the IP forwarding table
+	res = add_or_remove_ip_route(event.remoteApplicationName.processName,
+			             ipcp_id, event.portId, false);
+	if (res != 0) {
+		LOG_ERR("Problems removing entry from IP routing table");
+	}
+
+	LOG_INFO("IP over RINA flow between %s and %s deallocated, port-id: %d",
+		  event.localApplicationName.processName.c_str(),
+		  event.remoteApplicationName.processName.c_str(),
+		  event.portId);
+
+	return 0;
+}
+
+int IPVPNManager::add_flow(const rina::FlowRequestEvent& event)
+{
+	std::map<int, rina::FlowRequestEvent>::iterator it;
+
+	it = iporina_flows.find(event.portId);
+	if (it != iporina_flows.end()) {
+		LOG_ERR("Cannot add IP over RINA flow with port-id %d, already exists",
+			 event.portId);
+		return -1;
+	}
+
+	iporina_flows[event.portId] = event;
+
+	return 0;
+}
+
+int IPVPNManager::remove_flow(rina::FlowRequestEvent& event)
+{
+	std::map<int, rina::FlowRequestEvent>::iterator it;
+
+	it = iporina_flows.find(event.portId);
+	if (it == iporina_flows.end()) {
+		LOG_ERR("Cannot remove IP over RINA flow with port-id %d, not found",
+			 event.portId);
+		return -1;
+	}
+
+	event = it->second;
+	iporina_flows.erase(it);
+
+	return 0;
+}
+
+std::string IPVPNManager::exec_shell_command(std::string command)
+{
+	char buffer[128];
+	std::string result = "";
+	FILE * pipe = 0;
+
+	LOG_DBG("Executing command '%s' ...", command.c_str());
+
+	pipe = popen(command.c_str(), "r");
+	if (!pipe) throw std::runtime_error("popen() failed!");
+	try {
+		while (!feof(pipe)) {
+			if (fgets(buffer, 128, pipe) != NULL)
+				result += buffer;
+		}
+	} catch (...) {
+		pclose(pipe);
+		throw;
+	}
+	pclose(pipe);
+
+	return result;
+}
+
+std::string IPVPNManager::get_rina_dev_name(const int ipcp_id,
+					    const int port_id)
+{
+	std::stringstream ss;
+
+	ss << "rina." << ipcp_id << "." << port_id;
+	return ss.str();
+}
+
+std::string IPVPNManager::get_ip_prefix_string(const std::string& input)
+{
+	std::string result = input;
+	std::replace(result.begin(), result.end(), '|', '/'); // replace all '|' to '/'
+
+	return result;
+}
+
+int IPVPNManager::add_or_remove_ip_route(const std::string ip_prefix,
+					 const int ipcp_id,
+					 const int port_id,
+					 bool add)
+{
+	std::stringstream ss;
+	std::string prefix;
+	std::string suffix;
+	std::string result;
+	std::string dev_name;
+	std::string ifconfig_command;
+	std::string iproute_command;
+
+	dev_name = get_rina_dev_name(ipcp_id, port_id);
+
+	if (add) {
+		prefix = "add ";
+		suffix = " up";
+	} else {
+		prefix = "delete ";
+		suffix = " down";
+	}
+
+	ss << "ifconfig " << dev_name << suffix;
+	ifconfig_command = ss.str();
+
+	ss.str("");
+	ss << "ip route " << prefix
+	   << get_ip_prefix_string(ip_prefix) << " dev "
+	   << dev_name;
+	iproute_command = ss.str();
+
+	if (add) {
+		result = exec_shell_command(ifconfig_command);
+		//TODO parse result
+		result = exec_shell_command(iproute_command);
+		//TODO parse result
+	} else {
+		result = exec_shell_command(iproute_command);
+		//TODO parse result
+		result = exec_shell_command(ifconfig_command);
+		//TODO parse result
+	}
+
+	return 0;
+}
+
+// Class IPCManager
+ipcm_res_t IPCManager_::register_ip_prefix_to_dif(Promise* promise,
+						  const std::string& ip_range,
+						  const rina::ApplicationProcessNamingInformation& dif_name)
+{
+	IPCMIPCProcess *slave_ipcp = NULL;
+	APPregTransState* trans = NULL;
+	rina::ApplicationRegistrationRequestEvent event;
+	rina::ApplicationProcessNamingInformation daf_name;
+	rina::ApplicationRegistrationInformation ari;
+
+	// Select an IPC process from the DIF specified in the request
+	slave_ipcp = select_ipcp_by_dif(dif_name);
+	if (!slave_ipcp) {
+		LOG_ERR("Cannot find a suitable DIF to "
+			"register IP range %s ", ip_range.c_str());
+		return IPCM_FAILURE;
+	}
+
+	//Populate application name
+	event.applicationRegistrationInformation.appName.processName = ip_range;
+	event.applicationRegistrationInformation.appName.entityName = RINA_IP_FLOW_ENT_NAME;
+
+	//Auto release the read lock
+	rina::ReadScopedLock readlock(slave_ipcp->rwlock, false);
+
+	//Perform the registration
+	try {
+		//Create a transaction
+		trans = new APPregTransState(NULL, promise, slave_ipcp->get_id(), event);
+		if(!trans){
+			LOG_ERR("Unable to allocate memory for the transaction object. Out of memory! ");
+			return IPCM_FAILURE;
+		}
+
+		//Store transaction
+		if(add_transaction_state(trans) < 0){
+			LOG_ERR("Unable to add transaction; out of memory? ");
+			return IPCM_FAILURE;
+		}
+
+		ari.appName = event.applicationRegistrationInformation.appName;
+		ari.dafName = daf_name;
+		ari.pid = getpid();
+		ari.ctrl_port = 0;
+		ari.ipcProcessId = 0;
+		ari.applicationRegistrationType = rina::APPLICATION_REGISTRATION_SINGLE_DIF;
+		slave_ipcp->registerApplication(ari,
+						trans->tid);
+
+		LOG_INFO("Requested registration of IP prefix %s"
+				" to IPC process %s ",
+				ip_range.c_str(),
+				slave_ipcp->get_name().toString().c_str());
+	} catch (rina::IpcmRegisterApplicationException& e) {
+		//Remove the transaction and return
+		remove_transaction_state(trans->tid);
+
+		LOG_ERR("Error while registering IP prefix %s",
+			event.applicationRegistrationInformation.appName.toString().c_str());
+		return IPCM_FAILURE;
+	}
+
+	return IPCM_PENDING;
+}
+
+ipcm_res_t IPCManager_::unregister_ip_prefix_from_dif(Promise* promise,
+						      const std::string& ip_range,
+						      const rina::ApplicationProcessNamingInformation& dif_name)
+{
+	IPCMIPCProcess *slave_ipcp;
+	APPUnregTransState* trans;
+	rina::ApplicationUnregistrationRequestEvent req_event;
+
+	try
+	{
+		slave_ipcp = select_ipcp_by_dif(dif_name, true);
+
+		if (!slave_ipcp)
+		{
+			LOG_ERR("Cannot find any IPC process belonging to DIF %s",
+				dif_name.toString().c_str());
+			return IPCM_FAILURE;
+		}
+
+		rina::WriteScopedLock swritelock(slave_ipcp->rwlock, false);
+
+		//Create a transaction
+		req_event.applicationName.processName = ip_range;
+		req_event.applicationName.entityName = RINA_IP_FLOW_ENT_NAME;
+		trans = new APPUnregTransState(NULL, promise, slave_ipcp->get_id(), req_event);
+		if (!trans)
+		{
+			LOG_ERR("Unable to allocate memory for the transaction object. Out of memory! ");
+			return IPCM_FAILURE;
+		}
+
+		//Store transaction
+		if (add_transaction_state(trans) < 0)
+		{
+			LOG_ERR("Unable to add transaction; out of memory?");
+			return IPCM_FAILURE;
+		}
+
+		// Forward the unregistration request to the IPC process
+		// that the client IPC process is registered to
+		slave_ipcp->unregisterApplication(req_event.applicationName, trans->tid);
+
+		LOG_INFO("Requested unregistration of IP prefix %s"
+				" from IPC process %s",
+				ip_range.c_str(),
+				slave_ipcp->get_name().toString().c_str());
+	} catch (rina::ConcurrentException& e)
+	{
+		LOG_ERR("Error while unregistering IP prefix %s"
+				" from IPC process %s, The operation timed out.",
+				ip_range.c_str(),
+				slave_ipcp->get_name().toString().c_str());
+		remove_transaction_state(trans->tid);
+		return IPCM_FAILURE;
+	} catch (rina::IpcmUnregisterApplicationException& e)
+	{
+		LOG_ERR("Error while unregistering IP prefix %s"
+				" from IPC process %s",
+				ip_range.c_str(),
+				slave_ipcp->get_name().toString().c_str());
+		remove_transaction_state(trans->tid);
+		return IPCM_FAILURE;
+	} catch (rina::Exception& e)
+	{
+		LOG_ERR("Unknown error while requesting unregistering IPCP");
+		remove_transaction_state(trans->tid);
+		return IPCM_FAILURE;
+	}
+
+	return IPCM_PENDING;
+}
+
+ipcm_res_t IPCManager_::allocate_iporina_flow(Promise* promise,
+				 	      const std::string& src_ip_range,
+					      const std::string& dst_ip_range,
+					      const std::string& dif_name,
+					      const rina::FlowSpecification flow_spec)
+{
+	rina::FlowRequestEvent event;
+
+	event.localRequest = true;
+	event.localApplicationName.processName = src_ip_range;
+	event.localApplicationName.entityName = RINA_IP_FLOW_ENT_NAME;
+	event.remoteApplicationName.processName = dst_ip_range;
+	event.remoteApplicationName.entityName = RINA_IP_FLOW_ENT_NAME;
+	event.flowSpecification = flow_spec;
+	event.DIFName.processName = dif_name;
+	event.DIFName.processInstance = "";
+
+	return flow_allocation_requested_event_handler(promise, &event);
+}
+
+void IPCManager_::allocate_iporina_flow_response(const rina::FlowRequestEvent& event,
+				    	    	 int result,
+						 bool notify_source)
+{
+	IPCMIPCProcess * ipcp;
+
+	ipcp = lookup_ipcp_by_id(event.ipcProcessId);
+	if (!ipcp) {
+		LOG_ERR("Error: Could not retrieve IPC process with id %d "
+			", to serve remote flow allocation request", event.ipcProcessId);
+		return;
+	}
+
+	//Auto release the read lock
+	rina::ReadScopedLock readlock(ipcp->rwlock, false);
+
+	try {
+		// Inform the IPC process about the response of the flow
+		// allocation procedure
+		ipcp->allocateFlowResponse(event, result, 0, notify_source, 0);
+
+		LOG_INFO("Informing IPC process %s about flow allocation from application %s"
+			" to application %s in DIF %s [success = %d, port-id = %d]",
+			 ipcp->proxy_->name.getProcessNamePlusInstance().c_str(),
+			 event.localApplicationName.toString().c_str(),
+			 event.remoteApplicationName.toString().c_str(),
+			 ipcp->dif_name_.processName.c_str(), result, event.portId);
+	} catch (rina::AllocateFlowException& e) {
+		LOG_ERR("Error while informing IPC process %d"
+			" about flow allocation", ipcp->proxy_->id);
+	}
+}
+
+ipcm_res_t IPCManager_::deallocate_iporina_flow(Promise* promise,
+				   	   	int port_id)
+{
+	rina::FlowRequestEvent req_event;
+	rina::FlowDeallocateRequestEvent event;
+
+	if (ip_vpn_manager->get_iporina_flow_info(port_id, req_event)) {
+		return IPCM_FAILURE;
+	}
+
+	event.sequenceNumber = 0;
+	event.portId = port_id;
+
+	return flow_deallocation_requested_event_handler(promise, &event);
+}
+
+} //namespace rinad

--- a/rinad/src/ipcm/ip-vpn-manager.h
+++ b/rinad/src/ipcm/ip-vpn-manager.h
@@ -1,0 +1,65 @@
+/*
+ * IP VPN Manager. Manages creation and deletion of IP over RINA flows
+ * and VPNs. Manages registration of IP prefixes as application names
+ * in RINA DIFs, as well as allocation of flows between IP prefixes,
+ * the creation of VPNs and the reconfiguration of the IP forwarding table.
+ *
+ *    Eduard Grasa <eduard.grasa@i2cat.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301  USA
+ */
+
+#ifndef __IP_VPN_MANAGER_H__
+#define __IP_VPN_MANAGER_H__
+
+#include <librina/concurrency.h>
+
+#define RINA_IP_FLOW_ENT_NAME "RINA_IP"
+
+namespace rinad {
+
+class IPVPNManager {
+public:
+	IPVPNManager();
+	~IPVPNManager();
+	int add_registered_ip_prefix(const std::string& ip_prefix);
+	int remove_registered_ip_prefix(const std::string& ip_prefix);
+	bool ip_prefix_registered(const std::string& ip_prefix);
+	int iporina_flow_allocated(const rina::FlowRequestEvent& event);
+	void iporina_flow_allocation_requested(const rina::FlowRequestEvent& event);
+	int get_iporina_flow_info(int port_id, rina::FlowRequestEvent& event);
+	int iporina_flow_deallocated(int port_id, const int ipcp_id);
+
+private:
+	bool __ip_prefix_registered(const std::string& ip_prefix);
+	int add_flow(const rina::FlowRequestEvent& event);
+	int remove_flow(rina::FlowRequestEvent& event);
+	int add_or_remove_ip_route(const std::string ip_prefix,
+			const int ipcp_id,
+			int port_id,
+			bool add);
+	std::string exec_shell_command(std::string result);
+	std::string get_rina_dev_name(const int ipcp_id, int port_id);
+	std::string get_ip_prefix_string(const std::string& input);
+
+	std::list<std::string> reg_ip_prefixes;
+	rina::Lockable lock;
+	std::map<int, rina::FlowRequestEvent> iporina_flows;
+};
+
+} //namespace rinad
+
+#endif  /* __IP_VPN_MANAGER_H__ */

--- a/rinad/src/ipcm/ipcm.cc
+++ b/rinad/src/ipcm/ipcm.cc
@@ -90,7 +90,8 @@ IPCManager_::IPCManager_()
           io_thread(NULL),
           dif_template_manager(NULL),
           dif_allocator(NULL),
-	  osp_monitor(NULL)
+	  osp_monitor(NULL),
+	  ip_vpn_manager(NULL)
 {
 }
 
@@ -102,6 +103,10 @@ IPCManager_::~IPCManager_()
 
 	if (dif_allocator) {
 		delete dif_allocator;
+	}
+
+	if (ip_vpn_manager) {
+	        delete ip_vpn_manager;
 	}
 
 	forwarded_calls.clear();
@@ -146,6 +151,9 @@ void IPCManager_::init(const std::string& loglevel, std::string& config_file)
         // Initialize OS Process Monitor
         osp_monitor = new OSProcessMonitor();
         osp_monitor->start();
+
+        // Initialize IP VPN Manager
+        ip_vpn_manager = new IPVPNManager();
     } catch (rina::InitializationException& e)
     {
         LOG_ERR("Error while initializing librina-ipc-manager");

--- a/rinad/src/ipcm/ipcm.h
+++ b/rinad/src/ipcm/ipcm.h
@@ -40,6 +40,7 @@
 #include "dif-template-manager.h"
 #include "catalog.h"
 #include "process-event-listener.h"
+#include "ip-vpn-manager.h"
 
 //Addons
 #include "addon.h"
@@ -551,6 +552,27 @@ public:
 	// @ret IPCM_FAILURE on failure, otherwise the IPCM_SUCCESS
 	ipcm_res_t update_catalog(Addon* callee);
 
+	ipcm_res_t register_ip_prefix_to_dif(Promise* promise,
+					     const std::string& ip_range,
+					     const rina::ApplicationProcessNamingInformation& difName);
+
+	ipcm_res_t unregister_ip_prefix_from_dif(Promise* promise,
+					         const std::string& ip_range,
+						 const rina::ApplicationProcessNamingInformation& difName);
+
+	ipcm_res_t allocate_iporina_flow(Promise* promise,
+					 const std::string& src_ip_range,
+					 const std::string& dst_ip_range,
+					 const std::string& dif_name,
+					 const rina::FlowSpecification flow_spec);
+
+	void allocate_iporina_flow_response(const rina::FlowRequestEvent& event,
+					    int result,
+					    bool notify_source);
+
+	ipcm_res_t deallocate_iporina_flow(Promise* promise,
+					   int port_id);
+
 	//
 	// Get the current logging debug level
 	//
@@ -619,6 +641,9 @@ public:
 
         //Catalog of policies
         Catalog catalog;
+
+        //The IP VPN Manager
+        IPVPNManager * ip_vpn_manager;
 
 protected:
 


### PR DESCRIPTION
Add IP over RINA capabilities via a dedicated RINA network device that exposes a flow, allowing the kernel to use it to forward IP packets with certain prefixes to their destination. 
Ported functionality from ARCFIRE branch, will have to be later updated to a more flexible model (allowing multiple IP prefixes to be forwarded through the same RINA flow).