### PR TITLE
PR05 -- Timeout ARP requests

### DIFF
--- a/kernel/ipcps/shim-eth-core.c
+++ b/kernel/ipcps/shim-eth-core.c
@@ -632,24 +632,6 @@ static void rinarp_resolve_handler(void *             opaque,
         struct shim_eth_flow *      flow;
 
         LOG_DBG("Entered the ARP resolve handler of the Ethernet shim");
-        if (irati_verbosity >= LOG_VERB_DBG) {
-                char *s;
-                const uint8_t *ha;
-
-                LOG_DBG("Resolving with: ");
-                if (timed_out)
-                        LOG_DBG("\tResolution timed out!");
-
-                s = gpa_address_to_string_gfp(GFP_KERNEL, dest_pa);
-                LOG_DBG("\tdest_pa: %s", s);
-                rkfree(s);
-                if (!timed_out) {
-                        ha = gha_address(flow->dest_ha);
-                        LOG_DBG("\tdest_ha: %u:%u:%u:%u:%u:%u",
-                                ha[0], ha[1],  ha[2], ha[3], ha[4], ha[5]);
-                } else
-                        LOG_DBG("\tdest_ha: Timed out!");
-        }
 
         ASSERT(opaque);
 

--- a/kernel/ipcps/shim-eth-core.c
+++ b/kernel/ipcps/shim-eth-core.c
@@ -2293,11 +2293,10 @@ static struct ipcp_instance* eth_create(struct ipcp_factory_data*  data,
                                                 inst->data,
                                                 &eth_shim_dbg_inst_flows_ops);
                         inst->data->dbg_flows = d;
-                        d = debugfs_create_u32("arp_timeout_ms",
-                                               S_IRUSR | S_IWUSR,
-                                               inst->data->dbg,
-                                               &inst->data->info->arp_timeout_ms);
-                        inst->data->dbg_timeout = d;
+                        debugfs_create_u32("arp_timeout_ms",
+                                           S_IRUSR | S_IWUSR,
+                                           inst->data->dbg,
+                                           &inst->data->info->arp_timeout_ms);
                 }
         }
 #endif

