### PR TITLE
5.10 fixes

### DIFF
--- a/kernel/dtcp.c
+++ b/kernel/dtcp.c
@@ -23,6 +23,7 @@
 #define RINA_PREFIX "dtcp"
 
 #include <linux/delay.h>
+#include <linux/ktime.h>
 
 #include "logs.h"
 #include "utils.h"
@@ -50,7 +51,7 @@ int dtcp_pdu_send(struct dtcp * dtcp, struct du * du)
 }
 EXPORT_SYMBOL(dtcp_pdu_send);
 
-int dtcp_last_time_set(struct dtcp * dtcp, struct timespec * s)
+int dtcp_last_time_set(struct dtcp * dtcp, struct timespec64 * s)
 {
 	ASSERT(dtcp);
 	ASSERT(dtcp->sv);
@@ -136,7 +137,7 @@ static ssize_t dtcp_attr_show(struct robject *		     robj,
 		return sprintf(buf, "%u\n", instance->sv->pdus_rcvd_in_time_unit);
 	}
 	if (strcmp(robject_attr_name(attr), "last_time") == 0) {
-		struct timespec s;
+		struct timespec64 s;
 		s.tv_sec = instance->sv->last_time.tv_sec;
 		s.tv_nsec = instance->sv->last_time.tv_nsec;
 		return sprintf(buf, "%lld.%.9ld\n",
@@ -1333,12 +1334,12 @@ unsigned long dtcp_ms(struct timespec * ts) {
 
 /* Is the given rate exceeded? Reset if the time frame given elapses. */
 bool dtcp_rate_exceeded(struct dtcp * dtcp, int send) {
-	struct timespec now  = {0, 0};
+	struct timespec64 now  = {0, 0};
 	uint_t timedif_ms;
 	uint_t rate = 0;
 	uint_t lim = 0;
 
-	getnstimeofday(&now);
+	ktime_get_real_ts64(&now);
 
 	timedif_ms = (int)(now.tv_sec - dtcp->sv->last_time.tv_sec) * 1000 +
 		((int)now.tv_nsec - (int)dtcp->sv->last_time.tv_nsec) / 1000000;

--- a/kernel/dtcp.h
+++ b/kernel/dtcp.h
@@ -76,7 +76,7 @@ struct du	*pdu_ctrl_ack_create(struct dtcp *dtcp,
 				     seq_num_t snd_rt_wind_edge);
 struct du	*pdu_ctrl_generate(struct dtcp *dtcp, pdu_type_t type);
 int		dtcp_last_time_set(struct dtcp *dtcp,
-					   struct timespec *s);
+					   struct timespec64 *s);
 bool		dtcp_rate_exceeded(struct dtcp *dtcp, int send);
 
 /* end SDK */

--- a/kernel/dtp.c
+++ b/kernel/dtp.c
@@ -722,9 +722,9 @@ static void tf_a(struct timer_list * tl)
         return;
 }
 
-static unsigned int msec_to_next_rate(uint time_frame, struct timespec * last)
+static unsigned int msec_to_next_rate(uint time_frame, struct timespec64 * last)
 {
-	struct timespec now = {0,0};
+	struct timespec64 now = {0,0};
 
 	if(!last) {
 		LOG_ERR("%s arg invalid, last: 0x%pK", __func__, last);
@@ -738,7 +738,7 @@ static unsigned int msec_to_next_rate(uint time_frame, struct timespec * last)
 // Reordering and adjusting units:
 // ret = convert_to_ms_units(last - now) + timeframe
 // (Being sure to avoid overflow/underflow)
-	getnstimeofday(&now);
+	ktime_get_real_ts64(&now);
 	return ((int)last->tv_sec - (int)now.tv_sec) * 1000
 		+ ((int)last->tv_nsec - (int)now.tv_nsec) / 1000000
 		+ time_frame;
@@ -750,7 +750,7 @@ static unsigned int msec_to_next_rate(uint time_frame, struct timespec * last)
 void dtp_start_rate_timer(struct dtp * dtp, struct dtcp * dtcp)
 {
 	uint rtf, tf;
-	struct timespec t = {0,0};
+	struct timespec64 t = {0,0};
 
 	tf = 0;
 
@@ -767,8 +767,8 @@ void dtp_start_rate_timer(struct dtp * dtp, struct dtcp * dtcp)
 
 	tf = msec_to_next_rate(rtf, &t);
 
-	LOG_DBG("Rate based timer start, time %u msec, "
-		"last: %lu:%lu", tf, t.tv_sec, t.tv_nsec);
+	LOG_DBG("Rate based timer start, time %llu msec, "
+		"last: %llu:%llu", tf, t.tv_sec, t.tv_nsec);
 
 	rtimer_start(&dtp->timers.rate_window, tf);
 }
@@ -781,7 +781,7 @@ static void tf_rate_window(struct timer_list * tl)
 {
         struct dtp *  dtp;
         struct dtcp * dtcp;
-        struct timespec now  = {0, 0};
+        struct timespec64 now  = {0, 0};
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
         dtp = (struct dtp *) o;
@@ -798,7 +798,7 @@ static void tf_rate_window(struct timer_list * tl)
         LOG_DBG("rbfc Timer job start...");
         LOG_DBG("rbfc Re-opening the rate mechanism");
 
-        getnstimeofday(&now);
+        ktime_get_real_ts64(&now);
 
         spin_lock_bh(&dtp->sv_lock);
 	dtcp->sv->pdus_sent_in_time_unit = 0;

--- a/kernel/efcp-str.h
+++ b/kernel/efcp-str.h
@@ -22,6 +22,7 @@
 #define RINA_EFCP_STR_H
 
 #include <linux/list.h>
+#include <linux/time.h>
 
 #include "common.h"
 #include "delim.h"
@@ -284,7 +285,7 @@ struct dtcp_sv {
 		/* Last time-instant when the credit check has been done.
 		 * This is used by rate-based flow control mechanism.
 		 */
-		struct timespec last_time;
+		struct timespec64 last_time;
 
         /*
          * Control of duplicated control PDUs

--- a/kernel/ipcps/normal-ipcp.c
+++ b/kernel/ipcps/normal-ipcp.c
@@ -24,6 +24,7 @@
 #include <linux/list.h>
 #include <linux/string.h>
 #include <linux/version.h>
+#include <linux/time.h>
 
 #define IPCP_NAME   "normal-ipc"
 


### PR DESCRIPTION
This fixes compilation of the IRATI kernel modules for Linux 5.10 kernel

This is just an RFC PR as this is **untested**. The patch is enough for the modules to compile and load but I I do not know how to configure my sample RINA setup with encryption so that this code path get used. Suggestion are welcome.