### PR TITLE
exponentially increase cwnd during SLOW_START phase

### DIFF
--- a/plugins/dctcp/dtcp-ps-dctcp.c
+++ b/plugins/dctcp/dtcp-ps-dctcp.c
@@ -76,7 +76,7 @@ static int dctcp_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
 		data->state = CONG_AVOID;
 	} else if (data->state == SLOW_START) {
 		/* Increase credit by one */
-		cwnd++;
+		cwnd = cwnd << 1;
 	} else {
 		/* CA state, increase by 1/cwnd */
 		data->dec_credit += DEC_PRECISION/cwnd;

--- a/plugins/red/dtcp-ps-red.c
+++ b/plugins/red/dtcp-ps-red.c
@@ -63,7 +63,7 @@ red_rcvr_flow_control(struct dtcp_ps * ps, const struct pci * pci)
 	spin_lock_bh(&dtcp->parent->sv_lock);
         new_credit = dtcp->sv->rcvr_credit;
 	if (data->state == SLOW_START) {
-		new_credit++;
+		new_credit = new_credit << 1;
 		if (new_credit >= data->sshtresh) {
 			data->state = CONG_AVOID;
 		}


### PR DESCRIPTION
Shouldn't cwnd increased exponentially rather than linearly during slow_start phase?