### PR TITLE
Missing spin_unlock before return.

### DIFF
--- a/kernel/cidm.c
+++ b/kernel/cidm.c
@@ -95,6 +95,7 @@ int cidm_allocated(struct cidm * instance, cep_id_t cep_id)
         spin_lock(&instance->lock);
         list_for_each_entry_safe(pos, next, &instance->allocated_cep_ids, list) {
                 if (pos->cep_id == cep_id) {
+                    spin_unlock(&instance->lock);
                 	return 1;
                 }
         }


### PR DESCRIPTION
This statement was obviously missing and I think this is what caused the last lock ups that I've seen. Before going trigger-happy about closing the associated bug, though, I think I'll use the module for a bit longer.