### PR TITLE
Initialise version and PDU flags in packets

### DIFF
--- a/kernel/dtcp.c
+++ b/kernel/dtcp.c
@@ -379,6 +379,7 @@ struct du * pdu_ctrl_generate(struct dtcp * dtcp, pdu_type_t type)
 		       dtcp->parent->efcp->connection->destination_address,
                        seq,
 		       dtcp->parent->efcp->connection->qos_id,
+                       0,
 		       du->pci.len,
                        type)) {
 		LOG_ERR("Could not format recently created PCI");

--- a/kernel/dtp.c
+++ b/kernel/dtp.c
@@ -1310,6 +1310,7 @@ int dtp_write(struct dtp * instance,
                        efcp->connection->destination_address,
                        csn,
                        efcp->connection->qos_id,
+                       0,
 		       sbytes + du->pci.len,
                        PDU_TYPE_DT)) {
 		LOG_ERR("Could not format PCI");

--- a/kernel/du.c
+++ b/kernel/du.c
@@ -238,6 +238,7 @@ struct du * du_create_from_skb(struct sk_buff* skb)
 
 	tmp->skb = skb;
 	tmp->pci.h = NULL;
+	tmp->pci.len = 0;
 	tmp->cfg = NULL;
 	tmp->sdup_head = NULL;
 	tmp->sdup_tail = NULL;

--- a/kernel/ipcps/normal-ipcp.c
+++ b/kernel/ipcps/normal-ipcp.c
@@ -762,6 +762,7 @@ static int normal_mgmt_du_write(struct ipcp_instance_data * data,
                        0,
                        0,
                        1,
+                       0,
 		       du->pci.len + sbytes,
                        PDU_TYPE_MGMT)) {
         	LOG_ERR("Problems formatting PCI");

--- a/kernel/pci.c
+++ b/kernel/pci.c
@@ -37,6 +37,8 @@
 #define FLAGS_SIZE 1
 #define TYPE_SIZE 1
 
+#define VERSION 1
+
 enum pci_field_index {
 	PCI_BASE_VERSION = 0,
 	PCI_BASE_DST_ADD,
@@ -344,6 +346,10 @@ static struct efcp_config *__pci_efcp_config_get(const struct pci *pci)
 	return 0;}
 
 /* Base getters */
+cep_id_t pci_version(const struct pci *pci)
+{ PCI_GETTER_NO_DTC(pci, PCI_BASE_VERSION, VERSION_SIZE, version_t); }
+EXPORT_SYMBOL(pci_version);
+
 cep_id_t pci_cep_source(const struct pci *pci)
 { PCI_GETTER(pci, PCI_BASE_SRC_CEP, cep_id_length, cep_id_t); }
 EXPORT_SYMBOL(pci_cep_source);
@@ -377,6 +383,10 @@ ssize_t pci_length(const struct pci *pci)
 EXPORT_SYMBOL(pci_length);
 
 /* Base setters */
+int pci_version_set(struct pci *pci, version_t version)
+{ PCI_SETTER_NO_DTC(pci, PCI_BASE_VERSION, VERSION_SIZE, version); }
+EXPORT_SYMBOL(pci_version_set);
+
 int pci_sequence_number_set(struct pci *pci, seq_num_t sn)
 { PCI_SETTER(pci, PCI_DT_MGMT_SN, seq_num_length, sn); }
 EXPORT_SYMBOL(pci_sequence_number_set);
@@ -420,16 +430,19 @@ int pci_format(struct pci *pci,
 	       address_t dst_address,
 	       seq_num_t sequence_number,
 	       qos_id_t  qos_id,
+	       pdu_flags_t flags,
 	       ssize_t   length,
 	       pdu_type_t type)
 {
-	if (pci_type_set(pci, type)                       ||
+	if (pci_version_set(pci, VERSION)                 ||
+	    pci_type_set(pci, type)                       ||
 	    pci_cep_destination_set(pci, dst_cep_id)      ||
 	    pci_cep_source_set(pci, src_cep_id)           ||
 	    pci_destination_set(pci, dst_address)         ||
 	    pci_source_set(pci, src_address)              ||
 	    pci_sequence_number_set(pci, sequence_number) ||
 	    pci_qos_id_set(pci, qos_id)			  ||
+	    pci_flags_set(pci, flags)			  ||
 	    pci_len_set(pci, length)) {
 		return -1;
 	}

--- a/kernel/pci.h
+++ b/kernel/pci.h
@@ -29,6 +29,8 @@
 #include "common.h"
 #include "ipcp-instances.h"
 
+typedef uint8_t version_t;
+
 #define PDU_FLAGS_EXPLICIT_CONGESTION 0x01
 #define PDU_FLAGS_DATA_RUN            0x80
 /* To be truely defined; internal to stack, needs to be discussed */
@@ -106,6 +108,7 @@ int pci_len_set(struct pci *pci, ssize_t len);
 int pci_format(struct pci *pci, cep_id_t src_cep_id, cep_id_t dst_cep_id,
 	       address_t src_address, address_t dst_address,
 	       seq_num_t sequence_number, qos_id_t qos_id,
+	       pdu_flags_t flags,
 	       ssize_t length, pdu_type_t type);
 
 /* FIXME: remove _get from the API name */


### PR DESCRIPTION
The version and PDU flags fields did not seem to be initialised for the packets.