### PR TITLE
Stop the timers before freeing the RTX queue

### DIFF
--- a/kernel/dtp-utils.c
+++ b/kernel/dtp-utils.c
@@ -751,6 +751,8 @@ static void rtx_timer_func(struct timer_list * tl)
         q = dtp->rtxq;
         tr = dtp->sv->tr;
 
+        BUG_ON(q == NULL);
+
         spin_lock(&q->lock);
         if (rtxqueue_rtx(q, tr, dtp,
 			 dtp->dtcp->cfg->rxctrl_cfg->data_retransmit_max))

--- a/kernel/dtp.c
+++ b/kernel/dtp.c
@@ -1137,6 +1137,19 @@ int dtp_destroy(struct dtp * instance)
 
 	spin_lock_bh(&instance->lock);
 
+        /* Stop all the timer so they do not happen while we're freeing
+           the object. */
+
+        rtimer_destroy(&instance->timers.a);
+        /* tf_a posts workers that restart sender_inactivity timer, so the wq
+         * must be flushed before destroying the timer */
+
+        rtimer_stop(&instance->timers.sender_inactivity);
+        rtimer_stop(&instance->timers.receiver_inactivity);
+        rtimer_stop(&instance->timers.rate_window);
+        rtimer_stop(&instance->timers.rtx);
+        rtimer_stop(&instance->timers.rendezvous);
+
         if (instance->dtcp) {
                 dtcp = instance->dtcp;
                 instance->dtcp = NULL; /* Useful */


### PR DESCRIPTION
The timer are destroyed further down the cleanup routine but they can still be triggered after the RTX queue object is freed.