### PR TITLE
PR02 -- GRPC: GetByteSize is deprecated.

### DIFF
--- a/librina/src/cdap_v2.cc
+++ b/librina/src/cdap_v2.cc
@@ -2915,7 +2915,7 @@ void GPBSerializer::serializeMessage(const cdap_m_t &cdapMessage,
 	// VERSION
 	gpfCDAPMessage.set_version(cdapMessage.version_);
 
-	int size = gpfCDAPMessage.ByteSize();
+	int size = gpfCDAPMessage.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpfCDAPMessage.SerializeToArray(result.message_, size);
@@ -4141,7 +4141,7 @@ void StringEncoder::encode(const std::string& obj, ser_obj_t& serobj)
 	s.set_value(obj);
 
 	//Allocate memory
-	serobj.size_ = s.ByteSize();
+	serobj.size_ = s.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 
 	if (!serobj.message_)
@@ -4165,7 +4165,7 @@ void IntEncoder::encode(const int &obj, ser_obj_t& serobj)
 
 	gpb.set_value(obj);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }

--- a/librina/src/irm.cc
+++ b/librina/src/irm.cc
@@ -456,7 +456,7 @@ void DIFPropertiesEncoder::encode(const DIFProperties &obj,
 	gpb.set_max_sdu_size(obj.maxSDUSize);
 	gpb.set_dif_name(obj.DIFName.processName);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
@@ -494,7 +494,7 @@ void FlowInformationEncoder::encode(const FlowInformation &obj,
 	}
 	gpb.set_state((messages::flowStateValues_t) obj.state);
 
-	serobj.size_ = gpb.ByteSize();
+	serobj.size_ = gpb.ByteSizeLong();
 	serobj.message_ = new unsigned char[serobj.size_];
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }

--- a/librina/src/security-manager.cc
+++ b/librina/src/security-manager.cc
@@ -492,7 +492,7 @@ void encode_ssh2_auth_options(const SSH2AuthOptions& options,
 					      options.dh_public_key.length);
 	}
 
-	int size = gpb_options.ByteSize();
+	int size = gpb_options.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_options.SerializeToArray(result.message_, size);
@@ -515,7 +515,7 @@ void encode_client_chall_reply_ssh2(const UcharArray& client_chall_reply,
 					       server_chall.length);
 	}
 
-	int size = gpb_chall.ByteSize();
+	int size = gpb_chall.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_chall.SerializeToArray(result.message_ , size);

--- a/librina/src/tlshand-authp.cc
+++ b/librina/src/tlshand-authp.cc
@@ -100,7 +100,7 @@ void encode_tls_hand_auth_options(const TLSHandAuthOptions& options,
 					     options.random.random_bytes.length);
 	}
 
-	int size = gpb_options.ByteSize();
+	int size = gpb_options.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_options.SerializeToArray(result.message_, size);
@@ -121,7 +121,7 @@ void encode_server_hello_tls_hand(const TLSHandRandom& random,
 	gpb_hello.set_mac_alg(mac_alg);
 	gpb_hello.set_compress_method(compress_method);
 
-	int size = gpb_hello.ByteSize();
+	int size = gpb_hello.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_hello.SerializeToArray(result.message_ , size);
@@ -161,7 +161,7 @@ void encode_certificate_tls_hand(const UcharArray& certificate_chain,
 
 	gpb_certificate.set_certificate_chain(certificate_chain.data, certificate_chain.length);
 
-	int size = gpb_certificate.ByteSize();
+	int size = gpb_certificate.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_certificate.SerializeToArray(result.message_ , size);
@@ -191,7 +191,7 @@ void encode_client_key_exchange_tls_hand(const UcharArray& enc_pmaster_secret,
 
 	gpb_key_exchange.set_enc_pmaster_secret(enc_pmaster_secret.data, enc_pmaster_secret.length);
 
-	int size = gpb_key_exchange.ByteSize();
+	int size = gpb_key_exchange.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_key_exchange.SerializeToArray(result.message_ , size);
@@ -221,7 +221,7 @@ void encode_client_certificate_verify_tls_hand(const UcharArray& enc_verify_hash
 
 	gpb_cert_verify.set_enc_verify_hash(enc_verify_hash.data, enc_verify_hash.length);
 
-	int size = gpb_cert_verify.ByteSize();
+	int size = gpb_cert_verify.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_cert_verify.SerializeToArray(result.message_ , size);
@@ -251,7 +251,7 @@ void encode_finish_message_tls_hand(const UcharArray& opaque_verify_data,
 
 	gpb_finish.set_opaque_verify_data(opaque_verify_data.data, opaque_verify_data.length);
 
-	int size = gpb_finish.ByteSize();
+	int size = gpb_finish.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_finish.SerializeToArray(result.message_ , size);

--- a/rina-tools/src/key-managers/km-common.cc
+++ b/rina-tools/src/key-managers/km-common.cc
@@ -956,7 +956,7 @@ void KeyContainerManager::encode_key_container_message(const struct key_containe
 				      kc.public_key.size_);
 	}
 
-	int size = gpb_kc.ByteSize();
+	long size = gpb_kc.ByteSizeLong();
 	result.message_ = new unsigned char[size];
 	result.size_ = size;
 	gpb_kc.SerializeToArray(result.message_, size);


### PR DESCRIPTION
There is another pending PR for this but it's likely to be outdated. This patch is what I needed to do to get rinad and rina-tools to compile.