### PR TITLE
Several bug and warning fixes

### DIFF
--- a/kernel/delim-ps-default.c
+++ b/kernel/delim-ps-default.c
@@ -346,7 +346,7 @@ int default_delim_process_udf(struct delim_ps * ps, struct du * du,
 
 	flags = (char *) du_buffer(du);
 
-	LOG_DBG("Received UDF with length %d and flags %d",
+	LOG_DBG("Received UDF with length %ld and flags %d",
 		du_len(du) - 1, *flags);
 
 	if (*flags & 0x08) {

--- a/kernel/ipcps/shim-tcp-udp.c
+++ b/kernel/ipcps/shim-tcp-udp.c
@@ -1699,7 +1699,8 @@ static int tcp_udp_rcv_process_msg(struct sock * sk)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0)
         if (kernel_getsockname(sock, &own.sa, &len)) {
 #else
-	if (kernel_getsockname(sock, &own.sa)) {
+	len = kernel_getsockname(sock, &own.sa);
+	if (len < 0) {
 #endif
                 LOG_ERR("Couldn't retrieve hostname");
                 return -1;

--- a/librina/src/Makefile.am
+++ b/librina/src/Makefile.am
@@ -198,7 +198,7 @@ librinajsoncpp.pc: Makefile librinajsoncpp.pc.in
 	chmod a-w $@.tmp
 	mv $@.tmp $@
 
-CLEANFILES += librina.pc librinajsoncpp.pc
+CLEANFILES += librina.pc librinajsoncpp.pc CDAP.pb.h CDAP.pb.cc CDAP.stamp *.pb.h *.pb.cc *.stamp
 
 pkgconfigdir   = $(libdir)/pkgconfig
 pkgconfig_DATA = librina.pc librinajsoncpp.pc

--- a/rinad/src/common/encoders/Makefile.am
+++ b/rinad/src/common/encoders/Makefile.am
@@ -4,7 +4,7 @@
 # Written by: Francesco Salvestrini <f DOT salvestrini AT nextworks DOT it>
 #
 
-CLEANFILES       =
+CLEANFILES       = *.pb.h *.pb.c *.stamp
 MOSTLYCLEANFILES =
 EXTRA_DIST       =
 

--- a/rinad/src/ipcm/app-handlers.cc
+++ b/rinad/src/ipcm/app-handlers.cc
@@ -256,8 +256,6 @@ IPCManager_::ipcm_register_response_common(rina::IpcmRegisterApplicationResponse
                 FLUSH_LOG(ERR, ss);
         }
 
-        if (success)
-
         return success;
 }
 

--- a/rinad/src/ipcp/enrollment-task.cc
+++ b/rinad/src/ipcp/enrollment-task.cc
@@ -1381,6 +1381,7 @@ void EnrollmentTask::initiateEnrollment(const rina::EnrollmentRequest& request)
 	flowInformation.difName = request.neighbor_.supporting_dif_name_;
 	flowInformation.flowSpecification.msg_boundaries = true;
 	flowInformation.flowSpecification.orderedDelivery = true;
+	flowInformation.flowSpecification.maxAllowableGap = 0;
 	flowInformation.flowSpecification.delay = fspec.delay;
 	flowInformation.flowSpecification.loss = fspec.loss;
 	unsigned int handle = -1;

--- a/rinad/src/ipcp/plugins/sm-cbac/Makefile.am
+++ b/rinad/src/ipcp/plugins/sm-cbac/Makefile.am
@@ -7,7 +7,7 @@
 include Makefile.inc
 
 # EXTRA_DIST   =
-# CLEANFILES   =
+CLEANFILES = *.pb.h *.pb.cc sm-cbac.stamp
 # MOSTLYCLEANFILES = 
 # DISTCLEANFILES = 
 # protoSOURCES = 


### PR DESCRIPTION
Fixes the following issues:

- Wrong caling sequence in kernel_getsockname (#1334)
- Function that didn't return a result on ipcm (#1333)
- Generated proto files not removed when doing make clean (#1332)
- Kernel compilation warning
- Enrollment was not using a reliable N-1 flow in some cases