### PR TITLE
Ethernet shim generalization

### DIFF
--- a/kernel/dtp-utils.c
+++ b/kernel/dtp-utils.c
@@ -751,6 +751,8 @@ static void rtx_timer_func(struct timer_list * tl)
         q = dtp->rtxq;
         tr = dtp->sv->tr;
 
+        BUG_ON(q == NULL);
+
         spin_lock(&q->lock);
         if (rtxqueue_rtx(q, tr, dtp,
 			 dtp->dtcp->cfg->rxctrl_cfg->data_retransmit_max))

--- a/kernel/dtp.c
+++ b/kernel/dtp.c
@@ -1137,6 +1137,19 @@ int dtp_destroy(struct dtp * instance)
 
 	spin_lock_bh(&instance->lock);
 
+        /* Stop all the timer so they do not happen while we're freeing
+           the object. */
+
+        rtimer_destroy(&instance->timers.a);
+        /* tf_a posts workers that restart sender_inactivity timer, so the wq
+         * must be flushed before destroying the timer */
+
+        rtimer_stop(&instance->timers.sender_inactivity);
+        rtimer_stop(&instance->timers.receiver_inactivity);
+        rtimer_stop(&instance->timers.rate_window);
+        rtimer_stop(&instance->timers.rtx);
+        rtimer_stop(&instance->timers.rendezvous);
+
         if (instance->dtcp) {
                 dtcp = instance->dtcp;
                 instance->dtcp = NULL; /* Useful */

--- a/kernel/ipcps/Makefile.in
+++ b/kernel/ipcps/Makefile.in
@@ -15,9 +15,9 @@ endif
 EXTRA_CFLAGS := -I$(PWD)/../include
 
 obj-m  += normal-ipcp.o
-obj-m  += shim-eth-vlan.o
-shim-eth-vlan-y :=				\
-	shim-eth-vlan-core.o
+obj-m  += shim-eth.o
+shim-eth-y :=				\
+	shim-eth-core.o
 obj-m   += shim-tcp-udp.o
 
 ifeq ($(HAVE_VMPI),y)

--- a/rinad/src/ipcm/dif-validator.cc
+++ b/rinad/src/ipcm/dif-validator.cc
@@ -14,7 +14,7 @@ DIFConfigValidator::DIFConfigValidator(const rina::DIFInformation &dif_info,
 		type_ = NORMAL;
 	else if (type == "shim-dummy")
 		type_ = SHIM_DUMMY;
-	else if (type == "shim-eth-vlan")
+	else if (type == "shim-eth-vlan" || type == "shim-eth")
 		type_ = SHIM_ETH;
 	else if (type == "shim-tcp-udp")
 		type_ = SHIM_TCP_UDP;


### PR DESCRIPTION
This branch aims to generalize the Ethernet shim for it to be able to work without depending on VLAN. This was tested to be working between 2 VMs in VirtualBox. The patch tries to preserve the functionality of the original Ethernet VLAN shim but the change in the module name might break setups.

Posted early as a RFC. DO NOT MERGE in its current state as I'm noticing there are a little too much changes that are white spaces only. I think I can do better than this.