### PR TITLE
Fix a bug that prevented iporinad from building

### DIFF
--- a/rina-tools/src/rlite/Makefile.am
+++ b/rina-tools/src/rlite/Makefile.am
@@ -27,14 +27,13 @@ noinst_LTLIBRARIES =				\
 BUILT_SOURCES = $(protoSOURCES)
 
 libiporina_la_SOURCES =			\
-	$(protoSOURCES)
+	$(protoSOURCES)				\
 libiporina_la_CPPFLAGS =			\
 	-I$(builddir)/..			\
-	-I$(srcdir)/..				\
-	$(CPPFLAGS_EXTRA)
+	-I$(srcdir)/..
 
 iporinad_SOURCES = iporinad.cpp fdfwd.cpp cdap.cpp
-iporinad_LDADD = $(LIBRINA_API_LIBS) -liporina
+iporinad_LDADD = $(LIBRINA_API_LIBS) libiporina.la
 iporinad_CPPFLAGS = $(LIBRINA_API_CFLAGS) -std=c++11
 
 bin_PROGRAMS += rinaperf rina-echo-async rina-gw iporinad


### PR DESCRIPTION
Fix the Makefile.am to make sure libiporina.la is built as part of the build.

The branch fixing bug 1340 should be merged with this one because both PR fix IRATI on Raspbian.