--- a/kernel/ipcps/shim-eth-core.c
+++ b/kernel/ipcps/shim-eth-core.c
@@ -720,6 +720,11 @@ static void rinarp_resolve_handler(void *             opaque,
                 else {
                         spin_unlock_bh(&data->lock);
                         LOG_DBG("Flow creation ARP request has timed out.");
+                        kfa_port_id_release(data->kfa, flow->port_id);
+
+                        rfifo_destroy(flow->sdu_queue, (void (*)(void *)) du_destroy);
+                        flow->sdu_queue = NULL;
+
                         unbind_and_destroy_flow(data, flow);
                 }
 

--- a/kernel/ipcps/shim-eth-core.c
+++ b/kernel/ipcps/shim-eth-core.c
@@ -75,6 +75,13 @@ struct dentry *dbg_root;
 struct eth_info {
         uint16_t vlan_id;
         char *   interface_name;
+
+        // Allow for the ethernet shim to disregard the interface MAC
+        // address.
+        u8 spoof_mac[6];
+
+        // This is set to 1 if we're to use the spoofed MAC.
+        bool use_spoof_mac;
 };
 
 struct ipcp_factory_data {
@@ -727,6 +734,8 @@ eth_flow_allocate_request(struct ipcp_instance_data * data,
                 return -1;
         } */
 
+        LOG_DBG("Will try to create flow on port ID %d", id);
+
         flow = find_flow(data, id);
         if (!flow) {
                 flow = rkzalloc(sizeof(*flow), GFP_KERNEL);
@@ -867,6 +876,8 @@ eth_flow_allocate_response(struct ipcp_instance_data * data,
                 rfifo_destroy(flow->sdu_queue, (void (*)(void *)) du_destroy);
                 flow->sdu_queue = NULL;
         } else {
+                LOG_DBG("Allocating flow on port ID %d FAILED", port_id);
+
                 spin_lock(&data->lock);
                 flow->port_id_state = PORT_STATE_NULL;
                 spin_unlock(&data->lock);
@@ -947,7 +958,11 @@ static int eth_application_register(struct ipcp_instance_data* data,
                 name_destroy(data->app_name);
                 return -1;
         }
-        ha = gha_create(MAC_ADDR_802_3, data->dev->dev_addr);
+        if (!data->info->use_spoof_mac)
+                ha = gha_create(MAC_ADDR_802_3, data->dev->dev_addr);
+        else
+                ha = gha_create(MAC_ADDR_802_3, data->info->spoof_mac);
+
         if (!gha_is_ok(ha)) {
                 LOG_ERR("Failed to create gha");
                 name_destroy(data->app_name);
@@ -1633,6 +1648,12 @@ static int eth_set_net_devs_auto(struct ipcp_instance_data* data) {
         read_lock(&dev_base_lock);
         data->dev = __dev_get_by_name(&init_net, info->interface_name);
 
+        if (!data->dev) {
+            LOG_ERR("Unknown device: %s", info->interface_name);
+            read_unlock(&dev_base_lock);
+            return -1;
+        }
+
         if (is_vlan_dev(data->dev)) {
                 data->phy_dev = vlan_dev_real_dev(data->dev);
                 info->vlan_id = vlan_dev_vlan_id(data->dev);
@@ -1668,6 +1689,7 @@ static int eth_assign_to_dif(struct ipcp_instance_data * data,
         string_t *                      complete_interface;
         struct interface_data_mapping * mapping;
         int                             result;
+        string_t *                      spoof_mac;
 
         if (!data) {
                 LOG_ERR("Bogus data passed, bailing out");
@@ -1698,6 +1720,7 @@ static int eth_assign_to_dif(struct ipcp_instance_data * data,
         /* Retrieve configuration of IPC process from params */
         list_for_each_entry(tmp, &(config->ipcp_config_entries), next) {
                 const struct ipcp_config_entry * entry = tmp->entry;
+
                 if (!strcmp(entry->name, "interface-name")) {
                         ASSERT(entry->value);
 
@@ -1708,8 +1731,29 @@ static int eth_assign_to_dif(struct ipcp_instance_data * data,
                                 data->dif_name = NULL;
                                 return -1;
                         }
-                } else
-                        LOG_DBG("Unknown config param for eth shim, ignoring");
+                }
+                else if (!strcmp(entry->name, "spoof-mac")) {
+                        spoof_mac = rkstrdup(entry->value);
+                        if (!spoof_mac) {
+                                LOG_ERR("Cannot copy 'spoof-mac' value");
+                                return -1;
+                        }
+
+                        // Convert the string MAC address to it's
+                        // address representation.
+                        if (!mac_pton(spoof_mac, info->spoof_mac)) {
+                                LOG_ERR("Invalid spoof MAC: %s", spoof_mac);
+                                rkfree(spoof_mac);
+                                return -1;
+                        }
+
+                        LOG_INFO("Ethernet shim will pretend its MAC address is: %s",
+                                 spoof_mac);
+
+                        info->use_spoof_mac = 1;
+                        rkfree(spoof_mac);
+                }
+                else LOG_DBG("Ignoring unknown config param: %s", entry->name);
         }
 
         /* Fail here if we didn't get an interface */
@@ -1778,6 +1822,7 @@ static int eth_update_dif_config(struct ipcp_instance_data * data,
         string_t *                      complete_interface;
         struct interface_data_mapping * mapping;
         int                             result;
+        string_t *                      spoof_mac;
 
         if (!data) {
                 LOG_ERR("Bogus data passed, bailing out");
@@ -1799,15 +1844,34 @@ static int eth_update_dif_config(struct ipcp_instance_data * data,
 
                 entry = tmp->entry;
                 if (!strcmp(entry->name, "interface-name")) {
-                        ASSERT(entry->value);
-
                         info->interface_name = rkstrdup(entry->value);
                         if (!info->interface_name) {
-                                LOG_ERR("Cannot copy interface name");
+                                LOG_ERR("Cannot copy 'interface-name' value");
                                 return -1;
                         }
-                } else
-                        LOG_DBG("Unknown config param for Ethernet shim, ignoring");
+                }
+                else if (!strcmp(entry->name, "spoof-mac")) {
+                        spoof_mac = rkstrdup(entry->value);
+                        if (!spoof_mac) {
+                                LOG_ERR("Cannot copy 'spoof-mac' value");
+                                return -1;
+                        }
+
+                        // Convert the string MAC address to it's
+                        // address representation.
+                        if (!mac_pton(spoof_mac, info->spoof_mac)) {
+                                LOG_ERR("Invalid spoof MAC: %s", spoof_mac);
+                                rkfree(spoof_mac);
+                                return -1;
+                        }
+
+                        LOG_INFO("Ethernet shim will pretend its MAC address is: %s",
+                                 spoof_mac);
+
+                        info->use_spoof_mac = 1;
+                        rkfree(spoof_mac);
+                }
+                else LOG_DBG("Ignoring unknown config param: %s", entry->name);
         }
 
         dev_remove_pack(data->eth_packet_type);

--- a/kernel/ipcps/shim-eth-core.c
+++ b/kernel/ipcps/shim-eth-core.c
@@ -75,7 +75,7 @@ struct eth_info {
 
 static struct ipcp_factory_data {
         struct list_head instances;
-	struct notifier_block ntfy;
+        struct notifier_block ntfy;
 } eth_data;
 
 enum port_id_state {
@@ -147,11 +147,11 @@ struct ipcp_instance_data {
         struct rinarp_handle * app_handle;
         struct rinarp_handle * daf_handle;
 
-	/* To handle device notifications. */
-	struct notifier_block ntfy;
+        /* To handle device notifications. */
+        struct notifier_block ntfy;
 
-	/* Flow control between this IPCP and the associated netdev. */
-	unsigned int tx_busy;
+        /* Flow control between this IPCP and the associated netdev. */
+        unsigned int tx_busy;
 };
 
 /* Needed for eth_rcv function */
@@ -163,41 +163,41 @@ struct interface_data_mapping {
 };
 
 static ssize_t eth_ipcp_attr_show(struct robject *        robj,
-                         	       struct robj_attribute * attr,
-                                       char *                  buf)
+                                  struct robj_attribute * attr,
+                                  char *                  buf)
 {
-	struct ipcp_instance * instance;
+        struct ipcp_instance * instance;
 
-	instance = container_of(robj, struct ipcp_instance, robj);
-	if (!instance || !instance->data)
-		return 0;
+        instance = container_of(robj, struct ipcp_instance, robj);
+        if (!instance || !instance->data)
+                return 0;
 
-	if (strcmp(robject_attr_name(attr), "name") == 0)
-		return sprintf(buf, "%s\n",
-			name_tostring(instance->data->name));
-	if (strcmp(robject_attr_name(attr), "dif") == 0)
-		return sprintf(buf, "%s\n",
-			name_tostring(instance->data->dif_name));
-	if (strcmp(robject_attr_name(attr), "address") == 0)
+        if (strcmp(robject_attr_name(attr), "name") == 0)
+                return sprintf(buf, "%s\n",
+                        name_tostring(instance->data->name));
+        if (strcmp(robject_attr_name(attr), "dif") == 0)
+                return sprintf(buf, "%s\n",
+                        name_tostring(instance->data->dif_name));
+        if (strcmp(robject_attr_name(attr), "address") == 0)
                 return sprintf(buf,
-		               "%02X:%02X:%02X:%02X:%02X:%02X\n",
+                               "%02X:%02X:%02X:%02X:%02X:%02X\n",
                                instance->data->dev->dev_addr[5],
                                instance->data->dev->dev_addr[4],
                                instance->data->dev->dev_addr[3],
                                instance->data->dev->dev_addr[2],
                                instance->data->dev->dev_addr[1],
                                instance->data->dev->dev_addr[0]);
-	if (strcmp(robject_attr_name(attr), "type") == 0)
+        if (strcmp(robject_attr_name(attr), "type") == 0)
                 return sprintf(buf, "shim-eth\n");
-	if (strcmp(robject_attr_name(attr), "vlan_id") == 0)
-		return sprintf(buf, "%u\n", instance->data->info->vlan_id);
-	if (strcmp(robject_attr_name(attr), "iface") == 0)
-		return sprintf(buf, "%s\n",
-			instance->data->info->interface_name);
-	if (strcmp(robject_attr_name(attr), "tx_busy") == 0)
-		return sprintf(buf, "%u\n", instance->data->tx_busy);
+        if (strcmp(robject_attr_name(attr), "vlan_id") == 0)
+                return sprintf(buf, "%u\n", instance->data->info->vlan_id);
+        if (strcmp(robject_attr_name(attr), "iface") == 0)
+                return sprintf(buf, "%s\n",
+                        instance->data->info->interface_name);
+        if (strcmp(robject_attr_name(attr), "tx_busy") == 0)
+                return sprintf(buf, "%u\n", instance->data->tx_busy);
 
-	return 0;
+        return 0;
 }
 RINA_SYSFS_OPS(eth_ipcp);
 RINA_ATTRS(eth_ipcp, name, type, dif, address, vlan_id, iface, tx_busy);
@@ -211,7 +211,7 @@ inst_data_mapping_get(struct net_device * dev)
 {
         struct interface_data_mapping * mapping;
 
-	ASSERT(dev);
+        ASSERT(dev);
 
         spin_lock(&data_instances_lock);
 
@@ -233,7 +233,7 @@ find_instance(struct ipcp_factory_data * data,
 {
         struct ipcp_instance_data * pos;
 
-	ASSERT(data);
+        ASSERT(data);
 
         list_for_each_entry(pos, &(data->instances), list) {
                 if (pos->id == id) {
@@ -250,8 +250,8 @@ static struct shim_eth_flow * find_flow(struct ipcp_instance_data * data,
 {
         struct shim_eth_flow * flow;
 
-	ASSERT(data);
-	ASSERT(is_port_id_ok(id));
+        ASSERT(data);
+        ASSERT(is_port_id_ok(id));
 
         spin_lock_bh(&data->lock);
 
@@ -272,9 +272,9 @@ static struct gpa * name_to_gpa(const struct name * name)
         char *       tmp;
         struct gpa * gpa;
 
-	ASSERT(name);
+        ASSERT(name);
 
-	tmp = name_tostring(name);
+        tmp = name_tostring(name);
         if (!tmp)
                 return NULL;
 
@@ -295,7 +295,7 @@ find_flow_by_gha(struct ipcp_instance_data * data,
 {
         struct shim_eth_flow * flow;
 
-	ASSERT(data);
+        ASSERT(data);
         ASSERT(gha_is_ok(addr));
 
         list_for_each_entry(flow, &data->flows, list) {
@@ -314,7 +314,7 @@ find_flow_by_gpa(struct ipcp_instance_data * data,
         struct shim_eth_flow * flow;
 
         ASSERT(data);
-	ASSERT(gpa_is_ok(addr));
+        ASSERT(gpa_is_ok(addr));
 
         list_for_each_entry(flow, &data->flows, list) {
                 if (gpa_is_equal(addr, flow->dest_pa)) {
@@ -328,7 +328,7 @@ find_flow_by_gpa(struct ipcp_instance_data * data,
 static bool vlan_id_is_ok(uint16_t vlan_id)
 {
         if (vlan_id & 0xF000) /* vlan_id > 4095) */
-		return false;
+                return false;
 
         /*
          * Reserved values:
@@ -355,10 +355,10 @@ static string_t * create_vlan_interface_name(string_t * interface_name,
 
         ASSERT(interface_name);
 
-	if (!vlan_id_is_ok(vlan_id)) {
-		LOG_ERR("Wrong vlan-id %d", vlan_id);
-		return NULL;
-	}
+        if (!vlan_id_is_ok(vlan_id)) {
+                LOG_ERR("Wrong vlan-id %d", vlan_id);
+                return NULL;
+        }
 
         bzero(string_vlan_id, sizeof(string_vlan_id)); /* Be safe */
         snprintf(string_vlan_id, sizeof(string_vlan_id), "%d", vlan_id);
@@ -387,11 +387,11 @@ static int flow_destroy(struct ipcp_instance_data * data,
                         struct shim_eth_flow *      flow)
 {
         ASSERT(data);
-	ASSERT(flow);
+        ASSERT(flow);
 
         spin_lock(&data->lock);
         if (!list_empty(&flow->list)) {
-        	LOG_DBG("Deleting flow %d from list and destroying it", flow->port_id);
+                LOG_DBG("Deleting flow %d from list and destroying it", flow->port_id);
                 list_del(&flow->list);
         }
         spin_unlock(&data->lock);
@@ -408,7 +408,7 @@ static int flow_destroy(struct ipcp_instance_data * data,
 static int unbind_and_destroy_flow(struct ipcp_instance_data * data,
                                    struct shim_eth_flow *      flow)
 {
-	ASSERT(data);
+        ASSERT(data);
         ASSERT(flow);
 
         if (flow->user_ipcp) {
@@ -427,27 +427,27 @@ static int unbind_and_destroy_flow(struct ipcp_instance_data * data,
 }
 
 static int eth_unbind_user_ipcp(struct ipcp_instance_data * data,
-                                     port_id_t                   id)
+                                port_id_t                   id)
 {
         struct shim_eth_flow * flow;
 
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
-	if (!is_port_id_ok(id)) {
-		LOG_ERR("Invalid port ID passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
+        if (!is_port_id_ok(id)) {
+                LOG_ERR("Invalid port ID passed, bailing out");
+                return -1;
+        }
 
         flow = find_flow(data, id);
 
-	spin_lock_bh(&data->lock);
-	if (!flow) {
-		spin_unlock_bh(&data->lock);
-		LOG_WARN("Could not find flow %d", id);
+        spin_lock_bh(&data->lock);
+        if (!flow) {
+                spin_unlock_bh(&data->lock);
+                LOG_WARN("Could not find flow %d", id);
                 return -1;
-	}
+        }
 
         if (flow->user_ipcp) {
                 flow->user_ipcp = NULL;
@@ -468,9 +468,9 @@ static void rinarp_resolve_handler(void *             opaque,
 
         LOG_DBG("Entered the ARP resolve handler of the Ethernet shim");
 
-	ASSERT(opaque);
-	ASSERT(dest_pa);
-	ASSERT(dest_ha);
+        ASSERT(opaque);
+        ASSERT(dest_pa);
+        ASSERT(dest_ha);
 
         data = (struct ipcp_instance_data *) opaque;
 
@@ -540,39 +540,39 @@ static void rinarp_resolve_handler(void *             opaque,
                         return;
                 }
         } else {
-        	spin_unlock_bh(&data->lock);
+                spin_unlock_bh(&data->lock);
         }
 }
 
 static int
 eth_flow_allocate_request(struct ipcp_instance_data * data,
-                               struct ipcp_instance *      user_ipcp,
-                               const struct name *         source,
-                               const struct name *         dest,
-                               const struct flow_spec *    fspec,
-                               port_id_t                   id)
+                          struct ipcp_instance *      user_ipcp,
+                          const struct name *         source,
+                          const struct name *         dest,
+                          const struct flow_spec *    fspec,
+                          port_id_t                   id)
 {
         struct shim_eth_flow * flow;
 
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
-	if (!source) {
-		LOG_ERR("Bogus source passed, bailing out");
-		return -1;
-	}
+        if (!source) {
+                LOG_ERR("Bogus source passed, bailing out");
+                return -1;
+        }
 
-	if (!dest) {
-		LOG_ERR("Bogus dest passed, bailing out");
-		return -1;
-	}
+        if (!dest) {
+                LOG_ERR("Bogus dest passed, bailing out");
+                return -1;
+        }
 
-	if (!is_port_id_ok(id)) {
-		LOG_ERR("Invalid port ID passed, bailing out");
-		return -1;
-	}
+        if (!is_port_id_ok(id)) {
+                LOG_ERR("Invalid port ID passed, bailing out");
+                return -1;
+        }
 
         /* if (!data->app_name || !name_is_equal(source, data->app_name)) {
                 LOG_ERR("Wrong request, app is not registered");
@@ -613,9 +613,9 @@ eth_flow_allocate_request(struct ipcp_instance_data * data,
                                        rinarp_resolve_handler,
                                        data) &&
                     rinarp_resolve_gpa(data->daf_handle,
-                		       flow->dest_pa,
-				       rinarp_resolve_handler,
-				       data)) {
+                                       flow->dest_pa,
+                                       rinarp_resolve_handler,
+                                       data)) {
                         LOG_ERR("Failed to lookup ARP entry");
                         unbind_and_destroy_flow(data, flow);
                         return -1;
@@ -632,22 +632,22 @@ eth_flow_allocate_request(struct ipcp_instance_data * data,
 
 static int
 eth_flow_allocate_response(struct ipcp_instance_data * data,
-                                struct ipcp_instance *      user_ipcp,
-                                port_id_t                   port_id,
-                                int                         result)
+                           struct ipcp_instance *      user_ipcp,
+                           port_id_t                   port_id,
+                           int                         result)
 {
         struct shim_eth_flow * flow;
         struct ipcp_instance * ipcp;
 
-       	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
-	if (!is_port_id_ok(port_id)) {
-		LOG_ERR("Invalid port ID passed, bailing out");
-		return -1;
-	}
+        if (!is_port_id_ok(port_id)) {
+                LOG_ERR("Invalid port ID passed, bailing out");
+                return -1;
+        }
 
         if (!user_ipcp) {
                 LOG_ERR("Wrong user_ipcp passed, bailing out");
@@ -738,19 +738,19 @@ eth_flow_allocate_response(struct ipcp_instance_data * data,
 }
 
 static int eth_flow_deallocate(struct ipcp_instance_data * data,
-                                    port_id_t                   id)
+                               port_id_t                   id)
 {
         struct shim_eth_flow * flow;
 
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
-	if (!is_port_id_ok(id)) {
-		LOG_ERR("Invalid port ID passed, bailing out");
-		return -1;
-	}
+        if (!is_port_id_ok(id)) {
+                LOG_ERR("Invalid port ID passed, bailing out");
+                return -1;
+        }
 
         flow = find_flow(data, id);
         if (!flow) {
@@ -768,15 +768,15 @@ static int eth_application_register(struct ipcp_instance_data* data,
         struct gpa * pa;
         struct gha * ha;
 
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
-	if (!name) {
-		LOG_ERR("Invalid name passed, bailing out");
-		return -1;
-	}
+        if (!name) {
+                LOG_ERR("Invalid name passed, bailing out");
+                return -1;
+        }
 
         if (data->app_name) {
                 char * tmp = name_tostring(data->app_name);
@@ -818,8 +818,8 @@ static int eth_application_register(struct ipcp_instance_data* data,
         gpa_destroy(pa);
 
         if (daf_name) {
-        	data->daf_name = name_dup(daf_name);
-        	if (!data->daf_name) {
+                data->daf_name = name_dup(daf_name);
+                if (!data->daf_name) {
                         char * tmp = name_tostring(daf_name);
                         LOG_ERR("DAF %s registration has failed", tmp);
                         if (tmp) rkfree(tmp);
@@ -828,18 +828,18 @@ static int eth_application_register(struct ipcp_instance_data* data,
                         name_destroy(data->app_name);
                         gha_destroy(ha);
                         return -1;
-        	}
+                }
 
-        	pa = name_to_gpa(daf_name);
-        	if (!gpa_is_ok(pa)) {
-        		LOG_ERR("Failed to create gpa");
-        		rinarp_remove(data->app_handle);
-        		data->app_handle = NULL;
-        		name_destroy(data->daf_name);
+                pa = name_to_gpa(daf_name);
+                if (!gpa_is_ok(pa)) {
+                        LOG_ERR("Failed to create gpa");
+                        rinarp_remove(data->app_handle);
+                        data->app_handle = NULL;
+                        name_destroy(data->daf_name);
                         name_destroy(data->app_name);
                         gha_destroy(ha);
-        		return -1;
-        	}
+                        return -1;
+                }
 
                 data->daf_handle = rinarp_add(data->dev, pa, ha);
                 if (!data->daf_handle) {
@@ -863,17 +863,17 @@ static int eth_application_register(struct ipcp_instance_data* data,
 }
 
 static int eth_application_unregister(struct ipcp_instance_data * data,
-                                           const struct name *         name)
+                                      const struct name *         name)
 {
-      	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
-	if (!name) {
-		LOG_ERR("Invalid name passed, bailing out");
-		return -1;
-	}
+        if (!name) {
+                LOG_ERR("Invalid name passed, bailing out");
+                return -1;
+        }
 
         if (!data->app_name) {
                 LOG_ERR("Ethernet shim has no application registered");
@@ -911,51 +911,51 @@ static int eth_application_unregister(struct ipcp_instance_data * data,
 
 static void enable_all_port_ids(struct ipcp_instance_data * data)
 {
-	struct shim_eth_flow 	  * flow;
+        struct shim_eth_flow      * flow;
 
-	ASSERT(data);
+        ASSERT(data);
 
-	spin_lock_bh(&data->lock);
-	list_for_each_entry(flow, &data->flows, list) {
-		if (flow->user_ipcp && flow->user_ipcp->ops)
-			flow->user_ipcp->ops->enable_write(flow->user_ipcp->data,
-							   flow->port_id);
-	}
-	spin_unlock_bh(&data->lock);
+        spin_lock_bh(&data->lock);
+        list_for_each_entry(flow, &data->flows, list) {
+                if (flow->user_ipcp && flow->user_ipcp->ops)
+                        flow->user_ipcp->ops->enable_write(flow->user_ipcp->data,
+                                                           flow->port_id);
+        }
+        spin_unlock_bh(&data->lock);
 }
 
 static void enable_write_all(struct net_device * dev)
 {
-	struct ipcp_instance_data * pos;
+        struct ipcp_instance_data * pos;
 
-	ASSERT(dev);
+        ASSERT(dev);
 
         list_for_each_entry(pos, &(eth_data.instances), list) {
                 if (pos->phy_dev == dev)
-                	enable_all_port_ids(pos);
+                        enable_all_port_ids(pos);
         }
 }
 
 static void eth_skb_destructor(struct sk_buff *skb)
 {
-	struct ipcp_instance_data *data =
-		(struct ipcp_instance_data *)(skb_shinfo(skb)->destructor_arg);
-	bool notify;
+        struct ipcp_instance_data *data =
+                (struct ipcp_instance_data *)(skb_shinfo(skb)->destructor_arg);
+        bool notify;
 
-	spin_lock_bh(&data->lock);
-	notify = data->tx_busy;
-	data->tx_busy = 0;
-	spin_unlock_bh(&data->lock);
+        spin_lock_bh(&data->lock);
+        notify = data->tx_busy;
+        data->tx_busy = 0;
+        spin_unlock_bh(&data->lock);
 
-	if (notify) {
-		enable_write_all(data->phy_dev);
-	}
+        if (notify) {
+                enable_write_all(data->phy_dev);
+        }
 }
 
 static int eth_du_write(struct ipcp_instance_data * data,
-                             port_id_t                   id,
-                             struct du *                 du,
-                             bool                        blocking)
+                        port_id_t                   id,
+                        struct du *                 du,
+                        bool                        blocking)
 {
         struct shim_eth_flow *   flow;
         struct sk_buff *         skb;
@@ -967,19 +967,19 @@ static int eth_du_write(struct ipcp_instance_data * data,
 
         LOG_DBG("Entered the sdu-write");
 
-	if (unlikely(!data)) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (unlikely(!data)) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
         hlen   = sizeof(struct ethhdr);
         tlen   = data->dev->needed_tailroom;
         length = du_len(du);
 
         if (unlikely(length > (data->dev->mtu - hlen))) {
-        	LOG_ERR("SDU too large (%d), dropping", length);
-        	du_destroy(du);
-        	return -1;
+                LOG_ERR("SDU too large (%d), dropping", length);
+                du_destroy(du);
+                return -1;
         }
 
         flow = find_flow(data, id);
@@ -998,8 +998,8 @@ static int eth_du_write(struct ipcp_instance_data * data,
         }
 
         if (data->tx_busy) {
-        	spin_unlock_bh(&data->lock);
-        	return -EAGAIN;
+                spin_unlock_bh(&data->lock);
+                return -EAGAIN;
         }
         spin_unlock_bh(&data->lock);
 
@@ -1017,22 +1017,22 @@ static int eth_du_write(struct ipcp_instance_data * data,
                 return -1;
         }
 
-	/* FIXME: sdu_detach_skb() has to be removed */
+        /* FIXME: sdu_detach_skb() has to be removed */
         skb = du_detach_skb(du);
         bup_skb = skb_clone(skb, GFP_ATOMIC);
         if (!bup_skb) {
-        	LOG_ERR("Error cloning SBK, bailing out");
+                LOG_ERR("Error cloning SBK, bailing out");
                 kfree_skb(skb);
-        	du_destroy(du);
-        	return -1;
+                du_destroy(du);
+                return -1;
         }
         du_attach_skb(du, skb);
 
         if (unlikely(skb_tailroom(bup_skb) < tlen)) {
-		LOG_ERR("Missing tail room in SKB, bailing out...");
+                LOG_ERR("Missing tail room in SKB, bailing out...");
                 kfree_skb(bup_skb);
-        	du_destroy(du);
-        	return -1;
+                du_destroy(du);
+                return -1;
         }
 
         skb_reset_network_header(bup_skb);
@@ -1049,23 +1049,23 @@ static int eth_du_write(struct ipcp_instance_data * data,
 
         bup_skb->dev = data->dev;
         bup_skb->destructor = &eth_skb_destructor;
-	skb_shinfo(bup_skb)->destructor_arg = (void *)data;
+        skb_shinfo(bup_skb)->destructor_arg = (void *)data;
         retval = dev_queue_xmit(bup_skb);
 
         if (retval == -ENETDOWN) {
-        	LOG_ERR("dev_q_xmit returned device down");
-        	du_destroy(du);
-        	return -1;
+                LOG_ERR("dev_q_xmit returned device down");
+                du_destroy(du);
+                return -1;
         }
         if (retval != NET_XMIT_SUCCESS) {
-        	spin_lock_bh(&data->lock);
-        	LOG_DBG("qdisc cannot enqueue now (%d), try later", retval);
-        	data->tx_busy = 1;
-        	spin_unlock_bh(&data->lock);
-        	return -EAGAIN;
+                spin_lock_bh(&data->lock);
+                LOG_DBG("qdisc cannot enqueue now (%d), try later", retval);
+                data->tx_busy = 1;
+                spin_unlock_bh(&data->lock);
+                return -EAGAIN;
         }
 
-       	du_destroy(du);
+        du_destroy(du);
         LOG_DBG("Packet sent");
         return 0;
 }
@@ -1076,16 +1076,16 @@ static int eth_rcv_worker(void * o)
         const struct gpa *              gpaddr;
         struct name *                   sname;
         struct ipcp_instance           *ipcp;
-	struct ipcp_instance           *user_ipcp;
+        struct ipcp_instance           *user_ipcp;
 
         struct shim_eth_flow *          flow;
         struct rcv_work_data *          wdata;
         struct net_device *             dev;
-        string_t * 			gpastr;
+        string_t *                      gpastr;
 
         LOG_DBG("Worker waking up, going to create a flow");
 
-	ASSERT(o);
+        ASSERT(o);
 
         wdata = (struct rcv_work_data *) o;
 
@@ -1128,7 +1128,7 @@ static int eth_rcv_worker(void * o)
         if (!user_ipcp->ops->ipcp_name(user_ipcp->data)) {
                 LOG_DBG("This flow goes for an app");
                 if (kfa_flow_create(data->kfa, flow->port_id, ipcp, data->id,
-                		    NULL, false)) {
+                                    NULL, false)) {
                         LOG_ERR("Could not create flow in KFA");
                         kfa_port_id_release(data->kfa, flow->port_id);
                         if (flow_destroy(data, flow))
@@ -1152,7 +1152,7 @@ static int eth_rcv_worker(void * o)
 
                 gpastr = gpa_address_to_string_gfp(GFP_KERNEL, gpaddr);
                 if (!gpastr) {
-                	LOG_ERR("Failed to convert GPA address to string");
+                        LOG_ERR("Failed to convert GPA address to string");
                         kfa_port_id_release(data->kfa, flow->port_id);
                         unbind_and_destroy_flow(data, flow);
                         return -1;
@@ -1194,7 +1194,7 @@ static int eth_rcv_worker(void * o)
                                data->id,
                                flow->port_id,
                                data->dif_name,
-			       data->app_name,
+                               data->app_name,
                                sname,
                                data->fspec)) {
                 LOG_ERR("Couldn't tell the KIPCM about the flow");
@@ -1210,7 +1210,7 @@ static int eth_rcv_worker(void * o)
 }
 
 static int eth_recv_process_packet(struct sk_buff *    skb,
-					struct net_device * dev)
+                                   struct net_device * dev)
 {
         struct ethhdr *                 mh;
         unsigned char *                 saddr;
@@ -1219,21 +1219,21 @@ static int eth_recv_process_packet(struct sk_buff *    skb,
         struct shim_eth_flow *          flow;
         struct gha *                    ghaddr;
         struct du *                     du;
-	struct sk_buff *                linear_skb;
+        struct sk_buff *                linear_skb;
 
         struct rcv_work_data          * wdata;
         struct rwq_work_item          * item;
 
         /* C-c-c-checks */
-	if (!skb) {
-		LOG_ERR("Bogus skb passed, bailing out");
-		return -1;
-	}
+        if (!skb) {
+                LOG_ERR("Bogus skb passed, bailing out");
+                return -1;
+        }
 
-	if (!dev) {
-		LOG_ERR("Bogus dev passed, bailing out");
-		return -1;
-	}
+        if (!dev) {
+                LOG_ERR("Bogus dev passed, bailing out");
+                return -1;
+        }
 
         mapping = inst_data_mapping_get(dev);
         if (!mapping) {
@@ -1276,23 +1276,23 @@ static int eth_recv_process_packet(struct sk_buff *    skb,
         }
         ASSERT(gha_is_ok(ghaddr));
 
-	/* FIXME: If skb is not linear we need to make a copy... */
-	linear_skb = skb;
-	if (skb_is_nonlinear(skb)) {
-		LOG_DBG("SKB is fragmented, creating linear SKB");
-		linear_skb = skb_copy(skb, GFP_ATOMIC);
-		if (!linear_skb) {
-			LOG_ERR("Could not linearize received SKB");
-			kfree_skb(skb);
-			return -1;
-		}
-		LOG_DBG("Linear SKB fragmens: %d", skb_shinfo(linear_skb)->nr_frags);
-		kfree_skb(skb);
-	}
+        /* FIXME: If skb is not linear we need to make a copy... */
+        linear_skb = skb;
+        if (skb_is_nonlinear(skb)) {
+                LOG_DBG("SKB is fragmented, creating linear SKB");
+                linear_skb = skb_copy(skb, GFP_ATOMIC);
+                if (!linear_skb) {
+                        LOG_ERR("Could not linearize received SKB");
+                        kfree_skb(skb);
+                        return -1;
+                }
+                LOG_DBG("Linear SKB fragmens: %d", skb_shinfo(linear_skb)->nr_frags);
+                kfree_skb(skb);
+        }
 
-	du = du_create_from_skb(linear_skb);
-	if (!du) {
-		LOG_ERR("Could not create SDU from buffer");
+        du = du_create_from_skb(linear_skb);
+        if (!du) {
+                LOG_ERR("Could not create SDU from buffer");
                 kfree_skb(linear_skb);
                 return -1;
         }
@@ -1353,8 +1353,8 @@ static int eth_recv_process_packet(struct sk_buff *    skb,
                 LOG_DBG("Flow exists, queueing or delivering or dropping");
                 if (flow->port_id_state == PORT_STATE_ALLOCATED) {
                         if (!flow->user_ipcp) {
-                        	spin_unlock(&data->lock);
-                        	LOG_ERR("Flow is being deallocated, dropping PDU");
+                                spin_unlock(&data->lock);
+                                LOG_ERR("Flow is being deallocated, dropping PDU");
                                 du_destroy(du);
                                 return -1;
                         }
@@ -1396,12 +1396,12 @@ static int eth_recv_process_packet(struct sk_buff *    skb,
 }
 
 static int eth_rcv(struct sk_buff *     skb,
-                        struct net_device *  dev,
-                        struct packet_type * pt,       /* not used */
-                        struct net_device *  orig_dev) /* not used */
+                   struct net_device *  dev,
+                   struct packet_type * pt,       /* not used */
+                   struct net_device *  orig_dev) /* not used */
 {
-	ASSERT(skb);
-	ASSERT(dev);
+        ASSERT(skb);
+        ASSERT(dev);
 
         LOG_DBG("eth_rcv started, skb received");
         skb = skb_share_check(skb, GFP_ATOMIC);
@@ -1511,9 +1511,9 @@ static int eth_set_net_devs_auto(struct ipcp_instance_data* data) {
 }
 
 static int eth_assign_to_dif(struct ipcp_instance_data * data,
-                		  const struct name * dif_name,
-				  const string_t * type,
-				  struct dif_config * config)
+                             const struct name * dif_name,
+                             const string_t * type,
+                             struct dif_config * config)
 {
         struct eth_info *               info;
         struct ipcp_config *            tmp;
@@ -1521,15 +1521,15 @@ static int eth_assign_to_dif(struct ipcp_instance_data * data,
         struct interface_data_mapping * mapping;
         int                             result;
 
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
         if (!config) {
-		LOG_ERR("Bogus dif_information passed, bailing out");
-		return -1;
-	}
+                LOG_ERR("Bogus dif_information passed, bailing out");
+                return -1;
+        }
 
         info = data->info;
 
@@ -1549,19 +1549,19 @@ static int eth_assign_to_dif(struct ipcp_instance_data * data,
 
         /* Retrieve configuration of IPC process from params */
         list_for_each_entry(tmp, &(config->ipcp_config_entries), next) {
-		const struct ipcp_config_entry * entry = tmp->entry;
-		if (!strcmp(entry->name, "interface-name")) {
-			ASSERT(entry->value);
+                const struct ipcp_config_entry * entry = tmp->entry;
+                if (!strcmp(entry->name, "interface-name")) {
+                        ASSERT(entry->value);
 
-			info->interface_name = rkstrdup(entry->value);
-			if (!info->interface_name) {
-				LOG_ERR("Cannot copy interface name");
-				name_destroy(data->dif_name);
-				data->dif_name = NULL;
-				return -1;
-			}
-		} else
-                	LOG_DBG("Unknown config param for eth shim, ignoring");
+                        info->interface_name = rkstrdup(entry->value);
+                        if (!info->interface_name) {
+                                LOG_ERR("Cannot copy interface name");
+                                name_destroy(data->dif_name);
+                                data->dif_name = NULL;
+                                return -1;
+                        }
+                } else
+                        LOG_DBG("Unknown config param for eth shim, ignoring");
         }
 
         /* Fail here if we didn't get an interface */
@@ -1622,7 +1622,7 @@ static int eth_assign_to_dif(struct ipcp_instance_data * data,
 }
 
 static int eth_update_dif_config(struct ipcp_instance_data * data,
-                                      const struct dif_config *   new_config)
+                                 const struct dif_config *   new_config)
 {
         struct eth_info *               info;
         struct ipcp_config *            tmp;
@@ -1631,15 +1631,15 @@ static int eth_update_dif_config(struct ipcp_instance_data * data,
         struct interface_data_mapping * mapping;
         int                             result;
 
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return -1;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return -1;
+        }
 
         if (!new_config) {
-		LOG_ERR("Bogus configuration passed, bailing out");
-		return -1;
-	}
+                LOG_ERR("Bogus configuration passed, bailing out");
+                return -1;
+        }
 
         /* Get configuration struct pertaining to this shim instance */
         info               = data->info;
@@ -1651,29 +1651,29 @@ static int eth_update_dif_config(struct ipcp_instance_data * data,
 
                 entry = tmp->entry;
                 if (!strcmp(entry->name, "interface-name")) {
-                	ASSERT(entry->value);
+                        ASSERT(entry->value);
 
-                	info->interface_name = rkstrdup(entry->value);
-                	if (!info->interface_name) {
-                		LOG_ERR("Cannot copy interface name");
-                		return -1;
-                	}
-		} else
+                        info->interface_name = rkstrdup(entry->value);
+                        if (!info->interface_name) {
+                                LOG_ERR("Cannot copy interface name");
+                                return -1;
+                        }
+                } else
                         LOG_DBG("Unknown config param for Ethernet shim, ignoring");
         }
 
         dev_remove_pack(data->eth_packet_type);
 
-	if (data->dev) {
-		/* Remove from list */
-		mapping = inst_data_mapping_get(data->dev);
-		if (mapping) {
-			spin_lock(&data_instances_lock);
-			list_del(&mapping->list);
-			spin_unlock(&data_instances_lock);
-			rkfree(mapping);
-		}
-	}
+        if (data->dev) {
+                /* Remove from list */
+                mapping = inst_data_mapping_get(data->dev);
+                if (mapping) {
+                        spin_lock(&data_instances_lock);
+                        list_del(&mapping->list);
+                        spin_unlock(&data_instances_lock);
+                        rkfree(mapping);
+                }
+        }
 
         /* Add the packet handler. */
         data->eth_packet_type->type = cpu_to_be16(ETH_P_RINA);
@@ -1718,40 +1718,40 @@ static const struct name * eth_ipcp_name(struct ipcp_instance_data * data)
 
 static const struct name * eth_dif_name(struct ipcp_instance_data * data)
 {
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return NULL;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return NULL;
+        }
 
         return data->dif_name;
 }
 
 static size_t eth_max_sdu_size(struct ipcp_instance_data * data)
 {
-	if (!data) {
-		LOG_ERR("Bogus data passed, bailing out");
-		return 0;
-	}
+        if (!data) {
+                LOG_ERR("Bogus data passed, bailing out");
+                return 0;
+        }
 
         return data->dev->mtu - sizeof(struct ethhdr);
 }
 
 ipc_process_id_t eth_ipcp_id(struct ipcp_instance_data * data)
 {
-	ASSERT(data);
-	return data->id;
+        ASSERT(data);
+        return data->id;
 }
 
 static int eth_query_rib(struct ipcp_instance_data * data,
-                              struct list_head *          entries,
-                              const string_t *            object_class,
-                              const string_t *            object_name,
-                              uint64_t                    object_instance,
-                              uint32_t                    scope,
-                              const string_t *            filter)
+                         struct list_head *          entries,
+                         const string_t *            object_class,
+                         const string_t *            object_name,
+                         uint64_t                    object_instance,
+                         uint32_t                    scope,
+                         const string_t *            filter)
 {
-	LOG_MISSING;
-	return -1;
+        LOG_MISSING;
+        return -1;
 }
 
 static struct ipcp_instance_ops eth_instance_ops = {
@@ -1762,7 +1762,7 @@ static struct ipcp_instance_ops eth_instance_ops = {
         .flow_binding_ipcp         = NULL,
         .flow_unbinding_ipcp       = NULL,
         .flow_unbinding_user_ipcp  = eth_unbind_user_ipcp,
-	.nm1_flow_state_change	   = NULL,
+        .nm1_flow_state_change	   = NULL,
 
         .application_register      = eth_application_register,
         .application_unregister    = eth_application_unregister,
@@ -1774,19 +1774,19 @@ static struct ipcp_instance_ops eth_instance_ops = {
         .connection_update         = NULL,
         .connection_destroy        = NULL,
         .connection_create_arrived = NULL,
-	.connection_modify 	   = NULL,
+        .connection_modify         = NULL,
 
-        .du_enqueue               = NULL,
+        .du_enqueue                = NULL,
         .du_write                  = eth_du_write,
 
-        .mgmt_du_write            = NULL,
-        .mgmt_du_post             = NULL,
+        .mgmt_du_write             = NULL,
+        .mgmt_du_post              = NULL,
 
         .pff_add                   = NULL,
         .pff_remove                = NULL,
         .pff_dump                  = NULL,
         .pff_flush                 = NULL,
-	.pff_modify		   = NULL,
+        .pff_modify		   = NULL,
 
         .query_rib		   = eth_query_rib,
 
@@ -1797,75 +1797,75 @@ static struct ipcp_instance_ops eth_instance_ops = {
         .set_policy_set_param      = NULL,
         .select_policy_set         = NULL,
         .update_crypto_state	   = NULL,
-	.address_change            = NULL,
+        .address_change            = NULL,
         .dif_name		   = eth_dif_name,
         .max_sdu_size		   = eth_max_sdu_size
 };
 
 static int ntfy_user_ipcp_on_if_state_change(struct ipcp_instance_data * data,
-					     bool up)
+                                             bool up)
 {
         struct shim_eth_flow * flow;
 
-	ASSERT(data);
+        ASSERT(data);
 
         list_for_each_entry(flow, &data->flows, list) {
                 if (!flow->user_ipcp) {
-			/* This flow is used by an userspace application,
-			 * we are not able to notify that one for now. */
-			continue;
+                        /* This flow is used by an userspace application,
+                         * we are not able to notify that one for now. */
+                        continue;
                 }
 
-		flow->user_ipcp->ops->
+                flow->user_ipcp->ops->
                             nm1_flow_state_change(flow->user_ipcp->data,
                                                   flow->port_id, up);
         }
 
-	return 0;
+        return 0;
 }
 
 static int eth_netdev_notify(struct notifier_block *nb,
-				  unsigned long event,
-				  void *opaque)
+                             unsigned long event,
+                             void *opaque)
 {
-	struct net_device *dev;
+        struct net_device *dev;
         struct ipcp_instance_data * pos;
 
-	ASSERT(nb);
-	ASSERT(opaque);
+        ASSERT(nb);
+        ASSERT(opaque);
 
-	dev = netdev_notifier_info_to_dev(opaque);
+        dev = netdev_notifier_info_to_dev(opaque);
 
         list_for_each_entry(pos, &eth_data.instances, list) {
-		if (pos->dev != dev) {
-			/* We don't care about this network interface. */
-			continue;
-		}
+                if (pos->dev != dev) {
+                        /* We don't care about this network interface. */
+                        continue;
+                }
 
-		switch (event) {
+                switch (event) {
 
-		case NETDEV_UP:
-			LOG_INFO("Device %s goes up", dev->name);
-			ntfy_user_ipcp_on_if_state_change(pos, true);
-			spin_lock_bh(&pos->lock);
-			pos->tx_busy = 0;
-			spin_unlock_bh(&pos->lock);
-			enable_write_all(pos->phy_dev);
-			break;
+                case NETDEV_UP:
+                        LOG_INFO("Device %s goes up", dev->name);
+                        ntfy_user_ipcp_on_if_state_change(pos, true);
+                        spin_lock_bh(&pos->lock);
+                        pos->tx_busy = 0;
+                        spin_unlock_bh(&pos->lock);
+                        enable_write_all(pos->phy_dev);
+                        break;
 
-		case NETDEV_DOWN:
-			LOG_INFO("Device %s goes down", dev->name);
-			ntfy_user_ipcp_on_if_state_change(pos, false);
-			break;
+                case NETDEV_DOWN:
+                        LOG_INFO("Device %s goes down", dev->name);
+                        ntfy_user_ipcp_on_if_state_change(pos, false);
+                        break;
 
-		default:
-			LOG_DBG("Ignoring event %lu on device %s",
-				event, dev->name);
-			break;
-		}
-	}
+                default:
+                        LOG_DBG("Ignoring event %lu on device %s",
+                                event, dev->name);
+                        break;
+                }
+        }
 
-	return 0;
+        return 0;
 }
 
 static int eth_init(struct ipcp_factory_data *fdata)
@@ -1875,7 +1875,7 @@ static int eth_init(struct ipcp_factory_data *fdata)
         bzero(fdata, sizeof(*fdata));
 
         INIT_LIST_HEAD(&(fdata->instances));
-	INIT_LIST_HEAD(&data_instances_list);
+        INIT_LIST_HEAD(&data_instances_list);
 
         /* Register to receive messages about the network
          * interfaces. */
@@ -1909,17 +1909,17 @@ static int eth_fini(struct ipcp_factory_data * data)
 {
 
         ASSERT(data == &eth_data);
-	ASSERT(list_empty(&(data->instances)));
+        ASSERT(list_empty(&(data->instances)));
 
-	unregister_netdevice_notifier(&data->ntfy);
+        unregister_netdevice_notifier(&data->ntfy);
 
-	return 0;
+        return 0;
 }
 
 static int eth_fini2(struct ipcp_factory_data * data)
 {
         ASSERT(data == &eth_data);
-	return 0;
+        return 0;
 }
 
 static void inst_cleanup(struct ipcp_instance * inst)
@@ -1944,13 +1944,13 @@ static void inst_cleanup(struct ipcp_instance * inst)
 
 static struct ipcp_instance* eth_create(struct ipcp_factory_data*  data,
                                         const struct name*         name,
-                                              ipc_process_id_t           id,
-					      uint_t			 us_nl_port)
+                                        ipc_process_id_t           id,
+                                        uint_t		           us_nl_port)
 {
         struct ipcp_instance * inst;
 
         ASSERT(data);
-	ASSERT(name);
+        ASSERT(name);
 
         /* Check if there already is an instance with that id */
         if (find_instance(data,id)) {
@@ -1966,14 +1966,14 @@ static struct ipcp_instance* eth_create(struct ipcp_factory_data*  data,
         /* fill it properly */
         inst->ops  = &eth_instance_ops;
 
-	if (robject_rset_init_and_add(&inst->robj,
+        if (robject_rset_init_and_add(&inst->robj,
                                       &eth_ipcp_rtype,
-				      kipcm_rset(default_kipcm),
-				      "%u",
-				      id)) {
-		rkfree(inst);
-		return NULL;
-	}
+                                      kipcm_rset(default_kipcm),
+                                      "%u",
+                                      id)) {
+                rkfree(inst);
+                return NULL;
+        }
 
         inst->data = rkzalloc(sizeof(struct ipcp_instance_data), GFP_KERNEL);
         if (!inst->data) {
@@ -2005,7 +2005,7 @@ static struct ipcp_instance* eth_create(struct ipcp_factory_data*  data,
                 inst_cleanup(inst);
                 return NULL;
         }
-	inst->data->tx_busy = 0;
+        inst->data->tx_busy = 0;
 
         inst->data->fspec = rkzalloc(sizeof(*inst->data->fspec), GFP_KERNEL);
         if (!inst->data->fspec) {
@@ -2066,7 +2066,7 @@ static struct ipcp_instance* eth_create_vlan(struct ipcp_factory_data*  data,
 }
 
 static int eth_destroy(struct ipcp_factory_data * data,
-                            struct ipcp_instance *     instance)
+                       struct ipcp_instance *     instance)
 {
         struct interface_data_mapping * mapping;
         struct ipcp_instance_data * pos, * next;
@@ -2132,14 +2132,14 @@ static int eth_destroy(struct ipcp_factory_data * data,
                         }
 
                         if (pos->dev) {
-                        	mapping = inst_data_mapping_get(pos->dev);
-                        	if (mapping) {
-                        		LOG_DBG("removing mapping from list");
-                        		spin_lock(&data_instances_lock);
-                        		list_del(&mapping->list);
-                        		spin_unlock(&data_instances_lock);
-                        		rkfree(mapping);
-                        	}
+                                mapping = inst_data_mapping_get(pos->dev);
+                                if (mapping) {
+                                        LOG_DBG("removing mapping from list");
+                                        spin_lock(&data_instances_lock);
+                                        list_del(&mapping->list);
+                                        spin_unlock(&data_instances_lock);
+                                        rkfree(mapping);
+                                }
                         }
 
                         robject_del(&instance->robj);
@@ -2309,19 +2309,19 @@ static int __init mod_init(void)
         }
 
         shim_eth = kipcm_ipcp_factory_register(default_kipcm,
-                                           	    SHIM_NAME,
+                                               SHIM_NAME,
                                                &eth_data,
                                                &eth_ops);
         shim_eth_vlan = kipcm_ipcp_factory_register(default_kipcm,
                                                     SHIM_VLAN_NAME,
                                                     &eth_data,
-						    &eth_vlan_ops);
+                                                    &eth_vlan_ops);
         shim_wifi_ap = kipcm_ipcp_factory_register(default_kipcm,
-                                           	   SHIM_WIFI_AP_NAME,
+                                                   SHIM_WIFI_AP_NAME,
                                                    &eth_data,
                                                    &eth_ops2);
         shim_wifi_sta = kipcm_ipcp_factory_register(default_kipcm,
-                                           	    SHIM_WIFI_STA_NAME,
+                                                    SHIM_WIFI_STA_NAME,
                                                     &eth_data,
                                                     &eth_ops2);
 
@@ -2360,7 +2360,7 @@ static void __exit mod_exit(void)
         kipcm_ipcp_factory_unregister(default_kipcm, shim_wifi_ap);
         kipcm_ipcp_factory_unregister(default_kipcm, shim_wifi_sta);
 
-	LOG_INFO("IRATI shim Ethernet module removed");
+        LOG_INFO("IRATI shim Ethernet module removed");
 }
 
 module_init(mod_init);

--- a/kernel/ipcps/shim-eth-core.c
+++ b/kernel/ipcps/shim-eth-core.c
@@ -263,8 +263,8 @@ static int eth_shim_dbg_inst_flows_show(struct seq_file *s, void *v)
         list_for_each_entry(flow, &data->flows, list) {
                 seq_printf(s, "Port Id: %d\n", flow->port_id);
 
-                ha = gha_address(flow->dest_ha);
-                if (gha_is_ok(ha)) {
+                if (gha_is_ok(flow->dest_ha)) {
+                        ha = gha_address(flow->dest_ha);
                         seq_printf(s, "Dest Hardware Address: %u:%u:%u:%u:%u:%u\n",
                                    ha[0], ha[1],  ha[2], ha[3], ha[4], ha[5]);
                 } else

--- a/kernel/kfa-utils.c
+++ b/kernel/kfa-utils.c
@@ -20,6 +20,8 @@
 
 #include <linux/hashtable.h>
 #include <linux/list.h>
+#include <linux/debugfs.h>
+#include <linux/seq_file.h>
 
 #define RINA_PREFIX "kfa-utils"
 
@@ -181,3 +183,23 @@ int kfa_pmap_remove(struct kfa_pmap * map,
 
         return 0;
 }
+
+#ifdef CONFIG_DEBUG_FS
+int kfa_pmap_debugfs_show(struct kfa_pmap *map, struct seq_file * s,
+                          void (* flow_show_func)(struct ipcp_flow *, struct seq_file *))
+{
+        struct kfa_pmap_entry *entry;
+        struct hlist_node *tmp;
+        int bucket;
+
+        ASSERT(map);
+        ASSERT(flow_show_func);
+
+        seq_printf(s, "Current flows:\n");
+        hash_for_each_safe(map->table, bucket, tmp, entry, hlist) {
+                flow_show_func(entry->value_flow, s);
+        }
+
+        return 0;
+}
+#endif

--- a/kernel/kfa-utils.h
+++ b/kernel/kfa-utils.h
@@ -21,6 +21,8 @@
 #ifndef RINA_KFA_UTILS_H
 #define RINA_KFA_UTILS_H
 
+#include <linux/seq_file.h>
+
 #include "common.h"
 #include "kfa.h"
 
@@ -46,5 +48,10 @@ int                kfa_pmap_update(struct kfa_pmap *  map,
                                    struct ipcp_flow * value_flow);
 int                kfa_pmap_remove(struct kfa_pmap * map,
                                    port_id_t         key);
+
+#ifdef CONFIG_DEBUG_FS
+int kfa_pmap_debugfs_show(struct kfa_pmap *map, struct seq_file *s,
+                          void (* flow_show_func)(struct ipcp_flow *, struct seq_file *));
+#endif
 
 #endif

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -91,6 +91,7 @@ struct ipcp_instance_data {
 static void kfa_flows_dbg_flow_show(struct ipcp_flow *flow, struct seq_file *s) {
     char *fs, *ns;
     const struct name *n;
+    ipc_process_id_t pid;
 
     if (!flow) return;
 
@@ -111,6 +112,12 @@ static void kfa_flows_dbg_flow_show(struct ipcp_flow *flow, struct seq_file *s) 
     }
 
     seq_printf(s, "State: %s\n", fs);
+
+    if (flow->ipc_process->ops->ipcp_id) {
+        pid = flow->ipc_process->ops->ipcp_id(flow->ipc_process->data);
+        seq_printf(s, "IPCP process ID: %d\n", pid);
+    } else
+        seq_printf(s, "IPCP process ID: Unknown\n");
 
     if (flow->ipc_process->ops->dif_name) {
         n = flow->ipc_process->ops->dif_name(flow->ipc_process->data);

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -1249,7 +1249,7 @@ int kfa_ipcp_instance_destroy(struct ipcp_instance * instance)
  	return 0;
 }
 
-struct kfa *kfa_create(void)
+struct kfa *kfa_create(struct dentry* dbg_dir)
 {
 	struct kfa *instance;
 
@@ -1257,7 +1257,7 @@ struct kfa *kfa_create(void)
 	if (!instance)
 		return NULL;
 
-	instance->pidm = pidm_create();
+	instance->pidm = pidm_create(dbg_dir);
 	if (!instance->pidm) {
 		rkfree(instance);
 		return NULL;

--- a/kernel/kfa.c
+++ b/kernel/kfa.c
@@ -38,6 +38,7 @@
 #include "kfa.h"
 #include "kfa-utils.h"
 #include "rina-device.h"
+#include "ipcp-utils.h"
 
 #define RINA_IP_FLOW_ENT_NAME "RINA_IP"
 
@@ -86,11 +87,14 @@ struct ipcp_instance_data {
 };
 
 #ifdef CONFIG_DEBUG_FS
+
 static void kfa_flows_dbg_flow_show(struct ipcp_flow *flow, struct seq_file *s) {
-    const char *fs;
+    char *fs, *ns;
+    const struct name *n;
 
     if (!flow) return;
 
+    seq_printf(s, "Flow addr: %p\n", flow);
     seq_printf(s, "Port Id: %d\n", flow->port_id);
 
     switch (flow->state) {
@@ -108,6 +112,29 @@ static void kfa_flows_dbg_flow_show(struct ipcp_flow *flow, struct seq_file *s) 
 
     seq_printf(s, "State: %s\n", fs);
 
+    if (flow->ipc_process->ops->dif_name) {
+        n = flow->ipc_process->ops->dif_name(flow->ipc_process->data);
+        ns = name_tostring(n);
+        if (ns) {
+            seq_printf(s, "IPCP DIF name: %s\n", ns);
+            rkfree(ns);
+        } else
+            seq_printf(s, "IPCP DIF name: Can't convert name to string\n");
+    } else
+        seq_printf(s, "IPCP DIF name: Unknown\n");
+
+    if (flow->ipc_process->ops->ipcp_name) {
+        n = flow->ipc_process->ops->ipcp_name(flow->ipc_process->data);
+        ns = name_tostring(n);
+        if (ns) {
+            seq_printf(s, "IPCP Name: %s\n", ns);
+            rkfree(ns);
+        } else
+            seq_printf(s, "IPCP Name: Can't convert name to string\n");
+    } else
+        seq_printf(s, "IPCP Name: Unknown\n");
+
+    seq_printf(s, "\n");
 }
 
 static int kfa_flows_dbg_show(struct seq_file *s, void *v) {

--- a/kernel/kfa.h
+++ b/kernel/kfa.h
@@ -30,7 +30,7 @@
 
 struct kfa;
 
-struct kfa *kfa_create(void);
+struct kfa *kfa_create(struct dentry *dbg_dir);
 int	    kfa_destroy(struct kfa *instance);
 
 /* Only requests the pidm to reserve a valid port-id */

--- a/kernel/pidm.h
+++ b/kernel/pidm.h
@@ -25,7 +25,7 @@
 
 struct pidm;
 
-struct pidm * pidm_create(void);
+struct pidm * pidm_create(struct dentry* dbg_dir);
 int           pidm_destroy(struct pidm * instance);
 
 port_id_t     pidm_allocate(struct pidm * instance);

--- a/kernel/rinarp/arp826-arm.c
+++ b/kernel/rinarp/arp826-arm.c
@@ -193,12 +193,15 @@ static bool is_resolve_data_matching(struct resolve_data * a,
         ASSERT(a);
         ASSERT(b);
 
+        // This is fairly verbose and confusing in the logs.
+#if 0
         gha_log_dbg("A Source HW Addr (a->sha)", a->sha);
         gha_log_dbg("B Target HW Addr (b->tha)", b->tha);
         gpa_log_dbg("A Target Proto Addr (a->tpa)", b->tpa);
         gpa_log_dbg("B Source Proto Addr (b->spa)", b->spa);
         gpa_log_dbg("A Source Proto Addr (a->spa)", a->spa);
         gpa_log_dbg("B Target Proto Addr (b->tpa)", b->tpa);
+#endif
 
         if (a->dev != b->dev)
                 return false;
@@ -285,6 +288,11 @@ static int timeout_resolver(void *o) {
         res = (struct resolution *)o;
         if (!res) return -1;
 
+        ASSERT(res);
+        ASSERT(res->data);
+        ASSERT(res->tpa);
+        ASSERT(res->tha);
+
         /* If the request timed out, we have to use the target address
          * in the resolve_data object since this is what is used by
          * the notifier object to find the ARP request corresponding
@@ -338,6 +346,7 @@ static int reply_resolver(void *o)
                                     tmp->sha);
 
                         resolution_destroy(pos);
+                        break;
                 }
         }
 

--- a/kernel/rinarp/arp826-rxtx.c
+++ b/kernel/rinarp/arp826-rxtx.c
@@ -161,6 +161,7 @@ int arp_send_reply(struct net_device * dev,
         size_t              max_len;
 #endif
         struct sk_buff *    skb;
+        int n;
 
         LOG_DBG("Sending ARP reply");
 
@@ -202,8 +203,8 @@ int arp_send_reply(struct net_device * dev,
                 return -1;
         }
 
-        if (dev_queue_xmit(skb)) {
-                LOG_ERR("Failed to send RINARP reply");
+        if ((n = dev_queue_xmit(skb))) {
+                LOG_ERR("Failed to send RINARP reply, dev_queue_xmit ret: %d", n);
                 return -1;
         }
 
@@ -226,6 +227,7 @@ int arp_send_request(struct net_device * dev,
 #endif
         struct sk_buff *    skb;
         struct gha *        tha;
+        int n;
 
         LOG_DBG("Sending ARP request");
 
@@ -274,8 +276,8 @@ int arp_send_request(struct net_device * dev,
                 return -1;
         }
 
-        if (dev_queue_xmit(skb)) {
-                LOG_ERR("Failed to send RINARP request");
+        if ((n = dev_queue_xmit(skb))) {
+                LOG_ERR("Failed to send RINARP reply, dev_queue_xmit ret: %d", n);
                 gha_destroy(tha);
                 return -1;
         }

--- a/kernel/rinarp/arp826-rxtx.c
+++ b/kernel/rinarp/arp826-rxtx.c
@@ -119,6 +119,12 @@ static struct sk_buff * arp_create(struct net_device * dev,
                 return NULL;
         }
 
+        LOG_DBG("ARP packet:");
+        gha_log_dbg("\tSource HW Addr", sha);
+        gpa_log_dbg("\tSource Proto Addr", spa);
+        gha_log_dbg("\tTarget HW Addr", tha);
+        gpa_log_dbg("\tTarget Proto Addr", tpa);
+
         /* Fill out the packet, finally */
 
         arp->htype = htons(dev->type);
@@ -474,8 +480,7 @@ static int process(const struct sk_buff * skb,
                         return -1;
                 }
 
-                LOG_DBG("Showing the target ha");
-                gha_dump(target_ha);
+                gha_log_dbg("Target Hardware Address: ", target_ha);
 
                 if (arp_send_reply(dev,
                                    ptype,

--- a/kernel/rinarp/arp826-tables.c
+++ b/kernel/rinarp/arp826-tables.c
@@ -349,16 +349,11 @@ struct table_entry * tbl_find_by_gpa(struct table *     instance,
                 return NULL;
         }
 
-        LOG_DBG("Looking for the following address in table");
-        gpa_dump(address);
-
-        LOG_DBG("Showing addresses in table in the meanwhile");
+        gpa_log_dbg("Looking for GPA: %s", address);
 
         spin_lock(&instance->lock);
         list_for_each_entry(pos, &instance->entries, next) {
-                gpa_dump(pos->pa);
                 if (gpa_is_equal(pos->pa, address)) {
-                        LOG_DBG("That's the address I need");
                         spin_unlock(&instance->lock);
                         return pos;
                 }

--- a/kernel/rinarp/arp826-utils.c
+++ b/kernel/rinarp/arp826-utils.c
@@ -164,6 +164,21 @@ string_t * gpa_address_to_string_gfp(gfp_t              flags,
 }
 EXPORT_SYMBOL(gpa_address_to_string_gfp);
 
+string_t *gpa_address_to_string(const struct gpa *gpa, string_t *buf, size_t n)
+{
+        size_t max;
+
+        max = gpa->length;
+        if (max - 1 > n)
+                max = n;
+
+        memcpy(buf, gpa->address, max - 1);
+        buf[max] = '\0';
+
+        return buf;
+}
+EXPORT_SYMBOL(gpa_address_to_string);
+
 size_t gpa_address_length(const struct gpa * gpa)
 {
         if (!gpa_is_ok(gpa)) {
@@ -322,6 +337,26 @@ struct gha {
                 uint8_t mac_802_3[6];
         } data;
 };
+
+string_t *gha_address_to_string(const struct gha *gha, string_t *buf, size_t n)
+{
+        size_t max;
+
+        max = 17 + 1; // Size of a MAC address string + null terminator.
+        if (max > n)
+                max = n;
+
+        if (gha->type == MAC_ADDR_802_3)
+                snprintf(buf, max, "%02X:%02X:%02X:%02X:%02X:%02X",
+                         gha->data.mac_802_3[5], gha->data.mac_802_3[4],
+                         gha->data.mac_802_3[3], gha->data.mac_802_3[2],
+                         gha->data.mac_802_3[1], gha->data.mac_802_3[0]);
+        else
+                snprintf(buf, max, "<unknown format>");
+
+        return buf;
+}
+EXPORT_SYMBOL(gha_address_to_string);
 
 void gha_log_dbg(const char *s, const struct gha *gha)
 {

--- a/kernel/rinarp/arp826-utils.h
+++ b/kernel/rinarp/arp826-utils.h
@@ -47,6 +47,7 @@ bool            gpa_is_equal(const struct gpa * a,
 const uint8_t * gpa_address_value(const struct gpa * gpa);
 string_t * 	gpa_address_to_string_gfp(gfp_t              flags,
 				          const struct gpa * gpa);
+string_t *      gpa_address_to_string(const struct gpa *gpa, string_t *buf, size_t n);
 size_t          gpa_address_length(const struct gpa * gpa);
 
 /* Grows a GPA adding the filler symbols up to length (if needed) */
@@ -107,6 +108,7 @@ size_t              gha_address_length(const struct gha * gha);
 gha_type_t          gha_type(const struct gha * gha);
 bool                gha_is_equal(const struct gha * a,
                                  const struct gha * b);
+string_t *          gha_address_to_string(const struct gha *gha, string_t *buf, size_t n);
 
 void                gha_log_dbg(const char *fmt, const struct gha *gha);
 

--- a/kernel/rinarp/arp826-utils.h
+++ b/kernel/rinarp/arp826-utils.h
@@ -69,8 +69,7 @@ int             gpa_address_shrink_ni(struct gpa * gpa,
 int             gpa_address_shrink_gfp(gfp_t        flags,
                                        struct gpa * gpa,
                                        uint8_t      filler);
-
-void            gpa_dump(const struct gpa * gpa);
+void            gpa_log_dbg(const char *fmt, const struct gpa *gpa);
 
 typedef enum {
         MAC_ADDR_802_3
@@ -108,8 +107,8 @@ size_t              gha_address_length(const struct gha * gha);
 gha_type_t          gha_type(const struct gha * gha);
 bool                gha_is_equal(const struct gha * a,
                                  const struct gha * b);
-void                gha_dump(const struct gha * gha);
 
+void                gha_log_dbg(const char *fmt, const struct gha *gha);
 
 /*
  * Miscellaneous

--- a/kernel/rinarp/arp826.h
+++ b/kernel/rinarp/arp826.h
@@ -50,6 +50,7 @@ int                arp826_resolve_gpa(struct net_device * dev,
                                       const struct gha *  sha,
                                       const struct gpa *  tpa,
                                       arp826_notify_t     notify,
+                                      uint32_t            timeout_ms,
                                       void *              opaque);
 const struct gpa * arp826_find_gpa(struct net_device * dev,
                                    uint16_t            ptype,

--- a/kernel/rinarp/arp826.h
+++ b/kernel/rinarp/arp826.h
@@ -40,6 +40,7 @@ int                arp826_remove(struct net_device * dev,
                                  const struct gha *  ha);
 
 typedef void (* arp826_notify_t)(void *             opaque,
+                                 bool               timed_out,
                                  const struct gpa * tpa,
                                  const struct gha * tha);
 

--- a/kernel/rinarp/rinarp.c
+++ b/kernel/rinarp/rinarp.c
@@ -127,6 +127,7 @@ EXPORT_SYMBOL(rinarp_remove);
 int rinarp_resolve_gpa(struct rinarp_handle * handle,
                        const struct gpa *     tpa,
                        rinarp_notification_t  notify,
+                       uint32_t               timeout_ms,
                        void *                 opaque)
 {
         if (!handle_is_ok(handle) ||
@@ -139,7 +140,8 @@ int rinarp_resolve_gpa(struct rinarp_handle * handle,
 
         return arp826_resolve_gpa(handle->dev, ETH_P_RINA,
                                   handle->pa, handle->ha, tpa,
-                                  (arp826_notify_t) notify, opaque);
+                                  (arp826_notify_t) notify, timeout_ms,
+                                  opaque);
 }
 EXPORT_SYMBOL(rinarp_resolve_gpa);
 

--- a/kernel/rinarp/rinarp.h
+++ b/kernel/rinarp/rinarp.h
@@ -37,6 +37,7 @@ struct rinarp_handle * rinarp_add(struct net_device * dev,
 int                    rinarp_remove(struct rinarp_handle * handle);
 
 typedef void (* rinarp_notification_t)(void *             opaque,
+                                       bool               timed_out,
                                        const struct gpa * tpa,
                                        const struct gha * tha);
 

--- a/kernel/rinarp/rinarp.h
+++ b/kernel/rinarp/rinarp.h
@@ -44,6 +44,7 @@ typedef void (* rinarp_notification_t)(void *             opaque,
 int                    rinarp_resolve_gpa(struct rinarp_handle * handle,
                                           const struct gpa *     tpa,
                                           rinarp_notification_t  notify,
+                                          uint32_t               timeout_ms,
                                           void *                 opaque);
 
 /* FIXME: Should return a copy */


### PR DESCRIPTION
This patch adds a timeouts to ARP requests sent through a network interface. The default timeout is somewhat arbitrarily set to 5000 milliseconds by can be manipulated using a debugfs handle.

I admit this is a fairly large set of changes which could (should) be broken down in several parts. In fact, I see a few patch there that could be their own PRs. I'm not going to touch this for now though as I would like someone else to look into this set of change before putting in anymore work in it.

This set of patch was meant to prevent a lockup within IRATI when it ran out of ports to allocate. Unfortunately, it does not fix all situations as I've encountered some more lockups and have not had the time to fix those. It did improve the stability of IRATI significantly while using it in the project I've worked on last year.