### PR TITLE
PR01 -- Allow some configuration elements to be overriden on the command line

### DIFF
--- a/rinad/src/common/rina-configuration.cc
+++ b/rinad/src/common/rina-configuration.cc
@@ -97,6 +97,7 @@ string LocalConfiguration::toString() const
         ss << "\tLibrary path: " << libraryPath << endl;
         ss << "\tLog path: " << logPath << endl;
         ss << "\tConsole socket: " << consoleSocket << endl;
+        ss << "\tSystem Name: " << system_name.toString() << endl;
 
 	ss << "\tPlugins paths:" <<endl;
 	for (list<string>::const_iterator lit = pluginsPaths.begin();


### PR DESCRIPTION
I've built a script which allows me to dynamically start and stop specific IPCM configurations. For this to work well, though, I had to modify the IPCM to allow some of it's configuration elements to be overridden on the command line. This obviously isn't going to change anything for people not wanting that feature.