### PR TITLE
protobuf: change ByteSize to ByteSizeLong

### DIFF
--- a/librina/src/cdap_v2.cc
+++ b/librina/src/cdap_v2.cc
@@ -2915,7 +2915,7 @@ void GPBSerializer::serializeMessage(const cdap_m_t &cdapMessage,
 	// VERSION
 	gpfCDAPMessage.set_version(cdapMessage.version_);
 
-	int size = gpfCDAPMessage.ByteSize();
+	int size = gpfCDAPMessage.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpfCDAPMessage.SerializeToArray(result.message_, size);
@@ -4141,7 +4141,7 @@ void StringEncoder::encode(const std::string& obj, ser_obj_t& serobj)
 	s.set_value(obj);
 
 	//Allocate memory
-	serobj.size_ = s.ByteSize();
+	serobj.size_ = s.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 
 	if (!serobj.message_)
@@ -4165,7 +4165,7 @@ void IntEncoder::encode(const int &obj, ser_obj_t& serobj)
 
 	gpb.set_value(obj);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }

--- a/librina/src/irm.cc
+++ b/librina/src/irm.cc
@@ -456,7 +456,7 @@ void DIFPropertiesEncoder::encode(const DIFProperties &obj,
 	gpb.set_max_sdu_size(obj.maxSDUSize);
 	gpb.set_dif_name(obj.DIFName.processName);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -494,7 +494,7 @@ void FlowInformationEncoder::encode(const FlowInformation &obj,
 	}
 	gpb.set_state((messages::flowStateValues_t) obj.state);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }

--- a/librina/src/security-manager.cc
+++ b/librina/src/security-manager.cc
@@ -492,7 +492,7 @@ void encode_ssh2_auth_options(const SSH2AuthOptions& options,
 					      options.dh_public_key.length);
 	}
 
-	int size = gpb_options.ByteSize();
+	int size = gpb_options.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_options.SerializeToArray(result.message_, size);
@@ -515,7 +515,7 @@ void encode_client_chall_reply_ssh2(const UcharArray& client_chall_reply,
 					       server_chall.length);
 	}
 
-	int size = gpb_chall.ByteSize();
+	int size = gpb_chall.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_chall.SerializeToArray(result.message_ , size);

--- a/librina/src/tlshand-authp.cc
+++ b/librina/src/tlshand-authp.cc
@@ -100,7 +100,7 @@ void encode_tls_hand_auth_options(const TLSHandAuthOptions& options,
 					     options.random.random_bytes.length);
 	}
 
