### PR TITLE
PR04 -- Initialize the 'timed_out' value to something

### DIFF
--- a/kernel/rinarp/arp826-arm.c
+++ b/kernel/rinarp/arp826-arm.c
@@ -129,6 +129,7 @@ static struct resolve_data * resolve_data_create_gfp(gfp_t               flags,
         tmp->sha   = sha;
         tmp->tpa   = tpa;
         tmp->tha   = tha;
+        tmp->timed_out = 0;
 
         return tmp;
 }


### PR DESCRIPTION
This is a tiny thing that I forgot to do in the code that has been merged in IRATI previously. It should be an non-issue to merge it.

I've been seeing the error message "ARP resolver called on timed out request"
without realizing that it meant that something was quite wrong in the code. It
turns out that when an ARP reply was received, the value of "timed_out" was not
initialized, which meant proper replies got rejected on a regular basis. Enough
requests still went through as normal that I didn't realize something was wrong
before now.