-	int size = gpb_options.ByteSize();
+	int size = gpb_options.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_options.SerializeToArray(result.message_, size);
@@ -121,7 +121,7 @@ void encode_server_hello_tls_hand(const TLSHandRandom& random,
 	gpb_hello.set_mac_alg(mac_alg);
 	gpb_hello.set_compress_method(compress_method);
 
-	int size = gpb_hello.ByteSize();
+	int size = gpb_hello.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_hello.SerializeToArray(result.message_ , size);
@@ -161,7 +161,7 @@ void encode_certificate_tls_hand(const UcharArray& certificate_chain,
 
 	gpb_certificate.set_certificate_chain(certificate_chain.data, certificate_chain.length);
 
-	int size = gpb_certificate.ByteSize();
+	int size = gpb_certificate.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_certificate.SerializeToArray(result.message_ , size);
@@ -191,7 +191,7 @@ void encode_client_key_exchange_tls_hand(const UcharArray& enc_pmaster_secret,
 
 	gpb_key_exchange.set_enc_pmaster_secret(enc_pmaster_secret.data, enc_pmaster_secret.length);
 
-	int size = gpb_key_exchange.ByteSize();
+	int size = gpb_key_exchange.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_key_exchange.SerializeToArray(result.message_ , size);
@@ -221,7 +221,7 @@ void encode_client_certificate_verify_tls_hand(const UcharArray& enc_verify_hash
 
 	gpb_cert_verify.set_enc_verify_hash(enc_verify_hash.data, enc_verify_hash.length);
 
-	int size = gpb_cert_verify.ByteSize();
+	int size = gpb_cert_verify.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_cert_verify.SerializeToArray(result.message_ , size);
@@ -251,7 +251,7 @@ void encode_finish_message_tls_hand(const UcharArray& opaque_verify_data,
 
 	gpb_finish.set_opaque_verify_data(opaque_verify_data.data, opaque_verify_data.length);
 
-	int size = gpb_finish.ByteSize();
+	int size = gpb_finish.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_finish.SerializeToArray(result.message_ , size);

--- a/rina-tools/src/key-managers/km-common.cc
+++ b/rina-tools/src/key-managers/km-common.cc
@@ -956,7 +956,7 @@ void KeyContainerManager::encode_key_container_message(const struct key_containe
 				      kc.public_key.size_);
 	}
 
-	int size = gpb_kc.ByteSize();
+	int size = gpb_kc.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_kc.SerializeToArray(result.message_, size);

--- a/rina-tools/src/rlite/Makefile.am
+++ b/rina-tools/src/rlite/Makefile.am
@@ -6,7 +6,7 @@ bin_PROGRAMS                       =
 AM_INSTALLCHECK_STD_OPTIONS_EXEMPT =
 
 rinaperf_SOURCES = rinaperf.c
-rinaperf_LDADD = $(LIBRINA_API_LIBS) -lm
+rinaperf_LDADD = $(LIBRINA_API_LIBS) -lm -lpthread
 rinaperf_CPPFLAGS = $(LIBRINA_API_CFLAGS)
 
 rina_echo_async_SOURCES = rina-echo-async.c
@@ -14,7 +14,7 @@ rina_echo_async_LDADD = $(LIBRINA_API_LIBS)
 rina_echo_async_CPPFLAGS = $(LIBRINA_API_CFLAGS)
 
 rina_gw_SOURCES = rina-gw.cpp fdfwd.cpp
-rina_gw_LDADD = $(LIBRINA_API_LIBS)
+rina_gw_LDADD = $(LIBRINA_API_LIBS) -lpthread
 rina_gw_CPPFLAGS = $(LIBRINA_API_CFLAGS) -std=c++11
 
 MOSTLYCLEANFILES =
@@ -33,7 +33,7 @@ libiporina_la_CPPFLAGS =			\
 	-I$(srcdir)/..
 
 iporinad_SOURCES = iporinad.cpp fdfwd.cpp cdap.cpp
-iporinad_LDADD = $(LIBRINA_API_LIBS) libiporina.la
+iporinad_LDADD = $(LIBRINA_API_LIBS) libiporina.la -lpthread
 iporinad_CPPFLAGS = $(LIBRINA_API_CFLAGS) -std=c++11
 
 bin_PROGRAMS += rinaperf rina-echo-async rina-gw iporinad

--- a/rina-tools/src/rlite/cdap.cpp
+++ b/rina-tools/src/rlite/cdap.cpp
@@ -1088,7 +1088,7 @@ msg_ser_stateless(CDAPMessage *m, char **buf, size_t *len)
 
     gm = static_cast<gpb::CDAPMessage>(*m);
 
-    *len = gm.ByteSize();
+    *len = gm.ByteSizeLong();
     *buf = new char[*len];
 
     gm.SerializeToArray(*buf, *len);

--- a/rina-tools/src/rlite/iporinad.cpp
+++ b/rina-tools/src/rlite/iporinad.cpp
@@ -184,14 +184,14 @@ struct Obj {
 static int
 ser_common(::google::protobuf::MessageLite &gm, char *buf, int size)
 {
-    if (gm.ByteSize() > size) {
-        fprintf(stderr, "User buffer too small [%u/%u]\n", gm.ByteSize(), size);
+    if (gm.ByteSizeLong() > size) {
+        fprintf(stderr, "User buffer too small [%u/%u]\n", gm.ByteSizeLong(), size);
         return -1;
     }
 
     gm.SerializeToArray(buf, size);
 
-    return gm.ByteSize();
+    return gm.ByteSizeLong();
 }
 
 struct Hello : public Obj {

--- a/rina-tools/src/tgen-apps/Makefile.am
+++ b/rina-tools/src/tgen-apps/Makefile.am
@@ -6,7 +6,7 @@ bin_PROGRAMS                       =
 AM_INSTALLCHECK_STD_OPTIONS_EXEMPT =
 
 tg_server_SOURCES = tg-server.cpp
-tg_server_LDADD = $(LIBRINA_API_LIBS)
+tg_server_LDADD = $(LIBRINA_API_LIBS) -lpthread
 tg_server_CPPFLAGS = $(LIBRINA_API_CFLAGS) -I$(srcdir)/../common -lpthread -std=c++11
 
 tg_client_SOURCES = tg-client.cpp

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -176,7 +176,7 @@ void DataTransferConstantsEncoder::encode(
         rina::messages::dataTransferConstants_t gpb;
 
         dt_const_helpers::toGPB(obj, gpb);
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -222,7 +222,7 @@ void DFTEEncoder::encode(const rina::DirectoryForwardingTableEntry &obj,
 
         dft_helpers::toGPB(obj, gpb);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -249,7 +249,7 @@ void DFTEListEncoder::encode(
 			dft_helpers::toGPB((*it), *gpb_dft);
 	}
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -293,7 +293,7 @@ void AppDIFMappingEncoder::encode(const AppToDIFMapping &obj, rina::ser_obj_t& s
 
         dif_alloc_helpers::toGPB(obj, gpb);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -317,7 +317,7 @@ void AppDIFMappingListEncoder::encode(const std::list<AppToDIFMapping> &obj,
 		dif_alloc_helpers::toGPB((*it), *gpb_dft);
 	}
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -667,7 +667,7 @@ void QoSCubeEncoder::encode(const rina::QoSCube &obj, rina::ser_obj_t &serobj)
 
         cube_helpers::toGPB(obj, gpb);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -695,7 +695,7 @@ void QoSCubeListEncoder::encodePointers(const std::list<rina::QoSCube*> &obj,
                 cube_helpers::toGPB(*(*it), *gpb_cube);
         }
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -713,7 +713,7 @@ void QoSCubeListEncoder::encode(const std::list<rina::QoSCube> &obj,
 		cube_helpers::toGPB((*it), *gpb_cube);
 	}
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 
@@ -766,7 +766,7 @@ void WhatevercastNameEncoder::encode(const rina::WhatevercastName &obj,
 
         whatever_helpers::toGPB(obj, gpb);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -794,7 +794,7 @@ void WhatevercastNameListEncoder::encode(
 			whatever_helpers::toGPB((*it), *gpb_name);
 	}
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -850,7 +850,7 @@ void NeighborEncoder::encode(const rina::Neighbor &obj, rina::ser_obj_t& serobj)
 
         neighbor_helpers::toGPB(obj, gpb);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -876,7 +876,7 @@ void NeighborListEncoder::encode(const std::list<rina::Neighbor> &obj,
 			neighbor_helpers::toGPB((*it), *gpb_neigh);
 	}
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -905,7 +905,7 @@ void ADataObjectEncoder::encode(const rina::cdap::ADataObject &obj,
         gpb.set_cdapmessage(obj.encoded_cdap_message_.message_,
                             obj.encoded_cdap_message_.size_);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -944,7 +944,7 @@ void EnrollmentInformationRequestEncoder::encode(
                 gpb.add_supportingdifs(it->processName);
         }
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -1080,7 +1080,7 @@ void FlowEncoder::encode(const configs::Flow &obj, rina::ser_obj_t& serobj)
         //hopCount
         gpb.set_hopcount(obj.hop_count);
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -1156,7 +1156,7 @@ void RoutingTableEntryEncoder::encode(const rina::RoutingTableEntry &obj,
                 }
         }
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -1210,7 +1210,7 @@ void PDUForwardingTableEntryEncoder::encode(
                 }
         }
 
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -1258,7 +1258,7 @@ void DTPInformationEncoder::encode(const rina::DTPInformation &obj,
 	gpb.set_bytes_tx(obj.stats.tx_bytes);
 	gpb.set_bytes_rx(obj.stats.rx_bytes);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -1289,7 +1289,7 @@ void DTCPInformationEncoder::encode(const rina::DTCPConfig &obj,
 
         gpb = cube_helpers::get_dtcpConfig_t(obj);
 
-        serobj.size_ = gpb->ByteSize();
+        serobj.size_ = gpb->ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
         gpb->SerializeToArray(serobj.message_, serobj.size_);
 
@@ -1720,7 +1720,7 @@ void IPCPConfigEncoder::encode(const configs::ipcp_config_t &obj,
         gpb.set_dif_template(obj.dif_template);
 
         //Allocate memory
-        ser_obj.size_ = gpb.ByteSize();
+        ser_obj.size_ = gpb.ByteSizeLong();
         ser_obj.message_ = new unsigned char[ser_obj.size_];
 
         if (!ser_obj.message_)
@@ -1772,7 +1772,7 @@ void IPCPEncoder::encode(const configs::ipcp_t& obj, rina::ser_obj_t& serobj)
         //TODO add name
 
         //Allocate memory
-        serobj.size_ = gpb_ap_name.ByteSize();
+        serobj.size_ = gpb_ap_name.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
 
         if (!serobj.message_)
@@ -1813,7 +1813,7 @@ void RIBObjectDataListEncoder::encode(
         }
 
         //Allocate memory
-        serobj.size_ = gpb.ByteSize();
+        serobj.size_ = gpb.ByteSizeLong();
         serobj.message_ = new unsigned char[serobj.size_];
 
         if (!serobj.message_)

--- a/rinad/src/ipcp/plugins/default/routing-ps.cc
+++ b/rinad/src/ipcp/plugins/default/routing-ps.cc
@@ -2283,7 +2283,7 @@ void FlowStateObjectEncoder::encode(const FlowStateObject &obj,
 
 	fso_helpers::toGPB(obj, gpb);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -2310,7 +2310,7 @@ void FlowStateObjectListEncoder::encode(const std::list<FlowStateObject> &obj,
 		fso_helpers::toGPB(*it, *gpb_fso);
 	}
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }

--- a/rinad/src/ipcp/plugins/sm-cbac/security-manager-cbac.cc
+++ b/rinad/src/ipcp/plugins/sm-cbac/security-manager-cbac.cc
@@ -338,7 +338,7 @@ void serializeToken(const Token_t &token,
         }
         
         // serializing
-        int size = gpbToken.ByteSize();
+        int size = gpbToken.ByteSizeLong();
         result.message_ = new unsigned char[size];
         result.size_ = size;
         gpbToken.SerializeToArray(result.message_, size);
@@ -394,7 +394,7 @@ void serializeTokenPlusSignature(const TokenPlusSignature_t &tokenSign,
         gpbTokenSign.set_token_sign(tokenSign.token_sign.data, tokenSign.token_sign.length);
 
         //serializing
-        int size = gpbTokenSign.ByteSize();
+        int size = gpbTokenSign.ByteSizeLong();
         result.message_ = new unsigned char[size];
         result.size_ = size;
         gpbTokenSign.SerializeToArray(result.message_, size);


### PR DESCRIPTION
According to github.com/protocolbuffers/protobuf:CHANGES.txt, ByteSize() and SpaceUsed()
are deprecated since protobuf 3.4.0 at 2017-08-14, protobuf suggested to use ByteSizeLong()
and SpaceUsedLong() instead.

With protobuf 3.12.4 and GCC 10.2.1, this already blocked 'stack' from been built.